### PR TITLE
Remove an allocation from ExecutionState::schedule

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -346,7 +346,7 @@ impl ExecutionState {
             .iter()
             .filter(|t| t.state == TaskState::Runnable)
             .map(|t| t.id)
-            .collect::<Vec<_>>();
+            .collect::<SmallVec<[_; MAX_INLINE_TASKS]>>();
 
         if runnable.is_empty() {
             self.next_task = ScheduledTask::Finished;


### PR DESCRIPTION
This is a frequent short-lived allocation of a new Vec on every context
switch, when we can optimistically use a SmallVec instead. Removing this
allocation makes our benchmarks anywhere from 50-150% faster
(admittedly, the benchmarks context switch more frequently than real
code, so this is a best case).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.