### PR TITLE
Fix wakers to not resurrect already finished tasks

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -119,7 +119,7 @@ impl Execution {
         ExecutionState::with(|state| {
             match ret {
                 Ok(Poll::Ready(_)) => {
-                    state.current_mut().state = TaskState::Finished;
+                    state.current_mut().finish();
                 }
                 Ok(Poll::Pending) => {
                     state.current_mut().block_after_running();
@@ -347,7 +347,7 @@ impl ExecutionState {
         let runnable = self
             .tasks
             .iter()
-            .filter(|t| t.state == TaskState::Runnable)
+            .filter(|t| t.runnable())
             .map(|t| t.id)
             .collect::<SmallVec<[_; MAX_INLINE_TASKS]>>();
 

--- a/src/runtime/task/waker.rs
+++ b/src/runtime/task/waker.rs
@@ -29,6 +29,11 @@ unsafe fn raw_waker_wake(data: *const ()) {
     let task_id = TaskId::from(data as usize);
     ExecutionState::with(|state| {
         let waiter = state.get_mut(task_id);
+
+        if waiter.finished() {
+            return;
+        }
+
         waiter.unblock();
 
         let current = state.current_mut();

--- a/tests/asynch/mod.rs
+++ b/tests/asynch/mod.rs
@@ -4,3 +4,4 @@
 mod basic;
 mod channel;
 mod countdown_timer;
+mod waker;

--- a/tests/asynch/waker.rs
+++ b/tests/asynch/waker.rs
@@ -1,0 +1,52 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+use shuttle::{asynch, check_dfs};
+use test_env_log::test;
+
+#[test]
+fn wake_after_finish() {
+    #[derive(Clone)]
+    struct Future1 {
+        // We don't care about interleaving this lock; just using it to share the waker across tasks
+        waker: std::sync::Arc<std::sync::Mutex<Option<Waker>>>,
+    }
+
+    impl Future1 {
+        fn new() -> Self {
+            Self {
+                waker: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            }
+        }
+    }
+
+    impl Future for Future1 {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            *self.waker.lock().unwrap() = Some(cx.waker().clone());
+            Poll::Ready(())
+        }
+    }
+
+    check_dfs(
+        || {
+            let future1 = Future1::new();
+
+            // Convert `future1` into an `async fn`, which is not allowed to be polled again after
+            // returning `Ready`
+            let future1_clone = future1.clone();
+            asynch::block_on(async move {
+                future1_clone.await;
+            });
+
+            let waker = future1.waker.lock().unwrap().take();
+            if let Some(waker) = waker {
+                waker.wake();
+            }
+        },
+        None,
+        None,
+    )
+}


### PR DESCRIPTION
It's an error to re-poll an `async fn` after it's already returned. But
if someone has stored a waker for a task, it's still valid for them to
invoke the waker even though the corresponding task has finished (the
futures API doesn't give them a way to check). For example, the
`futures` implementation of `mpsc` can try to wake the receiver when
dropping a sender, even if the receiver task has already gone away. So
we need to not resurrect a task that has already finished if its waker
is later invoked. In fact, a task in Finished state should never change
states again, so I added assertions preventing that.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
