### PR TITLE
Give a better error message when ExecutionState is inaccessible

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -227,11 +227,12 @@ impl ExecutionState {
     where
         F: FnOnce(&mut ExecutionState) -> T,
     {
-        EXECUTION_STATE.with(|cell| f(&mut *cell.borrow_mut()))
+        Self::try_with(f).expect("Shuttle internal error: cannot access ExecutionState. are you trying to access a Shuttle primitive from outside a Shuttle test?")
     }
 
     /// Like `with`, but returns None instead of panicing if there is no current ExecutionState or
     /// if the current ExecutionState is already borrowed.
+    #[inline]
     pub(crate) fn try_with<F, T>(f: F) -> Option<T>
     where
         F: FnOnce(&mut ExecutionState) -> T,

--- a/tests/basic/execution.rs
+++ b/tests/basic/execution.rs
@@ -235,3 +235,12 @@ fn context_switches_mutex() {
         None,
     );
 }
+
+/// Check that we get a good failure message if accessing a Shuttle primitive from outside an
+/// execution.
+#[test]
+#[should_panic(expected = "are you trying to access a Shuttle primitive from outside a Shuttle test?")]
+fn failure_outside_execution() {
+    let lock = shuttle::sync::Mutex::new(0u64);
+    let _ = lock.lock().unwrap();
+}


### PR DESCRIPTION
This happens most often if you try to access a Shuttle primitive from
outside a Shuttle test. Rather than spewing an opaque error message
about a thread local not being set, let's give a somewhat meaningful
error message about what probably went wrong.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
