### PR TITLE
Use Level::ERROR for all tracing spans

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -419,7 +419,7 @@ impl ExecutionState {
         // `self.current_span_entered` before dropping the `self.current_span` it points to.
         self.current_span_entered.take();
         if let ScheduledTask::Some(tid) = self.current_task {
-            self.current_span = span!(Level::DEBUG, "step", i = self.current_schedule.len() - 1, task = tid.0);
+            self.current_span = span!(Level::ERROR, "step", i = self.current_schedule.len() - 1, task = tid.0);
             self.current_span_entered = Some(unsafe { extend_span_entered_lt(self.current_span.enter()) });
         }
     }

--- a/src/runtime/runner.rs
+++ b/src/runtime/runner.rs
@@ -53,7 +53,7 @@ impl<S: Scheduler + 'static> Runner<S> {
                 };
                 let execution = Execution::new(self.scheduler.clone(), schedule);
                 let f = Arc::clone(&f);
-                span!(Level::INFO, "execution", i).in_scope(|| execution.run(&self.config, move || f()));
+                span!(Level::ERROR, "execution", i).in_scope(|| execution.run(&self.config, move || f()));
             }
         })
     }
@@ -117,7 +117,7 @@ impl PortfolioRunner {
 
                     let runner = Runner::new(scheduler, config);
 
-                    span!(Level::INFO, "job", i).in_scope(|| {
+                    span!(Level::ERROR, "job", i).in_scope(|| {
                         let ret = panic::catch_unwind(panic::AssertUnwindSafe(|| runner.run(f)));
 
                         match ret {


### PR DESCRIPTION
The level of the span determines when it will be included in tracing output:
a span at level TRACE will only be included in messages at level TRACE, a span
at level INFO will be included in messages at level INFO or lower, etc. So we
want to put these spans at level ERROR to include them in *all* output. The
idea is that Shuttle users can use e.g. `tracing::info!` in their program to
debug, and those messages will include the span info (most importantly, the
task ID) from Shuttle.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
