### PR TITLE
Add option to not persist failures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,14 +244,12 @@ impl Default for Config {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FailurePersistence {
+    /// Do not persist failing schedules
+    None,
     /// Print failing schedules to stdout/stderr
     Print,
-    /// Persist schedules as files
-    File {
-        /// The directory in which to save schedule files. If this is `None`, defaults to the
-        /// current directory ([`std::env::current_dir`]).
-        directory: Option<std::path::PathBuf>,
-    },
+    /// Persist schedules as files in the given directory, or the current directory if None.
+    File(Option<std::path::PathBuf>),
 }
 
 /// Specifies an upper bound on the number of steps a single iteration of a Shuttle test can take,

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -8,9 +8,13 @@ use crate::{Config, FailurePersistence};
 
 /// Produce a message describing how to replay a failing schedule.
 pub fn persist_failure(schedule: &Schedule, message: String, config: &Config) -> String {
+    if config.failure_persistence == FailurePersistence::None {
+        return message;
+    }
+
     let serialized_schedule = serialize_schedule(schedule);
     // Try to persist to a file, but fall through to stdout if that fails for some reason
-    if let FailurePersistence::File { directory } = &config.failure_persistence {
+    if let FailurePersistence::File(directory) = &config.failure_persistence {
         match persist_failure_to_file(&serialized_schedule, directory.as_ref()) {
             Ok(path) => return format!("{}\nfailing schedule persisted to file: {}\npass that path to `shuttle::replay_from_file` to replay the failure", message, path.display()),
             Err(e) => eprintln!("failed to persist schedule to file (error: {}), falling back to printing the schedule", e),

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -69,9 +69,7 @@ where
         let tempdir_path = tempdir.path().to_path_buf();
         panic::catch_unwind(move || {
             let mut config = Config::new();
-            config.failure_persistence = FailurePersistence::File {
-                directory: Some(tempdir_path),
-            };
+            config.failure_persistence = FailurePersistence::File(Some(tempdir_path));
             let runner = Runner::new(scheduler, config);
             runner.run(move || test_func())
         })


### PR DESCRIPTION
Sometimes we don't want to print failures (most notably when replaying a
schedule that we already know fails). This change adds an additional
setting for the existing `failure_persistence` config that disables
printing failing schedules entirely. It also changes the File variant of
that config to be an anonymous struct, since its meaning is pretty
clear.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.