### PR TITLE
Implement SeqCst atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["concurrency", "lock", "thread", "async"]
 categories = ["asynchronous", "concurrency", "development-tools::testing"]
 
 [dependencies]
+ansi_term = "~0.12.1"
 bitvec = "~0.21.0"
 futures = "~0.3.5"
 generator = "~0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,10 @@ pub struct Config {
     /// by hitting its maximum number of iterations), whichever comes first. This time limit will
     /// not abort a currently running test iteration; the limit is only checked between iterations.
     pub max_time: Option<std::time::Duration>,
+
+    /// Whether to enable warnings about [Shuttle's unsound implementation of
+    /// `atomic`](crate::sync::atomic#warning-about-relaxed-behaviors).
+    pub silence_atomic_ordering_warning: bool,
 }
 
 impl Config {
@@ -220,6 +224,7 @@ impl Config {
             failure_persistence: FailurePersistence::Print,
             max_steps: MaxSteps::FailAfter(1_000_000),
             max_time: None,
+            silence_atomic_ordering_warning: false,
         }
     }
 }

--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -1,0 +1,142 @@
+use crate::sync::atomic::Atomic;
+use std::sync::atomic::Ordering;
+
+/// A boolean type which can be safely shared between threads.
+pub struct AtomicBool {
+    inner: Atomic<bool>,
+}
+
+impl Default for AtomicBool {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl From<bool> for AtomicBool {
+    fn from(b: bool) -> Self {
+        Self::new(b)
+    }
+}
+
+impl std::fmt::Debug for AtomicBool {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Debug::fmt(unsafe { &self.raw_load() }, f)
+    }
+}
+
+impl AtomicBool {
+    /// Creates a new atomic boolean.
+    pub const fn new(v: bool) -> Self {
+        Self { inner: Atomic::new(v) }
+    }
+
+    /// Returns a mutable reference to the underlying boolean.
+    pub fn get_mut(&mut self) -> &mut bool {
+        self.inner.get_mut()
+    }
+
+    /// Consumes the atomic and returns the contained value.
+    pub fn into_inner(self) -> bool {
+        self.inner.into_inner()
+    }
+
+    /// Loads a value from the atomic boolean.
+    pub fn load(&self, order: Ordering) -> bool {
+        self.inner.load(order)
+    }
+
+    /// Stores a value into the atomic boolean.
+    pub fn store(&self, val: bool, order: Ordering) {
+        self.inner.store(val, order)
+    }
+
+    /// Stores a value into the atomic boolean, returning the previous value.
+    pub fn swap(&self, val: bool, order: Ordering) -> bool {
+        self.inner.swap(val, order)
+    }
+
+    /// Fetches the value, and applies a function to it that returns an optional new value.
+    /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some(_)`, else
+    /// `Err(previous_value)`.
+    pub fn fetch_update<F>(&self, set_order: Ordering, fetch_order: Ordering, f: F) -> Result<bool, bool>
+    where
+        F: FnMut(bool) -> Option<bool>,
+    {
+        self.inner.fetch_update(set_order, fetch_order, f)
+    }
+
+    /// Stores a value into the atomic boolean if the current value is the same as the
+    /// `current` value.
+    #[deprecated(since = "0.0.6", note = "Use `compare_exchange` or `compare_exchange_weak` instead")]
+    pub fn compare_and_swap(&self, current: bool, new: bool, order: Ordering) -> bool {
+        match self.compare_exchange(current, new, order, order) {
+            Ok(v) => v,
+            Err(v) => v,
+        }
+    }
+
+    /// Stores a value into the atomic boolean if the current value is the same as the
+    /// `current` value.
+    ///
+    /// The return value is a result indicating whether the new value was written and
+    /// containing the previous value. On success this value is guaranteed to be equal to
+    /// `current`.
+    pub fn compare_exchange(
+        &self,
+        current: bool,
+        new: bool,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<bool, bool> {
+        self.fetch_update(success, failure, |val| (val == current).then(|| new))
+    }
+
+    /// Stores a value into the atomic boolean if the current value is the same as the
+    /// `current` value.
+    ///
+    /// Unlike [`AtomicBool::compare_exchange`], this function is allowed to spuriously fail
+    /// even when the comparison succeeds, which can result in more efficient code on some
+    /// platforms. The return value is a result indicating whether the new value was written
+    /// and containing the previous value.
+    // TODO actually produce spurious failures
+    pub fn compare_exchange_weak(
+        &self,
+        current: bool,
+        new: bool,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<bool, bool> {
+        self.compare_exchange(current, new, success, failure)
+    }
+
+    /// Logical "and" with the current value. Returns the previous value.
+    pub fn fetch_and(&self, val: bool, order: Ordering) -> bool {
+        self.fetch_update(order, order, |old| Some(old & val)).unwrap()
+    }
+
+    /// Logical "nand" with the current value. Returns the previous value.
+    pub fn fetch_nand(&self, val: bool, order: Ordering) -> bool {
+        self.fetch_update(order, order, |old| Some(!(old & val))).unwrap()
+    }
+
+    /// Logical "or" with the current value. Returns the previous value.
+    pub fn fetch_or(&self, val: bool, order: Ordering) -> bool {
+        self.fetch_update(order, order, |old| Some(old | val)).unwrap()
+    }
+
+    /// Logical "xor" with the current value. Returns the previous value.
+    pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool {
+        self.fetch_update(order, order, |old| Some(old ^ val)).unwrap()
+    }
+
+    /// Load the atomic value directly without triggering any Shuttle context switches.
+    ///
+    /// # Safety
+    ///
+    /// Shuttle does not consider potential concurrent interleavings of this function call,
+    /// and so it should be used when those interleavings aren't important (primarily in
+    /// debugging scenarios where we might want to just print this atomic's value).
+    pub unsafe fn raw_load(&self) -> bool {
+        self.inner.raw_load()
+    }
+}

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -1,0 +1,193 @@
+use crate::sync::atomic::Atomic;
+use std::sync::atomic::Ordering;
+
+macro_rules! atomic_int {
+    ($name:ident, $int_type:ty) => {
+        /// An integer type which can be safely shared between threads.
+        pub struct $name {
+            inner: Atomic<$int_type>,
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new(Default::default())
+            }
+        }
+
+        impl From<$int_type> for $name {
+            fn from(v: $int_type) -> Self {
+                Self::new(v)
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                std::fmt::Debug::fmt(unsafe { &self.raw_load() }, f)
+            }
+        }
+
+        impl $name {
+            /// Creates a new atomic integer.
+            pub const fn new(v: $int_type) -> Self {
+                Self {
+                    inner: Atomic::new(v),
+                }
+            }
+
+            /// Returns a mutable reference to the underlying integer.
+            pub fn get_mut(&mut self) -> &mut $int_type {
+                self.inner.get_mut()
+            }
+
+            /// Consumes the atomic and returns the contained value.
+            pub fn into_inner(self) -> $int_type {
+                self.inner.into_inner()
+            }
+
+            /// Loads a value from the atomic integer.
+            pub fn load(&self, order: Ordering) -> $int_type {
+                self.inner.load(order)
+            }
+
+            /// Stores a value into the atomic integer.
+            pub fn store(&self, val: $int_type, order: Ordering) {
+                self.inner.store(val, order)
+            }
+
+            /// Stores a value into the atomic integer, returning the previous value.
+            pub fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.inner.swap(val, order)
+            }
+
+            /// Fetches the value, and applies a function to it that returns an optional new value.
+            /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some(_)`, else
+            /// `Err(previous_value)`.
+            pub fn fetch_update<F>(
+                &self,
+                set_order: Ordering,
+                fetch_order: Ordering,
+                f: F,
+            ) -> Result<$int_type, $int_type>
+            where
+                F: FnMut($int_type) -> Option<$int_type>,
+            {
+                self.inner.fetch_update(set_order, fetch_order, f)
+            }
+
+            /// Stores a value into the atomic integer if the current value is the same as the
+            /// `current` value.
+            #[deprecated(
+                since = "0.0.6",
+                note = "Use `compare_exchange` or `compare_exchange_weak` instead"
+            )]
+            pub fn compare_and_swap(&self, current: $int_type, new: $int_type, order: Ordering) -> $int_type {
+                match self.compare_exchange(current, new, order, order) {
+                    Ok(v) => v,
+                    Err(v) => v,
+                }
+            }
+
+            /// Stores a value into the atomic integer if the current value is the same as the
+            /// `current` value.
+            ///
+            /// The return value is a result indicating whether the new value was written and
+            /// containing the previous value. On success this value is guaranteed to be equal to
+            /// `current`.
+            pub fn compare_exchange(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                self.fetch_update(success, failure, |val| (val == current).then(|| new))
+            }
+
+            /// Stores a value into the atomic integer if the current value is the same as the
+            /// `current` value.
+            ///
+            /// Unlike `compare_exchange`, this function is allowed to spuriously fail even when
+            /// the comparison succeeds, which can result in more efficient code on some platforms.
+            /// The return value is a result indicating whether the new value was written and
+            /// containing the previous value.
+            // TODO actually produce spurious failures
+            pub fn compare_exchange_weak(
+                &self,
+                current: $int_type,
+                new: $int_type,
+                success: Ordering,
+                failure: Ordering,
+            ) -> Result<$int_type, $int_type> {
+                self.compare_exchange(current, new, success, failure)
+            }
+
+            /// Adds to the current value, returning the previous value.
+            ///
+            /// This operation wraps around on overflow.
+            pub fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old.wrapping_add(val)))
+                    .unwrap()
+            }
+
+            /// Subtracts from the current value, returning the previous value.
+            ///
+            /// This operation wraps around on overflow.
+            pub fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old.wrapping_sub(val)))
+                    .unwrap()
+            }
+
+            /// Bitwise "and" with the current value. Returns the previous value.
+            pub fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old & val)).unwrap()
+            }
+
+            /// Bitwise "nand" with the current value. Returns the previous value.
+            pub fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(!(old & val))).unwrap()
+            }
+
+            /// Bitwise "or" with the current value. Returns the previous value.
+            pub fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old | val)).unwrap()
+            }
+
+            /// Bitwise "xor" with the current value. Returns the previous value.
+            pub fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old ^ val)).unwrap()
+            }
+
+            /// Maximum with the current value. Returns the previous value.
+            pub fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old.max(val))).unwrap()
+            }
+
+            /// Minimum with the current value. Returns the previous value.
+            pub fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
+                self.fetch_update(order, order, |old| Some(old.min(val))).unwrap()
+            }
+
+            /// Load the atomic value directly without triggering any Shuttle context switches.
+            ///
+            /// # Safety
+            ///
+            /// Shuttle does not consider potential concurrent interleavings of this function call,
+            /// and so it should be used when those interleavings aren't important (primarily in
+            /// debugging scenarios where we might want to just print this atomic's value).
+            pub unsafe fn raw_load(&self) -> $int_type {
+                self.inner.raw_load()
+            }
+        }
+    };
+}
+
+atomic_int!(AtomicI8, i8);
+atomic_int!(AtomicI16, i16);
+atomic_int!(AtomicI32, i32);
+atomic_int!(AtomicI64, i64);
+atomic_int!(AtomicIsize, isize);
+atomic_int!(AtomicU8, u8);
+atomic_int!(AtomicU16, u16);
+atomic_int!(AtomicU32, u32);
+atomic_int!(AtomicU64, u64);
+atomic_int!(AtomicUsize, usize);

--- a/src/sync/atomic/mod.rs
+++ b/src/sync/atomic/mod.rs
@@ -1,0 +1,189 @@
+//! Atomic types
+//!
+//! Atomic types provide primitive shared-memory communication between threads, and are the building
+//! blocks of other concurrent types.
+//!
+//! This module defines atomic versions of a select number of primitive types, the same as
+//! [`std::sync::atomic`] in the standard library. See that module's documentation for more details.
+//!
+//! # Warning about relaxed behaviors
+//!
+//! Shuttle does not faithfully model behaviors of relaxed atomic orderings (those other than
+//! [`SeqCst`](Ordering::SeqCst)). Code that uses these orderings may contain bugs that Shuttle is
+//! unable to find if the bug requires the relaxed behavior to occur. **Shuttle models *all* atomic
+//! operations as if they were using SeqCst ordering.**
+//!
+//! For example, consider this test that uses a `flag` variable to indicate that data is present in
+//! a separate `data` variable:
+//! ```
+//! # use std::sync::Arc;
+//! # use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+//! # use std::thread;
+//! let flag = Arc::new(AtomicBool::new(false));
+//! let data = Arc::new(AtomicU64::new(0));
+//!
+//! {
+//!     let flag = Arc::clone(&flag);
+//!     let data = Arc::clone(&data);
+//!     thread::spawn(move|| {
+//!         data.store(42, Ordering::Relaxed);
+//!         flag.store(true, Ordering::Relaxed);
+//!     });
+//! }
+//!
+//! if flag.load(Ordering::Relaxed) {
+//!     assert_eq!(data.load(Ordering::Relaxed), 42);
+//! }
+//! ```
+//! This code is incorrect because of the relaxed orderings used for the loads and stores. Some
+//! architectures will allow an execution where `flag` is true but the assertion is false. However,
+//! Shuttle treats all atomic operations as SeqCst, and this test would be correct if we used SeqCst
+//! for all atomic operations, so Shuttle cannot find this bug.
+//!
+//! If you are writing code that relies on relaxed atomic operations and need to check its
+//! correctness, the [Loom] crate provides support for reasoning about Acquire and Release orderings
+//! and partial support for Relaxed orderings.
+//!
+//! To disable the warning printed about this issue, set the `SHUTTLE_SILENCE_ORDERING_WARNING`
+//! environment variable to any value, or set the
+//! [`silence_atomic_ordering_warning`](crate::Config::silence_atomic_ordering_warning) field of
+//! [`Config`](crate::Config) to true.
+//!
+//! [Loom]: https://crates.io/crates/loom
+
+mod bool;
+mod int;
+mod ptr;
+
+pub use self::bool::AtomicBool;
+pub use int::*;
+pub use ptr::AtomicPtr;
+pub use std::sync::atomic::Ordering;
+
+use crate::runtime::execution::ExecutionState;
+use crate::runtime::thread;
+use std::cell::RefCell;
+
+static PRINTED_ORDERING_WARNING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+#[inline]
+fn maybe_warn_about_ordering(order: Ordering) {
+    use ansi_term::Colour;
+
+    #[allow(clippy::clippy::collapsible_if)]
+    if order != Ordering::SeqCst {
+        if PRINTED_ORDERING_WARNING
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            if std::env::var("SHUTTLE_SILENCE_ORDERING_WARNING").is_ok() {
+                return;
+            }
+
+            if ExecutionState::with(|state| state.config.silence_atomic_ordering_warning) {
+                return;
+            }
+
+            eprintln!(
+                "{}: Shuttle only correctly models SeqCst atomics and treats all other Orderings \
+                as if they were SeqCst. Bugs caused by weaker orderings like {:?} may be missed. \
+                See https://docs.rs/shuttle/*/shuttle/sync/atomic/index.html#warning-about-relaxed-behaviors \
+                for details or to disable this warning.",
+                Colour::Yellow.normal().paint("WARNING"),
+                order
+            );
+        }
+    }
+}
+
+/// An atomic fence, like the standard library's [std::sync::atomic::fence].
+pub fn fence(order: Ordering) {
+    if order == Ordering::Relaxed {
+        panic!("there is no such thing as a relaxed fence");
+    }
+
+    maybe_warn_about_ordering(order);
+
+    // SeqCst fences are no-ops in our execution model
+}
+
+// We can just reuse the standard library's compiler fence, as they have no visible run-time
+// behavior and so we need neither insert yieldpoints nor warn about non-SeqCst orderings.
+pub use std::sync::atomic::compiler_fence;
+
+/// Base type for atomic implementations. This type handles generating the right interleavings for
+/// all atomics. The interesting stuff is in `load`, `store`, `swap`, and `fetch_update`; all other
+/// atomic operations are implemented in terms of those four primitives.
+#[derive(Debug)]
+struct Atomic<T> {
+    inner: RefCell<T>,
+}
+
+// Safety: Atomic is never actually passed across true threads, only across continuations. The
+// RefCell<_> type therefore can't be preempted mid-bookkeeping-operation.
+unsafe impl<T: Sync> Sync for Atomic<T> {}
+
+impl<T> Atomic<T> {
+    const fn new(v: T) -> Self {
+        Self { inner: RefCell::new(v) }
+    }
+}
+
+impl<T: Copy + Eq> Atomic<T> {
+    fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+
+    fn load(&self, order: Ordering) -> T {
+        maybe_warn_about_ordering(order);
+
+        thread::switch();
+        let value = *self.inner.borrow();
+        thread::switch();
+        value
+    }
+
+    fn store(&self, val: T, order: Ordering) {
+        maybe_warn_about_ordering(order);
+
+        thread::switch();
+        *self.inner.borrow_mut() = val;
+        thread::switch();
+    }
+
+    fn swap(&self, mut val: T, order: Ordering) -> T {
+        maybe_warn_about_ordering(order);
+
+        thread::switch();
+        std::mem::swap(&mut *self.inner.borrow_mut(), &mut val);
+        thread::switch();
+        val
+    }
+
+    fn fetch_update<F>(&self, set_order: Ordering, fetch_order: Ordering, mut f: F) -> Result<T, T>
+    where
+        F: FnMut(T) -> Option<T>,
+    {
+        maybe_warn_about_ordering(set_order);
+        maybe_warn_about_ordering(fetch_order);
+
+        thread::switch();
+        let current = *self.inner.borrow();
+        let ret = if let Some(new) = f(current) {
+            *self.inner.borrow_mut() = new;
+            Ok(current)
+        } else {
+            Err(current)
+        };
+        thread::switch();
+        ret
+    }
+
+    unsafe fn raw_load(&self) -> T {
+        *self.inner.borrow()
+    }
+}

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -1,0 +1,127 @@
+use crate::sync::atomic::Atomic;
+use std::sync::atomic::Ordering;
+
+/// A raw pointer type which can be safely shared between threads.
+pub struct AtomicPtr<T> {
+    inner: Atomic<*mut T>,
+}
+
+impl<T> Default for AtomicPtr<T> {
+    fn default() -> Self {
+        Self::new(std::ptr::null_mut())
+    }
+}
+
+impl<T> From<*mut T> for AtomicPtr<T> {
+    fn from(p: *mut T) -> Self {
+        Self::new(p)
+    }
+}
+
+impl<T> std::fmt::Debug for AtomicPtr<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        std::fmt::Debug::fmt(unsafe { &self.raw_load() }, f)
+    }
+}
+
+// Atomic operations make it safe to Send + Sync this shared raw pointer (establishing the safety of
+// *using* the raw pointer is still up to the caller)
+unsafe impl<T> Send for AtomicPtr<T> {}
+unsafe impl<T> Sync for AtomicPtr<T> {}
+
+impl<T> AtomicPtr<T> {
+    /// Creates a new `AtomicPtr`.
+    pub const fn new(v: *mut T) -> Self {
+        Self { inner: Atomic::new(v) }
+    }
+
+    /// Returns a mutable reference to the underlying pointer.
+    pub fn get_mut(&mut self) -> &mut *mut T {
+        self.inner.get_mut()
+    }
+
+    /// Consumes the atomic and returns the contained value.
+    pub fn into_inner(self) -> *mut T {
+        self.inner.into_inner()
+    }
+
+    /// Loads a value from the pointer.
+    pub fn load(&self, order: Ordering) -> *mut T {
+        self.inner.load(order)
+    }
+
+    /// Stores a value into the pointer.
+    pub fn store(&self, val: *mut T, order: Ordering) {
+        self.inner.store(val, order)
+    }
+
+    /// Stores a value into the atomic pointer, returning the previous value.
+    pub fn swap(&self, val: *mut T, order: Ordering) -> *mut T {
+        self.inner.swap(val, order)
+    }
+
+    /// Fetches the value, and applies a function to it that returns an optional new value.
+    /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some(_)`, else
+    /// `Err(previous_value)`.
+    pub fn fetch_update<F>(&self, set_order: Ordering, fetch_order: Ordering, f: F) -> Result<*mut T, *mut T>
+    where
+        F: FnMut(*mut T) -> Option<*mut T>,
+    {
+        self.inner.fetch_update(set_order, fetch_order, f)
+    }
+
+    /// Stores a value into the atomic pointer if the current value is the same as the
+    /// `current` value.
+    #[deprecated(since = "0.0.6", note = "Use `compare_exchange` or `compare_exchange_weak` instead")]
+    pub fn compare_and_swap(&self, current: *mut T, new: *mut T, order: Ordering) -> *mut T {
+        match self.compare_exchange(current, new, order, order) {
+            Ok(v) => v,
+            Err(v) => v,
+        }
+    }
+
+    /// Stores a value into the atomic pointer if the current value is the same as the
+    /// `current` value.
+    ///
+    /// The return value is a result indicating whether the new value was written and
+    /// containing the previous value. On success this value is guaranteed to be equal to
+    /// `current`.
+    pub fn compare_exchange(
+        &self,
+        current: *mut T,
+        new: *mut T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*mut T, *mut T> {
+        self.fetch_update(success, failure, |val| (val == current).then(|| new))
+    }
+
+    /// Stores a value into the atomic pointer if the current value is the same as the
+    /// `current` value.
+    ///
+    /// Unlike [`AtomicPtr::compare_exchange`], this function is allowed to spuriously fail
+    /// even when the comparison succeeds, which can result in more efficient code on some
+    /// platforms. The return value is a result indicating whether the new value was written
+    /// and containing the previous value.
+    // TODO actually produce spurious failures
+    pub fn compare_exchange_weak(
+        &self,
+        current: *mut T,
+        new: *mut T,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<*mut T, *mut T> {
+        self.compare_exchange(current, new, success, failure)
+    }
+
+    /// Load the atomic value directly without triggering any Shuttle context switches.
+    ///
+    /// # Safety
+    ///
+    /// Shuttle does not consider potential concurrent interleavings of this function call,
+    /// and so it should be used when those interleavings aren't important (primarily in
+    /// debugging scenarios where we might want to just print this atomic's value).
+    pub unsafe fn raw_load(&self) -> *mut T {
+        self.inner.raw_load()
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,5 +1,6 @@
 //! Shuttle's implementation of [`std::sync`].
 
+pub mod atomic;
 mod barrier;
 mod condvar;
 pub mod mpsc;

--- a/tests/basic/atomic.rs
+++ b/tests/basic/atomic.rs
@@ -1,0 +1,456 @@
+use shuttle::sync::atomic::*;
+use shuttle::{asynch, check_dfs, thread};
+use std::collections::HashSet;
+use std::sync::Arc;
+use test_env_log::test;
+
+macro_rules! int_tests {
+    ($name:ident, $ty:ident) => {
+        mod $name {
+            use super::*;
+            use test_env_log::test;
+
+            #[test]
+            fn store_store_reordering() {
+                let observed_states = Arc::new(std::sync::Mutex::new(HashSet::new()));
+                let observed_states_clone = observed_states.clone();
+
+                check_dfs(
+                    move || {
+                        let x = Arc::new($ty::new(0));
+                        let y = Arc::new($ty::new(0));
+
+                        let thd1 = {
+                            let x = x.clone();
+                            let y = y.clone();
+                            thread::spawn(move || {
+                                x.store(1, Ordering::SeqCst);
+                                y.store(1, Ordering::SeqCst);
+                                ()
+                            })
+                        };
+                        let thd2 = {
+                            let x = x.clone();
+                            let y = y.clone();
+                            thread::spawn(move || {
+                                let y = y.load(Ordering::SeqCst);
+                                let x = x.load(Ordering::SeqCst);
+                                (x, y)
+                            })
+                        };
+
+                        let thd1 = thd1.join().unwrap();
+                        let thd2 = thd2.join().unwrap();
+                        observed_states.lock().unwrap().insert((thd1, thd2));
+                    },
+                    None,
+                );
+
+                let observed_states = Arc::try_unwrap(observed_states_clone)
+                    .unwrap()
+                    .into_inner()
+                    .unwrap();
+                assert!(observed_states.contains(&((), (0, 0))));
+                assert!(observed_states.contains(&((), (1, 0))));
+                assert!(observed_states.contains(&((), (1, 1))));
+                assert!(!observed_states.contains(&((), (0, 1))));
+            }
+
+            #[test]
+            fn store_load_reordering() {
+                let observed_states = Arc::new(std::sync::Mutex::new(HashSet::new()));
+                let observed_states_clone = observed_states.clone();
+
+                check_dfs(
+                    move || {
+                        let x = Arc::new($ty::new(0));
+                        let y = Arc::new($ty::new(0));
+
+                        let thd1 = {
+                            let x = x.clone();
+                            let y = y.clone();
+                            thread::spawn(move || {
+                                let x = x.load(Ordering::SeqCst);
+                                y.store(1, Ordering::SeqCst);
+                                (x,)
+                            })
+                        };
+                        let thd2 = {
+                            let x = x.clone();
+                            let y = y.clone();
+                            thread::spawn(move || {
+                                let y = y.load(Ordering::SeqCst);
+                                x.store(1, Ordering::SeqCst);
+                                (y,)
+                            })
+                        };
+
+                        let thd1 = thd1.join().unwrap();
+                        let thd2 = thd2.join().unwrap();
+                        observed_states.lock().unwrap().insert((thd1, thd2));
+                    },
+                    None,
+                );
+
+                let observed_states = Arc::try_unwrap(observed_states_clone)
+                    .unwrap()
+                    .into_inner()
+                    .unwrap();
+                assert!(observed_states.contains(&((0,), (0,))));
+                assert!(observed_states.contains(&((0,), (1,))));
+                assert!(observed_states.contains(&((1,), (0,))));
+                assert!(!observed_states.contains(&((1,), (1,))));
+            }
+
+            #[test]
+            fn load_store_reordering() {
+                let observed_states = Arc::new(std::sync::Mutex::new(HashSet::new()));
+                let observed_states_clone = observed_states.clone();
+
+                check_dfs(
+                    move || {
+                        let x = Arc::new($ty::new(0));
+                        let y = Arc::new($ty::new(0));
+
+                        let thd1 = {
+                            let x = x.clone();
+                            let y = y.clone();
+                            thread::spawn(move || {
+                                x.store(1, Ordering::SeqCst);
+                                let y = y.load(Ordering::SeqCst);
+                                (y,)
+                            })
+                        };
+                        let thd2 = {
+                            let x = x.clone();
+                            let y = y.clone();
+                            thread::spawn(move || {
+                                y.store(1, Ordering::SeqCst);
+                                let x = x.load(Ordering::SeqCst);
+                                (x,)
+                            })
+                        };
+
+                        let thd1 = thd1.join().unwrap();
+                        let thd2 = thd2.join().unwrap();
+                        observed_states.lock().unwrap().insert((thd1, thd2));
+                    },
+                    None,
+                );
+
+                let observed_states = Arc::try_unwrap(observed_states_clone)
+                    .unwrap()
+                    .into_inner()
+                    .unwrap();
+                assert!(!observed_states.contains(&((0,), (0,)))); // would be allowed on x86
+                assert!(observed_states.contains(&((0,), (1,))));
+                assert!(observed_states.contains(&((1,), (0,))));
+                assert!(observed_states.contains(&((1,), (1,))));
+            }
+
+            #[test]
+            fn fetch_update() {
+                let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+                let observed_values_clone = observed_values.clone();
+
+                check_dfs(
+                    move || {
+                        let x = Arc::new($ty::new(0));
+
+                        let thd1 = {
+                            let x = x.clone();
+                            thread::spawn(move || {
+                                x.store(1, Ordering::SeqCst);
+                            })
+                        };
+
+                        let thd2 = {
+                            let x = x.clone();
+                            thread::spawn(move || {
+                                x.store(2, Ordering::SeqCst);
+                            })
+                        };
+
+                        x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| Some(x + 5))
+                            .unwrap();
+
+                        thd1.join().unwrap();
+                        thd2.join().unwrap();
+
+                        let x = Arc::try_unwrap(x).unwrap().into_inner();
+                        observed_values_clone.lock().unwrap().insert(x);
+                    },
+                    None,
+                );
+
+                let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+                assert_eq!(observed_values.len(), 4);
+                assert!(observed_values.contains(&1));
+                assert!(observed_values.contains(&2));
+                assert!(observed_values.contains(&6));
+                assert!(observed_values.contains(&7));
+            }
+
+            #[test]
+            fn compare_exchange() {
+                let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+                let observed_values_clone = observed_values.clone();
+
+                check_dfs(
+                    move || {
+                        let x = Arc::new($ty::new(0));
+
+                        let thd1 = {
+                            let x = x.clone();
+                            thread::spawn(move || {
+                                x.store(1, Ordering::SeqCst);
+                            })
+                        };
+
+                        let result = x.compare_exchange(1, 5, Ordering::SeqCst, Ordering::SeqCst);
+
+                        thd1.join().unwrap();
+
+                        observed_values_clone.lock().unwrap().insert(result);
+                    },
+                    None,
+                );
+
+                let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+                assert_eq!(observed_values.len(), 2);
+                assert!(observed_values.contains(&Ok(1)));
+                assert!(observed_values.contains(&Err(0)));
+            }
+
+            #[test]
+            fn compare_exchange_weak() {
+                let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+                let observed_values_clone = observed_values.clone();
+
+                check_dfs(
+                    move || {
+                        let x = Arc::new($ty::new(0));
+
+                        let thd1 = {
+                            let x = x.clone();
+                            thread::spawn(move || {
+                                x.store(1, Ordering::SeqCst);
+                            })
+                        };
+
+                        let result = x.compare_exchange_weak(1, 5, Ordering::SeqCst, Ordering::SeqCst);
+
+                        thd1.join().unwrap();
+
+                        observed_values_clone.lock().unwrap().insert(result);
+                    },
+                    None,
+                );
+
+                let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+                // TODO our compare_exchange_weak cannot spuriously fail
+                assert_eq!(observed_values.len(), 2);
+                assert!(observed_values.contains(&Ok(1)));
+                assert!(observed_values.contains(&Err(0)));
+            }
+        }
+    };
+}
+
+int_tests!(int_i8, AtomicI8);
+int_tests!(int_i16, AtomicI16);
+int_tests!(int_i32, AtomicI32);
+int_tests!(int_i64, AtomicI64);
+int_tests!(int_isize, AtomicIsize);
+int_tests!(int_u8, AtomicU8);
+int_tests!(int_u16, AtomicU16);
+int_tests!(int_u32, AtomicU32);
+int_tests!(int_u64, AtomicU64);
+int_tests!(int_usize, AtomicUsize);
+
+mod bool {
+    use super::*;
+    use test_env_log::test;
+
+    #[test]
+    fn fetch_update() {
+        let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let observed_values_clone = observed_values.clone();
+
+        check_dfs(
+            move || {
+                let x = Arc::new(AtomicBool::new(false));
+
+                let thd1 = {
+                    let x = x.clone();
+                    thread::spawn(move || {
+                        x.store(true, Ordering::SeqCst);
+                    })
+                };
+
+                x.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |x| Some(!x))
+                    .unwrap();
+
+                thd1.join().unwrap();
+
+                let x = Arc::try_unwrap(x).unwrap().into_inner();
+                observed_values_clone.lock().unwrap().insert(x);
+            },
+            None,
+        );
+
+        let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+        assert_eq!(observed_values.len(), 2);
+    }
+
+    #[test]
+    fn compare_exchange() {
+        let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let observed_values_clone = observed_values.clone();
+
+        check_dfs(
+            move || {
+                let x = Arc::new(AtomicBool::new(false));
+
+                let thd1 = {
+                    let x = x.clone();
+                    thread::spawn(move || {
+                        x.store(true, Ordering::SeqCst);
+                    })
+                };
+
+                let result = x.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst);
+
+                thd1.join().unwrap();
+
+                observed_values_clone.lock().unwrap().insert(result);
+            },
+            None,
+        );
+
+        let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+        assert_eq!(observed_values.len(), 2);
+        assert!(observed_values.contains(&Ok(false)));
+        assert!(observed_values.contains(&Err(true)));
+    }
+}
+
+mod ptr {
+    use super::*;
+    use test_env_log::test;
+
+    #[test]
+    fn fetch_update() {
+        let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let observed_values_clone = observed_values.clone();
+
+        check_dfs(
+            move || {
+                let mut x = 0usize;
+                let x_ptr = &mut x as *mut _;
+                let ptr = Arc::new(AtomicPtr::new(x_ptr));
+
+                let thd1 = {
+                    let ptr = ptr.clone();
+                    thread::spawn(move || {
+                        let mut y = 0usize;
+                        ptr.store(&mut y as *mut _, Ordering::SeqCst);
+                    })
+                };
+
+                ptr.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |_| Some(x_ptr))
+                    .unwrap();
+
+                thd1.join().unwrap();
+
+                let ptr = Arc::try_unwrap(ptr).unwrap().into_inner();
+                observed_values_clone.lock().unwrap().insert(ptr == x_ptr);
+            },
+            None,
+        );
+
+        let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+        assert_eq!(observed_values.len(), 2);
+    }
+
+    #[test]
+    fn compare_exchange() {
+        let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+        let observed_values_clone = observed_values.clone();
+
+        check_dfs(
+            move || {
+                let mut x = 0usize;
+                let x_ptr = &mut x as *mut _;
+                let mut x2 = 0usize;
+                let x2_ptr = &mut x2 as *mut _;
+                let ptr = Arc::new(AtomicPtr::new(x_ptr));
+
+                let thd1 = {
+                    let ptr = ptr.clone();
+                    thread::spawn(move || {
+                        let mut y = 0usize;
+                        ptr.store(&mut y as *mut _, Ordering::SeqCst);
+                    })
+                };
+
+                let result = ptr.compare_exchange(x_ptr, x2_ptr, Ordering::SeqCst, Ordering::SeqCst);
+
+                thd1.join().unwrap();
+
+                observed_values_clone.lock().unwrap().insert(result.is_ok());
+            },
+            None,
+        );
+
+        let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+        assert_eq!(observed_values.len(), 2);
+    }
+}
+
+// We don't support relaxed orderings, but they at least shouldn't crash. This test should fail if
+// we modeled Ordering::Relaxed correctly, but we don't.
+#[test]
+fn relaxed_orderings_work() {
+    check_dfs(
+        move || {
+            let flag = Arc::new(AtomicBool::new(false));
+            let data = Arc::new(AtomicU64::new(0));
+
+            {
+                let flag = Arc::clone(&flag);
+                let data = Arc::clone(&data);
+                thread::spawn(move || {
+                    data.store(42, Ordering::Relaxed);
+                    flag.store(true, Ordering::Relaxed);
+                });
+            }
+
+            if flag.load(Ordering::Relaxed) {
+                assert_eq!(data.load(Ordering::Relaxed), 42);
+            }
+        },
+        None,
+    );
+}
+
+// Check that atomics work from within futures
+#[test]
+fn atomics_futures() {
+    check_dfs(
+        move || {
+            let flag = Arc::new(AtomicUsize::new(0));
+
+            let future = {
+                let flag = Arc::clone(&flag);
+                asynch::spawn(async move { flag.fetch_add(1, Ordering::SeqCst) })
+            };
+
+            let old = asynch::block_on(future).unwrap();
+
+            assert_eq!(old, 0);
+            assert_eq!(flag.load(Ordering::SeqCst), 1);
+        },
+        None,
+    )
+}

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -1,3 +1,4 @@
+mod atomic;
 mod barrier;
 mod condvar;
 mod config;


### PR DESCRIPTION
This change adds support for the `std::sync::atomic` module.
Sequentially consistent atomics are easy for us to model---we get
sequential consistency for free by just remembering the current value of
each atomic variable. We don't have a way to model other relaxed atomic
behaviors though. This change chooses to treat *all* atomic operations
as if they were SeqCst, and emits a warning the first time it encounters
non-SeqCst atomic operations.

The implementation here is almost certainly too conservative about
inserting context switches between atomic operations. In the future, we
should convince ourselves about which context switches are necessary and
remove the unnecessary ones. That would be a breaking change since it
would invalidate previously recorded scehdules.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
