### PR TITLE
Better handling for poisoned locks

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -2,8 +2,6 @@
 
 mod barrier;
 mod condvar;
-
-/// Multi-producer, single-consumer FIFO queue communication primitives.
 pub mod mpsc;
 mod mutex;
 mod rwlock;

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -1,3 +1,5 @@
+//! Multi-producer, single-consumer FIFO queue communication primitives.
+
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::{TaskId, DEFAULT_INLINE_TASKS};
 use crate::runtime::thread;

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -6,6 +6,7 @@ mod execution;
 mod metrics;
 mod mpsc;
 mod mutex;
+mod panic;
 mod pct;
 mod portfolio;
 mod replay;

--- a/tests/basic/panic.rs
+++ b/tests/basic/panic.rs
@@ -1,0 +1,57 @@
+use shuttle::sync::{Mutex, RwLock};
+use shuttle::{check_dfs, thread};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::{Arc, PoisonError};
+use test_env_log::test;
+
+#[test]
+fn mutex_poison() {
+    check_dfs(
+        || {
+            let lock = Arc::new(Mutex::new(false));
+
+            let thd = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    let _err = catch_unwind(AssertUnwindSafe(move || {
+                        let _lock = lock.lock().unwrap();
+                        panic!("expected panic");
+                    }))
+                    .unwrap_err();
+                })
+            };
+
+            thd.join().unwrap();
+
+            let result = lock.lock();
+            assert!(matches!(result, Err(PoisonError { .. })));
+        },
+        None,
+    )
+}
+
+#[test]
+fn rwlock_poison() {
+    check_dfs(
+        || {
+            let lock = Arc::new(RwLock::new(false));
+
+            let thd = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    let _err = catch_unwind(AssertUnwindSafe(move || {
+                        let _lock = lock.write().unwrap();
+                        panic!("expected panic");
+                    }))
+                    .unwrap_err();
+                })
+            };
+
+            thd.join().unwrap();
+
+            let result = lock.read();
+            assert!(matches!(result, Err(PoisonError { .. })));
+        },
+        None,
+    )
+}


### PR DESCRIPTION
A common pattern in Rust code is to acquire a lock in a `Drop`
implementation, e.g. to return a resource to a shared pool when dropped.
If code panics while holding that same lock, the Drop handler will try
to enter the lock during unwinding, but the lock is poisoned. In real
Rust code that usually creates a double-panic (`.lock().unwrap()` will
fail). In Shuttle test code it's also a double panic, but the second
panic exposes an unhelpful error about internal Shuttle state.

This change propagates the poison status of `Mutex`s and `RwLock`s so
that the second panic in this scenarios is more helpful and looks the
same as in regular Rust code. To do this, we change where some of the
bookkeeping happens in the `Drop` impls for lock guards, so that the
lock is returned to a usable state. Tests that double-panicked before
will still double-panic after this change, but the message will be the same
as it would be under a non-Shuttle execution (that the lock is poisoned)
rather than exposing the guts of Shuttle's lock implementations.

One thing that's weird here is that the semantics of poisoning require
that we acquire the lock before returning the poison error (so that
client code can `into_inner()` the poison issue and continue as normal
if it so pleases). This change probably won't work very well in code that
does that, as the lock is being returned to a state that will allow it to be
acquired, but isn't unblocking any pending threads.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.