### PR TITLE
Add function to get the number of context switches in the current execution

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,3 +371,13 @@ where
     let runner = Runner::new(scheduler, Default::default());
     runner.run(f);
 }
+
+/// The number of context switches that happened so far in the current Shuttle execution.
+///
+/// Note that this is the number of *possible* context switches, i.e., including times when the
+/// scheduler decided to continue with the same task.
+///
+/// Panics if called outside of a Shuttle execution.
+pub fn context_switches() -> usize {
+    crate::runtime::execution::ExecutionState::context_switches()
+}


### PR DESCRIPTION
This is useful, for example, to record a concurrent history for linearizability
checking. The number of context switches essentially serves as timestamp.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.