### PR TITLE
Update PCT scheduler to support an arbitrary number of tasks.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "~0.3.5"
 generator = "~0.7.0"
 hex = "~0.4.2"
 rand_core = "~0.5.1"
-rand = { version = "~0.7.3", default-features = false, features = ["getrandom", "alloc"] }
+rand = { version = "~0.7.3", default-features = false, features = ["getrandom"] }
 rand_pcg = "~0.2.1"
 scoped-tls = "~1.0.0"
 smallvec = "~1.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "~0.3.5"
 generator = "~0.7.0"
 hex = "~0.4.2"
 rand_core = "~0.5.1"
-rand = { version = "~0.7.3", default-features = false, features = ["getrandom"] }
+rand = { version = "~0.7.3", default-features = false, features = ["getrandom", "alloc"] }
 rand_pcg = "~0.2.1"
 scoped-tls = "~1.0.0"
 smallvec = "~1.6.1"

--- a/tests/basic/pct.rs
+++ b/tests/basic/pct.rs
@@ -94,3 +94,154 @@ fn yield_spin_loop_fair() {
 fn yield_spin_loop_unfair() {
     yield_spin_loop(false);
 }
+
+#[test]
+#[should_panic(expected = "null dereference")]
+// Based on Fig 1(a) of the PCT paper.  We model NULL pointer dereference with an Option unwrap
+fn figure1a_pct() {
+    const COUNT: usize = 5usize;
+    // n=2, d=1, so probability of finding the bug is at least 1/2
+    // So probability of hitting the bug in 20 iterations = 1 - (1 - 1/2)^20 > 99.9%
+    let scheduler = PctScheduler::new(1, 20);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(|| {
+        let t1 = Arc::new(Mutex::new(None));
+        let t2 = Arc::clone(&t1);
+
+        thread::spawn(move || {
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            *t1.lock().unwrap() = Some(1);
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+
+        thread::spawn(move || {
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            let _ = t2.lock().unwrap().expect("null dereference");
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+    });
+}
+
+// Based on Fig 1(b) from the PCT paper.  We model NULL pointer dereference with an Option unwrap.
+fn figure1b(num_threads: usize) {
+    assert!(num_threads >= 2);
+
+    let x1 = Arc::new(Mutex::new(Some(1)));
+    let x2 = Arc::clone(&x1);
+
+    // Optionally, spawn a bunch of threads that add scheduling choice points, each taking 5 steps
+    for _ in 0..num_threads - 2 {
+        thread::spawn(|| {
+            for _ in 0..5 {
+                thread::sleep(Duration::from_millis(1));
+            }
+        });
+    }
+
+    // Main worker threads take 10 steps each
+    thread::spawn(move || {
+        for _ in 0..5 {
+            thread::sleep(Duration::from_millis(1));
+        }
+        *x1.lock().unwrap() = None;
+        for _ in 0..4 {
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+
+    thread::spawn(move || {
+        for _ in 0..4 {
+            thread::sleep(Duration::from_millis(1));
+        }
+        let b = {
+            let b = x2.lock().unwrap().is_some();
+            b
+        };
+        if b {
+            let _ = x2.lock().unwrap().expect("null dereference");
+        }
+        for _ in 0..4 {
+            thread::sleep(Duration::from_millis(1));
+        }
+    });
+}
+
+#[test]
+#[should_panic(expected = "null dereference")]
+fn figure1b_pct() {
+    // n=2, k=20, d=2, so probability of finding the bug in one iteration is at least 1/(2*20)
+    // So probability of hitting the bug in 300 iterations = 1 - (1 - 1/40)^300 > 99.9%
+    let scheduler = PctScheduler::new(2, 300);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(|| {
+        figure1b(2);
+    });
+}
+
+#[test]
+#[should_panic(expected = "null dereference")]
+fn figure1b_pct_with_many_tasks() {
+    // Spawn 48 busy threads, each taking 5 steps, plus 2 main threads with 10 steps, so k=260
+    // n=50, k=260, d=2, so probability of finding the bug in one iteration is at least 1/(50*260)
+    // So probability of hitting the bug in 2000 iterations = 1 - (1 - 1/400)^2000 > 99.9%
+    let scheduler = PctScheduler::new(2, 2000);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(|| {
+        figure1b(50);
+    });
+}
+
+#[test]
+#[should_panic(expected = "deadlock")]
+// Based on Fig 1(c) from the PCT paper.
+fn figure_1c() {
+    const COUNT: usize = 4usize;
+    // n=2, k=2*14, d=2, so probability of finding the bug is at least 1/(2*28)
+    // So probability of hitting the bug in 400 iterations = 1 - (1 - 1/56)^400 > 99.9%
+    let scheduler = PctScheduler::new(2, 400);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(|| {
+        let a1 = Arc::new(Mutex::new(0));
+        let a2 = Arc::clone(&a1);
+        let b1 = Arc::new(Mutex::new(0));
+        let b2 = Arc::clone(&b1);
+
+        thread::spawn(move || {
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            let a = a1.lock().unwrap();
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            let b = b1.lock().unwrap();
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            assert_eq!(*a + *b, 0)
+        });
+
+        thread::spawn(move || {
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            let b = b2.lock().unwrap();
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            let a = a2.lock().unwrap();
+            for _ in 0..COUNT {
+                thread::sleep(Duration::from_millis(1));
+            }
+            assert_eq!(*a + *b, 0);
+        });
+    });
+}


### PR DESCRIPTION
PR#16 added support for spawning an arbitrary number of tasks, but the PCT scheduler still required the number of tasks to be specified statically (hardcoded to 16).  This PR extends the PCT scheduler to support an arbitrary number of tasks.  The main idea is that whenever a new task is seen, it is assigned an arbitrary priority.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.