### PR TITLE
Implement `Mutex::into_inner`

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -91,6 +91,13 @@ impl<T> Mutex<T> {
     pub fn try_lock(&self) -> TryLockResult<MutexGuard<T>> {
         unimplemented!()
     }
+
+    /// Consumes this mutex, returning the underlying data.
+    pub fn into_inner(self) -> LockResult<T> {
+        assert!(self.state.borrow().holder.is_none());
+        assert!(self.state.borrow().waiters.is_empty());
+        self.inner.into_inner()
+    }
 }
 
 // Safety: Mutex is never actually passed across true threads, only across continuations. The

--- a/tests/basic/mutex.rs
+++ b/tests/basic/mutex.rs
@@ -126,3 +126,29 @@ fn panic_drop() {
         panic!("expected panic");
     })
 }
+
+#[test]
+fn mutex_into_inner() {
+    shuttle::check_dfs(
+        || {
+            let lock = Arc::new(Mutex::new(0u64));
+
+            let threads = (0..2)
+                .map(|_| {
+                    let lock = lock.clone();
+                    thread::spawn(move || {
+                        *lock.lock().unwrap() += 1;
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thread in threads {
+                thread.join().unwrap();
+            }
+
+            let lock = Arc::try_unwrap(lock).unwrap();
+            assert_eq!(lock.into_inner().unwrap(), 2);
+        },
+        None,
+    )
+}

--- a/tests/basic/rwlock.rs
+++ b/tests/basic/rwlock.rs
@@ -194,3 +194,29 @@ fn rwlock_default() {
         None,
     );
 }
+
+#[test]
+fn rwlock_into_inner() {
+    shuttle::check_dfs(
+        || {
+            let lock = Arc::new(RwLock::new(0u64));
+
+            let threads = (0..2)
+                .map(|_| {
+                    let lock = lock.clone();
+                    thread::spawn(move || {
+                        *lock.write().unwrap() += 1;
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thread in threads {
+                thread.join().unwrap();
+            }
+
+            let lock = Arc::try_unwrap(lock).unwrap();
+            assert_eq!(lock.into_inner().unwrap(), 2);
+        },
+        None,
+    )
+}


### PR DESCRIPTION
We already had `RwLock::into_inner` and this is the same thing. Also
wrote tests for both `into_inner`s.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
