### PR TITLE
Add hints to `yield_now` to allow schedulers to deprioritize a yielding thread

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -161,6 +161,7 @@ pub async fn yield_now() {
 
             self.yielded = true;
             cx.waker().wake_by_ref();
+            ExecutionState::request_yield();
             Poll::Pending
         }
     }

--- a/src/runtime/runner.rs
+++ b/src/runtime/runner.rs
@@ -172,11 +172,16 @@ impl<S: Scheduler> Scheduler for PortfolioStoppableScheduler<S> {
         }
     }
 
-    fn next_task(&mut self, runnable_tasks: &[TaskId], current_task: Option<TaskId>) -> Option<TaskId> {
+    fn next_task(
+        &mut self,
+        runnable_tasks: &[TaskId],
+        current_task: Option<TaskId>,
+        is_yielding: bool,
+    ) -> Option<TaskId> {
         if self.stop_signal.load(Ordering::SeqCst) {
             None
         } else {
-            self.scheduler.next_task(runnable_tasks, current_task)
+            self.scheduler.next_task(runnable_tasks, current_task, is_yielding)
         }
     }
 

--- a/src/scheduler/dfs.rs
+++ b/src/scheduler/dfs.rs
@@ -64,7 +64,9 @@ impl Scheduler for DfsScheduler {
         Some(Schedule::new(self.data_source.reinitialize()))
     }
 
-    fn next_task(&mut self, runnable: &[TaskId], _current: Option<TaskId>) -> Option<TaskId> {
+    // TODO should we respect `is_yielding` by not allowing `current` to be scheduled next? That
+    // TODO would be unsound but perhaps useful for validating some code
+    fn next_task(&mut self, runnable: &[TaskId], _current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
         let next = if self.steps >= self.levels.len() {
             // First time we've reached this level
             assert_eq!(self.steps, self.levels.len());

--- a/src/scheduler/metrics.rs
+++ b/src/scheduler/metrics.rs
@@ -83,8 +83,13 @@ impl<S: Scheduler> Scheduler for MetricsScheduler<S> {
         self.inner.new_execution()
     }
 
-    fn next_task(&mut self, runnable_tasks: &[TaskId], current_task: Option<TaskId>) -> Option<TaskId> {
-        let choice = self.inner.next_task(runnable_tasks, current_task)?;
+    fn next_task(
+        &mut self,
+        runnable_tasks: &[TaskId],
+        current_task: Option<TaskId>,
+        is_yielding: bool,
+    ) -> Option<TaskId> {
+        let choice = self.inner.next_task(runnable_tasks, current_task, is_yielding)?;
 
         self.steps += 1;
         if choice != self.last_task {

--- a/src/scheduler/pct.rs
+++ b/src/scheduler/pct.rs
@@ -91,7 +91,7 @@ impl Scheduler for PctScheduler {
         Some(Schedule::new(self.data_source.reinitialize()))
     }
 
-    fn next_task(&mut self, runnable: &[TaskId], current: Option<TaskId>) -> Option<TaskId> {
+    fn next_task(&mut self, runnable: &[TaskId], current: Option<TaskId>, is_yielding: bool) -> Option<TaskId> {
         // No point doing priority changes when there's only one runnable task. This also means that
         // our step counter is counting actual scheduling decisions, not no-ops where there was no
         // choice about which task to run. From the paper (4.1, "Identifying Sequential Execution"):
@@ -100,7 +100,7 @@ impl Scheduler for PctScheduler {
         // > enables/creates a second thread.
         // TODO is this really correct? need to think about it more
         if runnable.len() > 1 {
-            if self.change_points.contains(&self.steps) {
+            if self.change_points.contains(&self.steps) || is_yielding {
                 // Deprioritize `current` by moving it to the end of the list
                 // TODO in the paper, the i'th change point gets priority i, whereas this gives d-i.
                 // TODO I don't think this matters, because the change points are randomized.

--- a/src/scheduler/random.rs
+++ b/src/scheduler/random.rs
@@ -51,7 +51,7 @@ impl Scheduler for RandomScheduler {
         }
     }
 
-    fn next_task(&mut self, runnable: &[TaskId], _current: Option<TaskId>) -> Option<TaskId> {
+    fn next_task(&mut self, runnable: &[TaskId], _current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
         Some(*runnable.choose(&mut self.rng).unwrap())
     }
 

--- a/src/scheduler/replay.rs
+++ b/src/scheduler/replay.rs
@@ -52,7 +52,7 @@ impl Scheduler for ReplayScheduler {
         }
     }
 
-    fn next_task(&mut self, runnable: &[TaskId], _current: Option<TaskId>) -> Option<TaskId> {
+    fn next_task(&mut self, runnable: &[TaskId], _current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
         if self.steps >= self.schedule.steps.len() {
             assert!(self.allow_incomplete, "schedule ended early");
             return None;

--- a/src/scheduler/round_robin.rs
+++ b/src/scheduler/round_robin.rs
@@ -31,7 +31,7 @@ impl Scheduler for RoundRobinScheduler {
         }
     }
 
-    fn next_task(&mut self, runnable: &[TaskId], current: Option<TaskId>) -> Option<TaskId> {
+    fn next_task(&mut self, runnable: &[TaskId], current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
         if current.is_none() {
             return Some(*runnable.first().unwrap());
         }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -118,9 +118,12 @@ impl<T> JoinHandle<T> {
     }
 }
 
-// TODO: don't need this? Just call switch directly?
 /// Cooperatively gives up a timeslice to the Shuttle scheduler.
+///
+/// Some Shuttle schedulers use this as a hint to deprioritize the current thread in order for other
+/// threads to make progress (e.g., in a spin loop).
 pub fn yield_now() {
+    ExecutionState::request_yield();
     thread::switch();
 }
 

--- a/tests/asynch/mod.rs
+++ b/tests/asynch/mod.rs
@@ -4,4 +4,5 @@
 mod basic;
 mod channel;
 mod countdown_timer;
+mod pct;
 mod waker;

--- a/tests/asynch/pct.rs
+++ b/tests/asynch/pct.rs
@@ -1,0 +1,73 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use shuttle::scheduler::PctScheduler;
+use shuttle::sync::Arc;
+use shuttle::{asynch, Config, MaxSteps, Runner};
+
+/// Like [`shuttle::asynch::yield_now`] but doesn't request a yield from the scheduler
+struct UnfairYieldNow {
+    yielded: bool,
+}
+
+impl Future for UnfairYieldNow {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.yielded {
+            return Poll::Ready(());
+        }
+
+        self.yielded = true;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}
+
+// Check that PCT correctly deprioritizes a yielding task. If it wasn't, there would be some
+// iteration of this test where the yielding task has the highest priority and so the others
+// never make progress.
+fn yield_spin_loop(use_yield: bool) {
+    const NUM_TASKS: usize = 4;
+
+    let scheduler = PctScheduler::new(1, 100);
+    let mut config = Config::new();
+    config.max_steps = MaxSteps::FailAfter(50);
+    let runner = Runner::new(scheduler, config);
+    runner.run(move || {
+        let count = Arc::new(AtomicUsize::new(0usize));
+
+        let _thds = (0..NUM_TASKS)
+            .map(|_| {
+                let count = count.clone();
+                asynch::spawn(async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        asynch::block_on(async move {
+            while count.load(Ordering::SeqCst) < NUM_TASKS {
+                if use_yield {
+                    asynch::yield_now().await;
+                } else {
+                    let yielder = UnfairYieldNow { yielded: false };
+                    yielder.await;
+                }
+            }
+        })
+    })
+}
+
+#[test]
+fn yield_spin_loop_fair() {
+    yield_spin_loop(true);
+}
+
+#[test]
+#[should_panic(expected = "exceeded max_steps bound")]
+fn yield_spin_loop_unfair() {
+    yield_spin_loop(false);
+}

--- a/tests/basic/execution.rs
+++ b/tests/basic/execution.rs
@@ -133,7 +133,12 @@ fn max_steps_early_exit_scheduler() {
             }
         }
 
-        fn next_task(&mut self, runnable_tasks: &[TaskId], _current_task: Option<TaskId>) -> Option<TaskId> {
+        fn next_task(
+            &mut self,
+            runnable_tasks: &[TaskId],
+            _current_task: Option<TaskId>,
+            _is_yielding: bool,
+        ) -> Option<TaskId> {
             if self.steps >= self.max_steps {
                 None
             } else {


### PR DESCRIPTION
Tasks that implement busy-wait loops or other infinite loops are a fairness
issue for schedulers like PCT, which will run a thread indefinitely until it
blocks. This change makes both sync and async versions of `yield_now` act as
a hint to the scheduler that the current task should be deprioritized. Only
the PCT scheduler acts on this hint, by moving the current task to the lowest
priority. We could also make the DFS scheduler react to this hint by not
allowing it to re-schedule the current task immediately, but that would be
unsound.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
