### PR TITLE
Release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.0.6 (July 8, 2021)
+
+* Add support for `std::sync::atomic` (#33)
+* Add `shuttle::context_switches` to get a logical clock for an execution (#37)
+* Track causality between threads (#38)
+* Better handling for double panics and poisoned locks (#30, #40)
+* Add option to not persist failures (#34)
+
 # 0.0.5 (June 11, 2021)
 
 * Fix a performance regression with `tracing` introduced by #24 (#31)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.0.5"
-authors = ["James Bornholt <bornholt@amazon.com>", "Rajeev Joshi <jorajeev@amazon.com>"]
+version = "0.0.6"
 edition = "2018"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"


### PR DESCRIPTION
Also removing the `authors` field, which is being deprecated by crates.io.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
