### PR TITLE
Allow spawning of an arbitrary number of tasks.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,6 @@ pub use runtime::runner::{PortfolioRunner, Runner};
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Config {
-    /// Maximum number of supported tasks (includes threads and async tasks)
-    pub max_tasks: usize,
-
     /// Stack size allocated for each thread
     pub stack_size: usize,
 
@@ -212,7 +209,6 @@ impl Config {
     /// Create a new default configuration
     pub fn new() -> Self {
         Self {
-            max_tasks: 16usize,
             stack_size: 0x8000,
             failure_persistence: FailurePersistence::Print,
             max_steps: MaxSteps::FailAfter(1_000_000),

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -199,7 +199,6 @@ impl TaskSet {
         if tid.0 >= self.tasks.len() {
             self.tasks.resize(1 + tid.0, false);
         }
-        assert!(self.tasks.len() > tid.0);
         *self.tasks.get_mut(tid.0).unwrap() = true;
     }
 

--- a/src/scheduler/pct.rs
+++ b/src/scheduler/pct.rs
@@ -1,8 +1,7 @@
-use crate::runtime::task::TaskId;
+use crate::runtime::task::{TaskId, DEFAULT_INLINE_TASKS};
 use crate::scheduler::data::random::RandomDataSource;
 use crate::scheduler::data::DataSource;
 use crate::scheduler::{Schedule, Scheduler};
-use crate::Config;
 use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, RngCore, SeedableRng};
@@ -41,13 +40,14 @@ impl PctScheduler {
         assert!(max_depth > 0);
 
         let rng = Pcg64Mcg::seed_from_u64(seed);
-        let config: Config = Default::default();
 
+        // TODO This implementation crashes if we have an application that spawns more than `DEFAULT_INLINE_TASKS`
+        // TODO Fix the code so that we can handle an arbitrary number of tasks
         Self {
             max_iterations,
             max_depth,
             iterations: 0,
-            priority_queue: (0..config.max_tasks).map(TaskId::from).collect::<Vec<_>>(),
+            priority_queue: (0..DEFAULT_INLINE_TASKS).map(TaskId::from).collect::<Vec<_>>(),
             change_points: vec![],
             max_steps: 0,
             steps: 0,

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -1,5 +1,5 @@
 use crate::runtime::execution::ExecutionState;
-use crate::runtime::task::{TaskId, MAX_INLINE_TASKS};
+use crate::runtime::task::{TaskId, DEFAULT_INLINE_TASKS};
 use crate::runtime::thread;
 use smallvec::SmallVec;
 use std::cell::RefCell;
@@ -54,8 +54,8 @@ struct ChannelState<T> {
     messages: SmallVec<[T; MAX_INLINE_MESSAGES]>, // messages in the channel
     known_senders: usize,                         // number of senders referencing this channel
     known_receivers: usize,                       // number or receivers referencing this channel
-    waiting_senders: SmallVec<[TaskId; MAX_INLINE_TASKS]>, // list of currently blocked senders
-    waiting_receivers: SmallVec<[TaskId; MAX_INLINE_TASKS]>, // list of currently blocked receivers
+    waiting_senders: SmallVec<[TaskId; DEFAULT_INLINE_TASKS]>, // list of currently blocked senders
+    waiting_receivers: SmallVec<[TaskId; DEFAULT_INLINE_TASKS]>, // list of currently blocked receivers
 }
 
 impl<T> Debug for ChannelState<T> {

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -32,7 +32,7 @@ impl<T> Mutex<T> {
     pub fn new(value: T) -> Self {
         let state = MutexState {
             holder: None,
-            waiters: TaskSet::new(ExecutionState::with(|s| s.config.max_tasks)),
+            waiters: TaskSet::new(),
         };
 
         Self {

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -38,11 +38,10 @@ enum RwLockType {
 impl<T> RwLock<T> {
     /// Create a new instance of an `RwLock<T>` which is unlocked.
     pub fn new(value: T) -> Self {
-        let max_tasks = ExecutionState::with(|s| s.config.max_tasks);
         let state = RwLockState {
             holder: RwLockHolder::None,
-            waiting_readers: TaskSet::new(max_tasks),
-            waiting_writers: TaskSet::new(max_tasks),
+            waiting_readers: TaskSet::new(),
+            waiting_writers: TaskSet::new(),
         };
 
         Self {
@@ -146,7 +145,7 @@ impl<T> RwLock<T> {
                 state.holder = RwLockHolder::Write(me);
             }
             (RwLockType::Read, RwLockHolder::None) => {
-                let mut readers = TaskSet::new(ExecutionState::with(|s| s.config.max_tasks));
+                let mut readers = TaskSet::new();
                 readers.insert(me);
                 state.holder = RwLockHolder::Read(readers);
             }


### PR DESCRIPTION
Previously, we required users to specify (via the `max_tasks` parameter in the `Config`) the maximum number of tasks that could be spawned during an execution.  This change lifts that restriction, and allows spawning of an arbitrary number of tasks.

Note: The PCT scheduler still only supports creation of upto 16 tasks.  A forthcoming PR will update PCT to also support spawning of an arbitrary number of tasks.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.