### PR TITLE
Prevent `Config` being constructed directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,14 +198,25 @@ pub struct Config {
 
     /// Stack size allocated for each thread
     pub stack_size: usize,
+
+    // Support adding more fields
+    _private: (),
+}
+
+impl Config {
+    /// Create a new default configuration
+    pub fn new() -> Self {
+        Self {
+            max_tasks: 16usize,
+            stack_size: 0x8000,
+            _private: (),
+        }
+    }
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self {
-            max_tasks: 16usize,
-            stack_size: 0x8000,
-        }
+        Self::new()
     }
 }
 

--- a/tests/basic/config.rs
+++ b/tests/basic/config.rs
@@ -4,10 +4,8 @@ use shuttle::{thread, Config, Runner};
 use std::sync::Arc;
 
 fn check_max_tasks(max_tasks: usize, num_spawn: usize) {
-    let config = Config {
-        max_tasks,
-        ..Default::default()
-    };
+    let mut config = Config::new();
+    config.max_tasks = max_tasks;
 
     let scheduler = RandomScheduler::new(100);
     let runner = Runner::new(scheduler, config);
@@ -36,11 +34,9 @@ fn max_task_ok() {
 #[test]
 #[ignore] // Crashes with SIGBUS if you run it
 fn max_stack_depth() {
-    let stack_size = 1024usize;
-    let config = Config {
-        stack_size,
-        ..Default::default()
-    };
+    let mut config = Config::new();
+    config.stack_size = 1024;
+
     let scheduler = RandomScheduler::new(100);
     let runner = Runner::new(scheduler, config);
     runner.run(|| {


### PR DESCRIPTION
This change allows us to add more fields to `Config` in the future
without it being a breaking change. Consumers can still access the
public fields, but can't explicitly construct an instance of `Config`
(they have to go through `Config::new()` or `Default` to get one).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.