### PR TITLE
Print a failing schedule even during double panics

### DIFF
--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -1,13 +1,64 @@
+//! This module contains the logic for printing and persisting enough failure information when a
+//! test panics to allow the failure to be replayed.
+//!
+//! The core idea is that we install a custom panic hook (`init_panic_hook`) that runs when a thread
+//! panics. That hook tries to print information about the failing schedule by calling
+//! `persist_failure`.
+//!
+//! The complexity in this logic comes from a few requirements beyond the simple panic hook:
+//! 1. If a panic occurs within `ExecutionState`, the panic hook might not be able to access the
+//!    execution state to retrieve the failing schedule, so we need to be careful about accessing it
+//!    and try to recover from this problem when the panic is later caught in
+//!    `ExecutionState::step`. We try wherever possible to avoid panicing in this state, but if it
+//!    does happen we want to get useful output and not crash.
+//! 2. In addition to simply printing the failing schedule, we want to include it in the panic
+//!    payload wherever possible, so that we can parse it back out in tests (essentially we are
+//!    reinventing try/catch, which is usually an anti-pattern in Rust, but here we don't have
+//!    control over the user code that panics). That means sometimes we end up calling
+//!    `persist_schedule` twice -- once in the panic hook (where we can't modify the panic payload)
+//!    and again when we catch the panic (where we can modify the payload). We don't want to print
+//!    the schedule twice, so we keep track of whether the info has already been printed.
+
 use std::fs::OpenOptions;
 use std::io::{ErrorKind, Write};
+use std::panic;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, Once};
 
+use crate::runtime::execution::ExecutionState;
 use crate::scheduler::serialization::serialize_schedule;
 use crate::scheduler::Schedule;
 use crate::{Config, FailurePersistence};
 
 /// Produce a message describing how to replay a failing schedule.
-pub fn persist_failure(schedule: &Schedule, message: String, config: &Config) -> String {
+///
+/// If `print_if_fresh` is true, the message will also be printed to stderr if this is the first
+/// time `persist_failure` has been called.
+pub fn persist_failure(schedule: &Schedule, message: String, config: &Config, print_if_fresh: bool) -> String {
+    // Disarm the panic hook so that we don't print the failure twice
+    if let PanicHookState::Persisted(persisted_message) = PANIC_HOOK.with(|lock| lock.lock().unwrap().clone()) {
+        return persisted_message;
+    }
+
+    let persisted_message = persist_failure_inner(schedule, message, config);
+    PANIC_HOOK.with(|lock| *lock.lock().unwrap() = PanicHookState::Persisted(persisted_message.clone()));
+    if print_if_fresh {
+        eprintln!("{}", persisted_message);
+    }
+    persisted_message
+}
+
+/// Produce a message describing how to replay a failing schedule that ended on a given task.
+pub fn persist_task_failure(schedule: &Schedule, task_name: String, config: &Config, print_if_fresh: bool) -> String {
+    persist_failure(
+        schedule,
+        format!("test panicked in task '{}'", task_name),
+        config,
+        print_if_fresh,
+    )
+}
+
+fn persist_failure_inner(schedule: &Schedule, message: String, config: &Config) -> String {
     if config.failure_persistence == FailurePersistence::None {
         return message;
     }
@@ -53,4 +104,55 @@ fn persist_failure_to_file(serialized_schedule: &str, destination: Option<&PathB
     };
     file.write_all(serialized_schedule.as_bytes())?;
     path.canonicalize()
+}
+
+#[derive(Debug, Clone)]
+enum PanicHookState {
+    Disarmed,
+    Armed(Config),
+    Persisted(String),
+}
+
+thread_local! {
+    static PANIC_HOOK: Mutex<PanicHookState> = Mutex::new(PanicHookState::Disarmed);
+}
+
+/// A guard that disarms the panic hook when dropped
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct PanicHookGuard;
+
+impl Drop for PanicHookGuard {
+    fn drop(&mut self) {
+        PANIC_HOOK.with(|lock| *lock.lock().unwrap() = PanicHookState::Disarmed);
+    }
+}
+
+/// Set up a panic hook that will try to print the current schedule to stderr so that the failure
+/// can be replayed. Returns a guard that will disarm the panic hook when dropped.
+///
+/// See the module documentation for more details on how this method fits into the failure reporting
+/// story.
+#[must_use = "the panic hook will be disarmed when the returned guard is dropped"]
+pub fn init_panic_hook(config: Config) -> PanicHookGuard {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let original_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |panic_info| {
+            let state = PANIC_HOOK.with(|lock| std::mem::replace(&mut *lock.lock().unwrap(), PanicHookState::Disarmed));
+            // The hook is armed if this is the first time it's fired
+            if let PanicHookState::Armed(config) = state {
+                // We might not be able to get the info we need (e.g., if we panic while borrowing
+                // ExecutionState)
+                if let Some((name, schedule)) = ExecutionState::failure_info() {
+                    persist_task_failure(&schedule, name, &config, true);
+                }
+            }
+            original_hook(panic_info);
+        }));
+    });
+
+    PANIC_HOOK.with(|lock| *lock.lock().unwrap() = PanicHookState::Armed(config));
+
+    PanicHookGuard
 }

--- a/tests/basic/panic.rs
+++ b/tests/basic/panic.rs
@@ -1,5 +1,7 @@
+use shuttle::scheduler::DfsScheduler;
 use shuttle::sync::{Mutex, RwLock};
-use shuttle::{check_dfs, thread};
+use shuttle::{check_dfs, thread, Config, Runner};
+use std::collections::VecDeque;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::{Arc, PoisonError};
 use test_env_log::test;
@@ -54,4 +56,56 @@ fn rwlock_poison() {
         },
         None,
     )
+}
+
+// This test generates a panic that poisons a lock, and then while unwinding due to that panic, runs
+// a Drop handler that tries to acquire that same lock. That leads to a double panic, which aborts
+// the process. Since this is a common pattern in Rust, we want to check that we at least get a
+// usable schedule printed when this happens.
+#[test]
+#[ignore] // tests a double panic, so we can't enable it by default
+fn max_steps_panic_during_drop() {
+    let config = Config::new();
+    let scheduler = DfsScheduler::new(None, false);
+    let runner = Runner::new(scheduler, config);
+    runner.run(|| {
+        #[derive(Clone)]
+        struct Pool {
+            items: Arc<Mutex<VecDeque<usize>>>,
+        }
+
+        struct PoolItem {
+            pool: Arc<Mutex<VecDeque<usize>>>,
+            item: usize,
+        }
+
+        impl Pool {
+            fn new(length: usize) -> Self {
+                Self {
+                    items: Arc::new(Mutex::new((0..length).collect())),
+                }
+            }
+
+            fn get(&self) -> PoolItem {
+                let mut items = self.items.lock().unwrap();
+                let item = items.pop_front().unwrap();
+                PoolItem {
+                    pool: self.items.clone(),
+                    item,
+                }
+            }
+        }
+
+        impl Drop for PoolItem {
+            fn drop(&mut self) {
+                let mut items = self.pool.lock().unwrap();
+                items.push_back(self.item);
+            }
+        }
+
+        let pool = Pool::new(1);
+
+        let _item1 = pool.get();
+        let _item2 = pool.get();
+    });
 }


### PR DESCRIPTION
Double panics are a common problem in concurrent Rust code. For example,
a thread might panic while holding a lock, and then need to acquire that
lock again during stack unwinding, but the lock is already poisoned. In
these cases, Shuttle currently can't print the schedule that led to the
original panic, because the double panic aborts the process before our
`catch_unwind` has a chance to run.

This change adds a new panic hook that gets a chance to run before the
double panic happens. We use this hook to print the schedule, so that
even if we double panic in future at least the user gets some output
they can use to reproduce the problem. There's some trickiness here
(outlined in a module comment for `failure.rs`) around running different
panic handlers at different times, which makes the code a little more
complex than I would have hoped, but it gets the job done.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
