### PR TITLE
Add option to persist schedules to a file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ criterion = { version = "~0.3.4", features = ["html_reports"] }
 proptest = "~0.10.1"
 proptest-derive = "~0.2.0"
 regex = "~1.3.9"
+tempfile = "~3.2.0"
 
 [lib]
 bench = false

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -1,0 +1,52 @@
+use std::fs::OpenOptions;
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+
+use crate::scheduler::serialization::serialize_schedule;
+use crate::scheduler::Schedule;
+use crate::{Config, FailurePersistence};
+
+/// Produce a message describing how to replay a failing schedule.
+pub fn persist_failure(schedule: &Schedule, message: String, config: &Config) -> String {
+    let serialized_schedule = serialize_schedule(schedule);
+    // Try to persist to a file, but fall through to stdout if that fails for some reason
+    if let FailurePersistence::File { directory } = &config.failure_persistence {
+        match persist_failure_to_file(&serialized_schedule, directory.as_ref()) {
+            Ok(path) => return format!("{}\nfailing schedule persisted to file: {}\npass that path to `shuttle::replay_from_file` to replay the failure", message, path.display()),
+            Err(e) => eprintln!("failed to persist schedule to file (error: {}), falling back to printing the schedule", e),
+        }
+    }
+    format!(
+        "{}\nfailing schedule: \"{}\"\npass that path to `shuttle::replay` to replay the failure",
+        message, serialized_schedule
+    )
+}
+
+/// Persist the given serialized schedule to a file and return the new file's path. The file will be
+/// placed in the current directory.
+fn persist_failure_to_file(serialized_schedule: &str, destination: Option<&PathBuf>) -> std::io::Result<PathBuf> {
+    // Try to find the first usable filename. This is quadratic but we don't expect a ton of
+    // conflicts here.
+    let mut i = 0;
+    let dir = if let Some(dir) = destination {
+        dir.clone()
+    } else {
+        std::env::current_dir()?
+    };
+    let (path, mut file) = loop {
+        let path = dir.clone().join(Path::new(&format!("schedule{:03}.txt", i)));
+        // `create_new` does the existence check and creation atomically, so this loop ensures that
+        // two concurrent tests won't try to persist to the same file.
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(file) => break (path, file),
+            Err(e) => {
+                if e.kind() != ErrorKind::AlreadyExists {
+                    return Err(e);
+                }
+            }
+        }
+        i += 1;
+    };
+    file.write_all(serialized_schedule.as_bytes())?;
+    Ok(path.canonicalize()?)
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod execution;
+mod failure;
 pub(crate) mod runner;
 pub(crate) mod task;
 pub(crate) mod thread;

--- a/src/runtime/runner.rs
+++ b/src/runtime/runner.rs
@@ -53,7 +53,7 @@ impl<S: Scheduler + 'static> Runner<S> {
                 };
                 let execution = Execution::new(self.scheduler.clone(), schedule);
                 let f = Arc::clone(&f);
-                span!(Level::INFO, "execution", i).in_scope(|| execution.run(self.config, move || f()));
+                span!(Level::INFO, "execution", i).in_scope(|| execution.run(&self.config, move || f()));
             }
         })
     }
@@ -110,6 +110,7 @@ impl PortfolioRunner {
                 let f = f.clone();
                 let tx = tx.clone();
                 let stop_signal = stop_signal.clone();
+                let config = config.clone();
 
                 thread::spawn(move || {
                     let scheduler = PortfolioStoppableScheduler { scheduler, stop_signal };

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -32,7 +32,7 @@ impl<T> Mutex<T> {
     pub fn new(value: T) -> Self {
         let state = MutexState {
             holder: None,
-            waiters: TaskSet::new(ExecutionState::config().max_tasks),
+            waiters: TaskSet::new(ExecutionState::with(|s| s.config.max_tasks)),
         };
 
         Self {

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -38,10 +38,11 @@ enum RwLockType {
 impl<T> RwLock<T> {
     /// Create a new instance of an `RwLock<T>` which is unlocked.
     pub fn new(value: T) -> Self {
+        let max_tasks = ExecutionState::with(|s| s.config.max_tasks);
         let state = RwLockState {
             holder: RwLockHolder::None,
-            waiting_readers: TaskSet::new(ExecutionState::config().max_tasks),
-            waiting_writers: TaskSet::new(ExecutionState::config().max_tasks),
+            waiting_readers: TaskSet::new(max_tasks),
+            waiting_writers: TaskSet::new(max_tasks),
         };
 
         Self {
@@ -145,7 +146,7 @@ impl<T> RwLock<T> {
                 state.holder = RwLockHolder::Write(me);
             }
             (RwLockType::Read, RwLockHolder::None) => {
-                let mut readers = TaskSet::new(ExecutionState::config().max_tasks);
+                let mut readers = TaskSet::new(ExecutionState::with(|s| s.config.max_tasks));
                 readers.insert(me);
                 state.holder = RwLockHolder::Read(readers);
             }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -53,7 +53,7 @@ where
 {
     // TODO Check if it's worth avoiding the call to `ExecutionState::config()` if we're going
     // TODO to use an existing continuation from the pool.
-    let stack_size = stack_size.unwrap_or(ExecutionState::config().stack_size);
+    let stack_size = stack_size.unwrap_or_else(|| ExecutionState::with(|s| s.config.stack_size));
     let result = std::sync::Arc::new(std::sync::Mutex::new(None));
     let task_id = {
         let result = std::sync::Arc::clone(&result);

--- a/tests/data/random.rs
+++ b/tests/data/random.rs
@@ -1,5 +1,6 @@
 use crate::check_replay_roundtrip;
 use shuttle::rand::{thread_rng, Rng};
+use shuttle::scheduler::RandomScheduler;
 use shuttle::sync::Mutex;
 use shuttle::{check_random, replay, thread};
 use shuttle::{scheduler::DFSScheduler, Runner};
@@ -35,10 +36,7 @@ fn random_mod_10_equals_7_replay_succeeds() {
 
 #[test]
 fn random_mod_10_equals_7_replay_roundtrip() {
-    check_replay_roundtrip(
-        || check_random(random_mod_10_equals_7, 1000),
-        |schedule| replay(random_mod_10_equals_7, schedule),
-    )
+    check_replay_roundtrip(random_mod_10_equals_7, RandomScheduler::new(1000))
 }
 
 // Check that multiple threads using `thread_rng` aren't seeing the same stream of randomness
@@ -156,10 +154,7 @@ fn broken_atomic_counter_stress_random() {
 
 #[test]
 fn broken_atomic_counter_stress_roundtrip() {
-    check_replay_roundtrip(
-        || check_random(broken_atomic_counter_stress, 1000),
-        |schedule| replay(broken_atomic_counter_stress, schedule),
-    )
+    check_replay_roundtrip(broken_atomic_counter_stress, RandomScheduler::new(1000))
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -5,30 +5,115 @@ mod basic;
 mod data;
 mod demo;
 
-use regex::Regex;
-use std::panic;
-use std::panic::UnwindSafe;
+use shuttle::scheduler::{ReplayScheduler, Scheduler};
+use shuttle::{replay_from_file, Config, FailurePersistence, Runner};
+use std::panic::{self, RefUnwindSafe, UnwindSafe};
+use std::sync::Arc;
 
-fn check_replay_roundtrip<F, R>(test_func: F, replay_func: R)
+/// Validates that schedule replay works by running a test, expecting it to fail, and then parsing
+/// and replaying the failing schedule from its output.
+fn check_replay_roundtrip<F, S>(test_func: F, scheduler: S)
 where
-    F: FnOnce() + UnwindSafe,
-    R: FnOnce(&str) + UnwindSafe,
+    F: Fn() + Send + Sync + RefUnwindSafe + 'static,
+    S: Scheduler + UnwindSafe + 'static,
 {
-    let re = Regex::new("schedule: \"([0-9a-f]+)\"").unwrap();
+    let test_func = Arc::new(test_func);
 
     // Run the test that should fail and capture the schedule it prints
-    let result = panic::catch_unwind(test_func).expect_err("test should panic");
+    let result = {
+        let test_func = test_func.clone();
+        panic::catch_unwind(move || {
+            let mut config = Config::new();
+            config.failure_persistence = FailurePersistence::Print;
+            let runner = Runner::new(scheduler, config);
+            runner.run(move || test_func())
+        })
+        .expect_err("test should panic")
+    };
     let output = result.downcast::<String>().unwrap();
-    let schedule = &re.captures(output.as_str()).expect("output should contain a schedule")[1];
+    let schedule = parse_schedule::from_stdout(&output).expect("output should contain a schedule");
 
     // Now replay that schedule and make sure it still fails and outputs the same schedule
-    let result = panic::catch_unwind(|| replay_func(schedule)).expect_err("replay should panic");
+    let result = {
+        let schedule = schedule.clone();
+        panic::catch_unwind(move || {
+            let mut config = Config::new();
+            config.failure_persistence = FailurePersistence::Print;
+            let scheduler = ReplayScheduler::new_from_encoded(&schedule);
+            let runner = Runner::new(scheduler, config);
+            runner.run(move || test_func());
+        })
+        .expect_err("replay should panic")
+    };
     let new_output = result.downcast::<String>().unwrap();
-    let new_schedule = &re
-        .captures(new_output.as_str())
-        .expect("output should contain a schedule")[1];
+    let new_schedule = parse_schedule::from_stdout(&new_output).expect("output should contain a schedule");
 
     assert_eq!(new_schedule, schedule);
     // This might be too strong a check, but seems reasonable: the panics should be identical
     assert_eq!(new_output, output);
+}
+
+/// Validates that schedule replay works by running a test, expecting it to fail, and then parsing
+/// and replaying the failing schedule from its output.
+fn check_replay_roundtrip_file<F, S>(test_func: F, scheduler: S)
+where
+    F: Fn() + Send + Sync + RefUnwindSafe + 'static,
+    S: Scheduler + UnwindSafe + 'static,
+{
+    let tempdir = tempfile::tempdir().expect("could not create tempdir");
+    let test_func = Arc::new(test_func);
+
+    // Run the test that should fail and capture the schedule it prints
+    let result = {
+        let test_func = test_func.clone();
+        let tempdir_path = tempdir.path().to_path_buf();
+        panic::catch_unwind(move || {
+            let mut config = Config::new();
+            config.failure_persistence = FailurePersistence::File {
+                directory: Some(tempdir_path),
+            };
+            let runner = Runner::new(scheduler, config);
+            runner.run(move || test_func())
+        })
+        .expect_err("test should panic")
+    };
+    let output = result.downcast::<String>().unwrap();
+    let (schedule, schedule_file) = parse_schedule::from_file(&output).expect("output should contain a schedule");
+
+    // Now replay that schedule and make sure it still fails and outputs the same schedule. We want
+    // to test the `replay_from_file` function directly, so this time we'll default to printing the
+    // schedule to stdout.
+    let result = {
+        panic::catch_unwind(move || replay_from_file(move || test_func(), schedule_file))
+            .expect_err("replay should panic")
+    };
+    let new_output = result.downcast::<String>().unwrap();
+    let new_schedule = parse_schedule::from_stdout(&new_output).expect("output should contain a schedule");
+
+    assert_eq!(new_schedule, schedule);
+    // Stronger `output == new_output` check doesn't hold here because we used different values of
+    // `FailurePersistence`s for each test
+}
+
+/// Helpers to parse schedules from different types of output (as determined by [`FailurePersistence`])
+mod parse_schedule {
+    use regex::Regex;
+    use std::fs::OpenOptions;
+    use std::io::Read;
+    use std::path::PathBuf;
+
+    pub(super) fn from_file<S: AsRef<String>>(output: S) -> Option<(String, PathBuf)> {
+        let file_regex = Regex::new("persisted to file: (.*)").unwrap();
+        let file_match = file_regex.captures(output.as_ref().as_str())?.get(1)?.as_str();
+        let mut file = OpenOptions::new().read(true).open(file_match).ok()?;
+        let mut schedule = String::new();
+        file.read_to_string(&mut schedule).ok()?;
+        Some((schedule, PathBuf::from(file_match)))
+    }
+
+    pub(super) fn from_stdout<S: AsRef<String>>(output: S) -> Option<String> {
+        let string_regex = Regex::new("failing schedule: \"([0-9a-f]+)\"").unwrap();
+        let captures = string_regex.captures(output.as_ref().as_str())?;
+        Some(captures.get(1)?.as_str().to_string())
+    }
 }


### PR DESCRIPTION
Large tests can produce failing schedules that are too unwieldy to
copy/paste into a call to `replay`. This change adds a new configuration
that can instead write schedules out to a file in a chosen directory.
When this option is enabled, failure messages instead print the name of
the file the schedule was saved to. Failing schedules saved in a file
can be replayed with a new `replay_from_file` convenience function.

The default config remains printing schedules to stdout/stderr, as this
seems like the best fit for use in CI pipelines, where the failing
schedule can be printed in the log file rather than needing to recover a
file from the build server.x

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.