### PR TITLE
Add LocalKey and thread local storage

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -3,6 +3,7 @@
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::TaskId;
 use crate::runtime::thread;
+use std::marker::PhantomData;
 use std::time::Duration;
 
 /// A unique identifier for a running thread
@@ -64,6 +65,16 @@ where
         let result = std::sync::Arc::clone(&result);
         let f = move || {
             let ret = f();
+
+            // Run thread-local destructors before publishing the result, because
+            // [`JoinHandle::join`] says join "waits for the associated thread to finish", but
+            // destructors must be run on the thread, so it can't be considered "finished" if the
+            // destructors haven't run yet.
+            // See `pop_local` for details on why this loop looks this slightly funky way.
+            while let Some(local) = ExecutionState::with(|state| state.current_mut().pop_local()) {
+                drop(local);
+            }
+
             // Publish the result and unblock the waiter. We need to do this now, because once this
             // closure completes, the Execution will consider this task Finished and invoke the
             // scheduler.
@@ -199,3 +210,91 @@ impl Builder {
         Ok(spawn_named(f, self.name, self.stack_size))
     }
 }
+
+/// A thread local storage key which owns its contents
+// Sadly, the fields of this thing need to be public because function pointers in const fns are
+// unstable, so an explicit instantiation is the only way to construct this struct. User code should
+// not rely on these fields.
+pub struct LocalKey<T: 'static> {
+    #[doc(hidden)]
+    pub init: fn() -> T,
+    #[doc(hidden)]
+    pub _p: PhantomData<T>,
+}
+
+impl<T: 'static> std::fmt::Debug for LocalKey<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalKey").finish_non_exhaustive()
+    }
+}
+
+impl<T: 'static> LocalKey<T> {
+    /// Acquires a reference to the value in this TLS key.
+    ///
+    /// This will lazily initialize the value if this thread has not referenced this key yet.
+    pub fn with<F, R>(&'static self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        self.try_with(f).expect(
+            "cannot access a Thread Local Storage value \
+            during or after destruction",
+        )
+    }
+
+    /// Acquires a reference to the value in this TLS key.
+    ///
+    /// This will lazily initialize the value if this thread has not referenced this key yet. If the
+    /// key has been destroyed (which may happen if this is called in a destructor), this function
+    /// will return an AccessError.
+    pub fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
+    where
+        F: FnOnce(&T) -> R,
+    {
+        let value = self.get().unwrap_or_else(|| {
+            let value = (self.init)();
+
+            ExecutionState::with(move |state| {
+                state.current_mut().init_local(self, value);
+            });
+
+            self.get().unwrap()
+        })?;
+
+        Ok(f(value))
+    }
+
+    fn get(&'static self) -> Option<Result<&T, AccessError>> {
+        // Safety: see the usage below
+        unsafe fn extend_lt<'a, 'b, T>(t: &'a T) -> &'b T {
+            std::mem::transmute(t)
+        }
+
+        ExecutionState::with(|state| {
+            if let Ok(value) = state.current().local(self)? {
+                // Safety: unfortunately the lifetime of a value in our thread-local storage is
+                // bound to the lifetime of `ExecutionState`, which has no visible relation to the
+                // lifetime of the thread we're running on. However, *we* know that the
+                // `ExecutionState` outlives any thread, including the caller, and so it's safe to
+                // give the caller the lifetime it's asking for here.
+                Some(Ok(unsafe { extend_lt(value) }))
+            } else {
+                // Slot has already been destructed
+                Some(Err(AccessError))
+            }
+        })
+    }
+}
+
+/// An error returned by [`LocalKey::try_with`]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[non_exhaustive]
+pub struct AccessError;
+
+impl std::fmt::Display for AccessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt("already destroyed", f)
+    }
+}
+
+impl std::error::Error for AccessError {}

--- a/tests/basic/thread.rs
+++ b/tests/basic/thread.rs
@@ -115,3 +115,237 @@ fn thread_identity() {
         None,
     );
 }
+
+/// Thread local tests
+///
+/// The first three are based on Loom's thread local tests:
+/// https://github.com/tokio-rs/loom/blob/562211da5978f729e5728667566636c34c9cbc8b/tests/thread_local.rs
+mod thread_local {
+    use super::*;
+    use shuttle::thread::LocalKey;
+    use std::cell::RefCell;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use test_env_log::test;
+
+    #[test]
+    fn basic() {
+        shuttle::thread_local! {
+            static THREAD_LOCAL: RefCell<usize> = RefCell::new(1);
+        }
+
+        fn do_test(n: usize) {
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+            });
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+                *local.borrow_mut() = n;
+                assert_eq!(*local.borrow(), n);
+            });
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), n);
+            });
+        }
+
+        check_dfs(
+            || {
+                let t1 = thread::spawn(|| do_test(2));
+
+                let t2 = thread::spawn(|| do_test(3));
+
+                do_test(4);
+
+                t1.join().unwrap();
+                t2.join().unwrap();
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn nested_with() {
+        shuttle::thread_local! {
+            static LOCAL1: RefCell<usize> = RefCell::new(1);
+            static LOCAL2: RefCell<usize> = RefCell::new(2);
+        }
+
+        check_dfs(
+            || {
+                LOCAL1.with(|local1| *local1.borrow_mut() = LOCAL2.with(|local2| *local2.borrow()));
+                LOCAL1.with(|local1| assert_eq!(*local1.borrow(), 2));
+            },
+            None,
+        );
+    }
+
+    struct CountDrops {
+        drops: &'static AtomicUsize,
+        dummy: bool,
+    }
+
+    impl Drop for CountDrops {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    impl CountDrops {
+        fn new(drops: &'static AtomicUsize) -> Self {
+            Self { drops, dummy: true }
+        }
+    }
+
+    #[test]
+    fn drop() {
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        shuttle::thread_local! {
+            static DROPPED_LOCAL: CountDrops = CountDrops::new(&DROPS);
+        }
+
+        check_dfs(
+            || {
+                // Reset the drop counter. We don't count drops with a fresh AtomicUsize within the test
+                // because we want to be able to check the drop counter *after* the last thread exits.
+                // If this is the first iteration, drops will be 0, otherwise it should be 3 (set by the
+                // previous iteration of the test).
+                let drops = DROPS.swap(0, Ordering::SeqCst);
+                assert!(drops == 0 || drops == 3);
+
+                let thd = thread::spawn(|| {
+                    // force access to the thread local so that it's initialized.
+                    DROPPED_LOCAL.with(|local| assert!(local.dummy));
+                    assert_eq!(DROPS.load(Ordering::SeqCst), 0);
+                });
+                thd.join().unwrap();
+
+                // When the first spawned thread completed, its copy of the thread local should have
+                // been dropped.
+                assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+
+                let thd = thread::spawn(|| {
+                    // force access to the thread local so that it's initialized.
+                    DROPPED_LOCAL.with(|local| assert!(local.dummy));
+                    assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+                });
+                thd.join().unwrap();
+
+                // When the second spawned thread completed, its copy of the thread local should have
+                // been dropped as well.
+                assert_eq!(DROPS.load(Ordering::SeqCst), 2);
+
+                // force access to the thread local so that it's initialized.
+                DROPPED_LOCAL.with(|local| assert!(local.dummy));
+            },
+            None,
+        );
+
+        // Finally, when the test's "main thread" completes, its copy of the local should also be
+        // dropped. Because we reset the `DROPS` static to 0 at the start of each iteration, we know
+        // the correct value here regardless of how many iterations run.
+        assert_eq!(DROPS.load(Ordering::SeqCst), 3);
+    }
+
+    // Like `drop`, but the destructor for one thread local initializes another thread local, and so
+    // both destructors must be run (which Loom doesn't do)
+    #[test]
+    fn drop_init() {
+        struct TouchOnDrop(CountDrops, &'static LocalKey<CountDrops>);
+
+        impl Drop for TouchOnDrop {
+            fn drop(&mut self) {
+                self.1.with(|local| assert!(local.dummy));
+            }
+        }
+
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+        shuttle::thread_local! {
+            static LOCAL1: CountDrops = CountDrops::new(&DROPS);
+            static LOCAL2: TouchOnDrop = TouchOnDrop(CountDrops::new(&DROPS), &LOCAL1);
+        }
+
+        check_dfs(
+            || {
+                let drops = DROPS.swap(0, Ordering::SeqCst);
+                // Same story as the `drop` test above, but the main thread only initializes LOCAL1
+                // and not LOCAL2, so its destructors only trigger one drop.
+                assert!(drops == 0 || drops == 3);
+
+                let thd = thread::spawn(|| {
+                    // force access to LOCAL2 so that it's initialized.
+                    LOCAL2.with(|local| assert!(local.0.dummy));
+                    assert_eq!(DROPS.load(Ordering::SeqCst), 0);
+                });
+                thd.join().unwrap();
+
+                // When the first spawned thread completed, its copy of LOCAL2 should drop, and
+                // LOCAL2's dtor initializes LOCAL1, which then also needs to be dropped. So we
+                // should have run two CountDrops dtors by this point.
+                assert_eq!(DROPS.load(Ordering::SeqCst), 2);
+
+                // force access to LOCAL1 so that it's initialized.
+                LOCAL1.with(|local| assert!(local.dummy));
+            },
+            None,
+        );
+
+        // The main thread only initializes LOCAL1 and not LOCAL2, so it only triggers one more drop
+        assert_eq!(DROPS.load(Ordering::SeqCst), 3);
+    }
+
+    // Runs some synchronization code in the Drop handler
+    #[test]
+    fn drop_lock() {
+        // Slightly funky type: the RefCell gives interior mutability, the Option allows us to
+        // initialize the static before the lock is constructed.
+        struct LockOnDrop(RefCell<Option<Arc<Mutex<usize>>>>);
+
+        impl Drop for LockOnDrop {
+            fn drop(&mut self) {
+                *self.0.borrow_mut().as_ref().unwrap().lock().unwrap() += 1;
+            }
+        }
+
+        shuttle::thread_local! {
+            static LOCAL: LockOnDrop = LockOnDrop(RefCell::new(None));
+        }
+
+        check_dfs(
+            || {
+                let lock = Arc::new(Mutex::new(0));
+
+                let thd = {
+                    let lock = Arc::clone(&lock);
+                    thread::spawn(move || {
+                        // initialize LOCAL with the lock
+                        LOCAL.with(|local| *local.0.borrow_mut() = Some(lock.clone()));
+                        assert_eq!(*lock.lock().unwrap(), 0);
+                    })
+                };
+                thd.join().unwrap();
+
+                // When the first spawned thread completed, its copy of LOCAL should drop, and bump
+                // the lock counter by 1.
+                assert_eq!(*lock.lock().unwrap(), 1);
+            },
+            None,
+        );
+    }
+
+    // Like `nested_with` but just testing the const variant of the `thread_local` macro
+    #[test]
+    fn const_nested_with() {
+        shuttle::thread_local! {
+            static LOCAL1: RefCell<usize> = const { RefCell::new(1) };
+            static LOCAL2: RefCell<usize> = const { RefCell::new(2) };
+        }
+
+        check_dfs(
+            || {
+                LOCAL1.with(|local1| *local1.borrow_mut() = LOCAL2.with(|local2| *local2.borrow()));
+            },
+            None,
+        );
+    }
+}


### PR DESCRIPTION
Thread local storage allows threads to create slots using `LocalKey`,
which is instantiated using the `thread_local` macro. The objects in
these slots have their destructors run when the corresponding thread
exits.

Rust's TLS implementation leaves a lot of decisions either "best effort"
or platform-defined, so we have some degrees of freedom here. We model
something roughly like the fast-path Unix implementation: we allow TLS
destructors to initialize other TLS slots, but prevent re-initialization
of any TLS slot that has already been destroyed. We do run TLS
destructors on the main thread before it exits.

This implementation is based on Loom's TLS implementation, but we have a
little richer support for destructors (shown in the `drop_init` test).

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
