### PR TITLE
Include default features for `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures = "~0.3.5"
 generator = "~0.7.0"
 hex = "~0.4.2"
 rand_core = "~0.5.1"
-rand = { version = "~0.7.3", default-features = false, features = ["getrandom"] }
+rand = "~0.7.3"
 rand_pcg = "~0.2.1"
 scoped-tls = "~1.0.0"
 smallvec = "~1.6.1"


### PR DESCRIPTION
We're using `rand::seq::index`, which turns out to require the `alloc`
feature of that crate, but the documentation doesn't specify that. This
has been causing some funkiness in builds of packages that depend on
Shuttle, so let's just fix it here. To be honest, I don't even remember
why we turned off the default features for rand to start with---we
certainly don't expect Shuttle to work in `no_std` environments.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
