### PR TITLE
Speed up two slow tests

### DIFF
--- a/tests/basic/rwlock.rs
+++ b/tests/basic/rwlock.rs
@@ -164,20 +164,14 @@ fn two_readers_and_one_writer() {
         });
     }
 
-    thread::spawn(move || {
-        let mut w = lock1.write().unwrap();
-        *w += 1;
-    });
+    // Writer runs on the main thread
+    let mut w = lock1.write().unwrap();
+    *w += 1;
 }
 
 #[test]
 fn rwlock_two_readers_and_one_writer_exhaustive() {
-    shuttle::check_dfs(
-        || {
-            two_readers_and_one_writer();
-        },
-        None,
-    );
+    shuttle::check_dfs(two_readers_and_one_writer, None);
 }
 
 #[test]


### PR DESCRIPTION
- producer_consumer_random can now use shuttle::rand to generate random
  parameters on every iterations, so the outer loop can go away. The diff looks
  big because of the indentation change.
- two_readers_and_one_writer can run the writer on the main thread, which
  dramatically reduces the search space for DFS

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
