### PR TITLE
Add a timeout option to Config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,12 @@ pub struct Config {
     /// Maximum number of steps a single iteration of a test can take, and how to react when the
     /// limit is reached
     pub max_steps: MaxSteps,
+
+    /// Time limit for an entire test. If set, calls to [`Runner::run`] will return when the time
+    /// limit is exceeded or the [`Scheduler`](crate::scheduler::Scheduler) chooses to stop (e.g.,
+    /// by hitting its maximum number of iterations), whichever comes first. This time limit will
+    /// not abort a currently running test iteration; the limit is only checked between iterations.
+    pub max_time: Option<std::time::Duration>,
 }
 
 impl Config {
@@ -212,6 +218,7 @@ impl Config {
             stack_size: 0x8000,
             failure_persistence: FailurePersistence::Print,
             max_steps: MaxSteps::FailAfter(1_000_000),
+            max_time: None,
         }
     }
 }

--- a/tests/asynch/pct.rs
+++ b/tests/asynch/pct.rs
@@ -58,7 +58,7 @@ fn yield_spin_loop(use_yield: bool) {
                 }
             }
         })
-    })
+    });
 }
 
 #[test]

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -12,3 +12,4 @@ mod replay;
 mod rwlock;
 mod shrink;
 mod thread;
+mod timeout;

--- a/tests/basic/pct.rs
+++ b/tests/basic/pct.rs
@@ -49,7 +49,7 @@ fn one_step() {
     let runner = Runner::new(scheduler, Default::default());
     runner.run(|| {
         thread::spawn(|| {});
-    })
+    });
 }
 
 // Check that PCT correctly deprioritizes a yielding thread. If it wasn't, there would be some
@@ -81,7 +81,7 @@ fn yield_spin_loop(use_yield: bool) {
                 thread::sleep(Duration::from_millis(1));
             }
         }
-    })
+    });
 }
 
 #[test]

--- a/tests/basic/timeout.rs
+++ b/tests/basic/timeout.rs
@@ -1,0 +1,70 @@
+use shuttle::scheduler::{RandomScheduler, Schedule, Scheduler, TaskId};
+use shuttle::sync::Mutex;
+use shuttle::Config;
+use shuttle::{thread, Runner};
+use std::sync::Arc;
+use std::time::Duration;
+use test_env_log::test;
+
+/// A scheduler that sleeps between executions to test timeout behavior
+#[derive(Debug)]
+struct SleepableScheduler<S> {
+    scheduler: S,
+    sleep_time: Duration,
+}
+
+impl<S: Scheduler> SleepableScheduler<S> {
+    fn new(scheduler: S, sleep_time: Duration) -> Self {
+        Self { scheduler, sleep_time }
+    }
+}
+
+impl<S: Scheduler> Scheduler for SleepableScheduler<S> {
+    fn new_execution(&mut self) -> Option<Schedule> {
+        std::thread::sleep(self.sleep_time);
+        self.scheduler.new_execution()
+    }
+
+    fn next_task(
+        &mut self,
+        runnable_tasks: &[TaskId],
+        current_task: Option<TaskId>,
+        is_yielding: bool,
+    ) -> Option<TaskId> {
+        self.scheduler.next_task(runnable_tasks, current_task, is_yielding)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.scheduler.next_u64()
+    }
+}
+
+#[test]
+fn runner_timeout() {
+    let scheduler = RandomScheduler::new(100000);
+    let scheduler = SleepableScheduler::new(scheduler, Duration::from_millis(10));
+
+    let mut config = Config::new();
+    config.max_time = Some(Duration::from_secs(1));
+
+    let runner = Runner::new(scheduler, config);
+
+    let iterations = runner.run(|| {
+        let lock = Arc::new(Mutex::new(0usize));
+        let lock_clone = Arc::clone(&lock);
+
+        thread::spawn(move || {
+            let mut counter = lock_clone.lock().unwrap();
+            *counter += 1;
+        });
+
+        let mut counter = lock.lock().unwrap();
+        *counter += 1;
+    });
+
+    assert!(iterations < 10000, "test must stop well before max_iterations");
+    assert!(
+        iterations >= 1,
+        "test must run at least once (maybe running on a _very_ slow host?"
+    );
+}


### PR DESCRIPTION
In some applications, we want to run Shuttle for as many iterations as
possible within some time budget to increase our confidence in the
code's correctness. This change adds a new `max_time` config that will
end a test once the timeout is reached. The timeout is only checked
between test iterations, so it won't abort midway through a single test
iteration.

To help guard against slow tests, `Runner::run` now returns the number
of iterations it ran. In normal operation this will be whatever number
of iterations the scheduler dictated (e.g., through `max_iterations`
options), but if the timeout is reached it may be smaller. Callers can
check this value to make sure the test wasn't unreasonably slow.
