### PR TITLE
Implement `Once` and generalize thread-local storage map

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod execution;
 mod failure;
 pub(crate) mod runner;
+pub(crate) mod storage;
 pub(crate) mod task;
 pub(crate) mod thread;

--- a/src/runtime/storage.rs
+++ b/src/runtime/storage.rs
@@ -1,0 +1,60 @@
+use std::any::Any;
+use std::collections::{HashMap, VecDeque};
+
+/// A unique identifier for a storage slot
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct StorageKey(pub usize, pub usize); // (identifier, type)
+
+/// A map of storage values.
+///
+/// We remember the insertion order into the storage HashMap so that destruction is deterministic.
+/// Values are Option<_> because we need to be able to incrementally destruct them, as it's valid
+/// for TLS destructors to initialize new TLS slots. When a slot is destructed, its key is removed
+/// from `order` and its value is replaced with None.
+pub(crate) struct StorageMap {
+    locals: HashMap<StorageKey, Option<Box<dyn Any>>>,
+    order: VecDeque<StorageKey>,
+}
+
+impl StorageMap {
+    pub fn new() -> Self {
+        Self {
+            locals: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    pub fn get<T: 'static>(&self, key: StorageKey) -> Option<Result<&T, AlreadyDestructedError>> {
+        self.locals.get(&key).map(|val| {
+            val.as_ref()
+                .map(|val| {
+                    Ok(val
+                        .downcast_ref::<T>()
+                        .expect("local value must downcast to expected type"))
+                })
+                .unwrap_or(Err(AlreadyDestructedError))
+        })
+    }
+
+    pub fn init<T: 'static>(&mut self, key: StorageKey, value: T) {
+        let result = self.locals.insert(key, Some(Box::new(value)));
+        assert!(result.is_none(), "cannot reinitialize a storage slot");
+        self.order.push_back(key);
+    }
+
+    /// Return ownership of the next still-initialized storage slot.
+    pub fn pop(&mut self) -> Option<Box<dyn Any>> {
+        let key = self.order.pop_front()?;
+        let value = self
+            .locals
+            .get_mut(&key)
+            .expect("keys in `order` must exist")
+            .take()
+            .expect("keys in `order` must not yet be destructed");
+        Some(value)
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub(crate) struct AlreadyDestructedError;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -5,6 +5,7 @@ mod barrier;
 mod condvar;
 pub mod mpsc;
 mod mutex;
+mod once;
 mod rwlock;
 
 pub use barrier::{Barrier, BarrierWaitResult};
@@ -12,6 +13,9 @@ pub use condvar::{Condvar, WaitTimeoutResult};
 
 pub use mutex::Mutex;
 pub use mutex::MutexGuard;
+
+pub use once::Once;
+pub use once::OnceState;
 
 pub use rwlock::RwLock;
 pub use rwlock::RwLockReadGuard;

--- a/src/sync/once.rs
+++ b/src/sync/once.rs
@@ -1,0 +1,170 @@
+use crate::runtime::execution::ExecutionState;
+use crate::runtime::storage::StorageKey;
+use crate::runtime::task::clock::VectorClock;
+use crate::sync::Mutex;
+use std::cell::RefCell;
+use std::rc::Rc;
+use tracing::trace;
+
+/// A synchronization primitive which can be used to run a one-time global initialization. Useful
+/// for one-time initialization for FFI or related functionality. This type can only be constructed
+/// with [`Once::new()`].
+#[derive(Debug)]
+pub struct Once {
+    // We use the address of the `Once` as an identifier, so it can't be zero-sized even though all
+    // its state is stored in ExecutionState storage
+    _dummy: usize,
+}
+
+/// A `Once` cell can either be `Running`, in which case a `Mutex` mediates racing threads trying to
+/// invoke `call_once`, or `Complete` once an initializer has completed, in which case the `Mutex`
+/// is no longer necessary.
+enum OnceInitState {
+    Running(Rc<Mutex<bool>>),
+    Complete(VectorClock),
+}
+
+impl std::fmt::Debug for OnceInitState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Running(_) => write!(f, "Running"),
+            Self::Complete(_) => write!(f, "Complete"),
+        }
+    }
+}
+
+impl Once {
+    /// Creates a new `Once` value.
+    pub const fn new() -> Self {
+        Self { _dummy: 0 }
+    }
+
+    /// Performs an initialization routine once and only once. The given closure will be executed
+    /// if this is the first time `call_once` has been called, and otherwise the routine will *not*
+    /// be invoked.
+    ///
+    /// This method will block the calling thread if another initialization routine is currently
+    /// running.
+    ///
+    /// When this function returns, it is guaranteed that some initialization has run and completed
+    /// (it may not be the closure specified).
+    pub fn call_once<F>(&self, f: F)
+    where
+        F: FnOnce(),
+    {
+        self.call_once_inner(|_state| f(), false);
+    }
+
+    /// Performs the same function as [`Once::call_once()`] except ignores poisoning.
+    ///
+    /// If the cell has previously been poisoned, this function will still attempt to call the given
+    /// closure. If the closure does not panic, the cell will no longer be poisoned.
+    pub fn call_once_force<F>(&self, f: F)
+    where
+        F: FnOnce(&OnceState),
+    {
+        self.call_once_inner(f, true);
+    }
+
+    /// Returns `true` if some [`Once::call_once()`] call has completed successfully.
+    pub fn is_completed(&self) -> bool {
+        ExecutionState::with(|state| {
+            let init = match self.get_state(state) {
+                Some(init) => init,
+                None => return false,
+            };
+            let init_state = init.borrow();
+            match &*init_state {
+                OnceInitState::Complete(clock) => {
+                    let clock = clock.clone();
+                    drop(init_state);
+                    state.update_clock(&clock);
+                    true
+                }
+                _ => false,
+            }
+        })
+    }
+
+    fn call_once_inner<F>(&self, f: F, ignore_poisoning: bool)
+    where
+        F: FnOnce(&OnceState),
+    {
+        let lock = ExecutionState::with(|state| {
+            // Initialize the state of the `Once` cell if we're the first thread to try
+            if self.get_state(state).is_none() {
+                self.init_state(state, OnceInitState::Running(Rc::new(Mutex::new(false))));
+            }
+
+            let init = self.get_state(state).expect("must be initialized by this point");
+            let init_state = init.borrow();
+            trace!(state=?init_state, "call_once on cell {:p}", self);
+            match &*init_state {
+                OnceInitState::Complete(clock) => {
+                    // If already complete, just update the clock from the thread that inited
+                    let clock = clock.clone();
+                    drop(init_state);
+                    state.update_clock(&clock);
+                    None
+                }
+                OnceInitState::Running(lock) => Some(Rc::clone(lock)),
+            }
+        });
+
+        // If there's a lock, then we need to try racing on it to decide who gets to run their
+        // initialization closure.
+        if let Some(lock) = lock {
+            let (mut flag, is_poisoned) = match lock.lock() {
+                Ok(flag) => (flag, false),
+                Err(_) if !ignore_poisoning => panic!("Once instance has previously been poisoned"),
+                Err(err) => (err.into_inner(), true),
+            };
+            if *flag {
+                return;
+            }
+
+            trace!("won the call_once race for cell {:p}", self);
+            f(&OnceState(is_poisoned));
+
+            *flag = true;
+            // We were the thread that won the race, so remember our current clock to establish
+            // causality with future threads that try (and fail) to run `call_once`. The threads
+            // that were racing with us will get causality through acquiring the `Mutex`.
+            ExecutionState::with(|state| {
+                let clock = state.increment_clock().clone();
+                *self
+                    .get_state(state)
+                    .expect("must be initialized by this point")
+                    .borrow_mut() = OnceInitState::Complete(clock);
+            });
+        }
+    }
+
+    fn get_state<'a>(&self, from: &'a ExecutionState) -> Option<&'a RefCell<OnceInitState>> {
+        from.get_storage::<_, RefCell<OnceInitState>>(self)
+    }
+
+    fn init_state(&self, into: &mut ExecutionState, new_state: OnceInitState) {
+        into.init_storage::<_, RefCell<OnceInitState>>(self, RefCell::new(new_state));
+    }
+}
+
+/// State yielded to [`Once::call_once_force()`]'s closure parameter. The state can be used to query
+/// the poison status of the [`Once`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct OnceState(bool);
+
+impl OnceState {
+    /// Returns `true` if the associated [`Once`] was poisoned prior to the invocation of the
+    /// closure passed to [`Once::call_once_force()`].
+    pub fn is_poisoned(&self) -> bool {
+        self.0
+    }
+}
+
+impl From<&Once> for StorageKey {
+    fn from(once: &Once) -> Self {
+        StorageKey(once as *const _ as usize, 0x2)
+    }
+}

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -8,6 +8,7 @@ mod execution;
 mod metrics;
 mod mpsc;
 mod mutex;
+mod once;
 mod panic;
 mod pct;
 mod portfolio;

--- a/tests/basic/once.rs
+++ b/tests/basic/once.rs
@@ -1,0 +1,251 @@
+use shuttle::scheduler::DfsScheduler;
+use shuttle::sync::Once;
+use shuttle::{check_dfs, check_pct, thread, Runner};
+use std::collections::HashSet;
+use std::panic;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use test_env_log::test;
+
+fn basic<F>(num_threads: usize, checker: F)
+where
+    F: FnOnce(Box<dyn Fn() + Send + Sync + 'static>),
+{
+    let initializer = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let initializer_clone = Arc::clone(&initializer);
+
+    checker(Box::new(move || {
+        let once = Arc::new(Once::new());
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        assert!(!once.is_completed());
+
+        let threads = (0..num_threads)
+            .map(|_| {
+                let once = Arc::clone(&once);
+                let counter = Arc::clone(&counter);
+                let initializer = Arc::clone(&initializer);
+                thread::spawn(move || {
+                    once.call_once(|| {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        initializer.lock().unwrap().insert(thread::current().id());
+                    });
+
+                    assert!(once.is_completed());
+                    assert_eq!(counter.load(Ordering::SeqCst), 1);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        assert!(once.is_completed());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }));
+
+    assert_eq!(initializer_clone.lock().unwrap().len(), num_threads);
+}
+
+#[test]
+fn basic_dfs() {
+    basic(2, |f| check_dfs(f, None));
+}
+
+#[test]
+fn basic_pct() {
+    basic(10, |f| check_pct(f, 1000, 3));
+}
+
+// Same as `basic`, but with a static Once. Static synchronization primitives should be reset across
+// executions, so this test should work exactly the same way.
+fn basic_static<F>(num_threads: usize, checker: F)
+where
+    F: FnOnce(Box<dyn Fn() + Send + Sync + 'static>),
+{
+    static O: Once = Once::new();
+
+    let initializer = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let initializer_clone = Arc::clone(&initializer);
+
+    checker(Box::new(move || {
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        assert!(!O.is_completed());
+
+        let threads = (0..num_threads)
+            .map(|_| {
+                let counter = Arc::clone(&counter);
+                let initializer = Arc::clone(&initializer);
+                thread::spawn(move || {
+                    O.call_once(|| {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        initializer.lock().unwrap().insert(thread::current().id());
+                    });
+
+                    assert!(O.is_completed());
+                    assert_eq!(counter.load(Ordering::SeqCst), 1);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        assert!(O.is_completed());
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }));
+
+    assert_eq!(initializer_clone.lock().unwrap().len(), num_threads);
+}
+
+#[test]
+fn basic_static_dfs() {
+    basic_static(2, |f| check_dfs(f, None));
+}
+
+#[test]
+fn basic_static_pct() {
+    basic_static(10, |f| check_pct(f, 1000, 3));
+}
+
+// Test that multiple Once cells race for initialization independently
+#[test]
+fn multiple() {
+    static O1: Once = Once::new();
+    static O2: Once = Once::new();
+
+    let initializer = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let initializer_clone = Arc::clone(&initializer);
+
+    check_dfs(
+        move || {
+            let counter = Arc::new(AtomicUsize::new(0));
+
+            let thd = {
+                let counter = Arc::clone(&counter);
+                thread::spawn(move || {
+                    O1.call_once(|| {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                    });
+                    O2.call_once(|| {
+                        counter.fetch_add(4, Ordering::SeqCst);
+                    });
+                })
+            };
+
+            O1.call_once(|| {
+                counter.fetch_add(2, Ordering::SeqCst);
+            });
+            O2.call_once(|| {
+                counter.fetch_add(8, Ordering::SeqCst);
+            });
+
+            thd.join().unwrap();
+
+            let counter = counter.load(Ordering::SeqCst);
+            // lower two bits for C1, upper two bits for C2
+            assert!(
+                counter & (1 + 2) == 1 || counter & (1 + 2) == 2,
+                "exactly one of the O1 calls should have run"
+            );
+            assert!(
+                counter & (4 + 8) == 4 || counter & (4 + 8) == 8,
+                "exactly one of the O2 calls should have run"
+            );
+            initializer.lock().unwrap().insert(counter);
+        },
+        None,
+    );
+
+    let initializer = Arc::try_unwrap(initializer_clone).unwrap().into_inner().unwrap();
+    assert_eq!(initializer.len(), 4);
+    assert!(initializer.contains(&5));
+    assert!(initializer.contains(&6));
+    assert!(initializer.contains(&9));
+    assert!(initializer.contains(&10));
+}
+
+// Ensure that concurrent Shuttle tests see an isolated version of a static Once cell. This test is
+// best effort, as it spawns OS threads and hopes they race.
+#[test]
+fn shared_static() {
+    static O: Once = Once::new();
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut total_executions = 0;
+
+    // Try a bunch of times to provoke the race
+    for _ in 0..50 {
+        #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7207
+        let threads = (0..3)
+            .map(|_| {
+                let counter = Arc::clone(&counter);
+                std::thread::spawn(move || {
+                    let scheduler = DfsScheduler::new(None, false);
+                    let runner = Runner::new(scheduler, Default::default());
+                    runner.run(move || {
+                        let thds = (0..2)
+                            .map(|_| {
+                                let counter = Arc::clone(&counter);
+                                thread::spawn(move || {
+                                    O.call_once(|| {
+                                        counter.fetch_add(1, Ordering::SeqCst);
+                                    });
+                                })
+                            })
+                            .collect::<Vec<_>>();
+
+                        for thd in thds {
+                            thd.join().unwrap();
+                        }
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        total_executions += threads.into_iter().map(|handle| handle.join().unwrap()).sum::<usize>();
+    }
+
+    // The Once cell should be initialized exactly once per test execution, otherwise the tests are
+    // incorrectly sharing the Once cell
+    assert_eq!(total_executions, counter.load(Ordering::SeqCst));
+}
+
+#[test]
+fn poison() {
+    static O: Once = Once::new();
+
+    check_dfs(
+        || {
+            let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                O.call_once(|| {
+                    panic!("expected panic");
+                })
+            }));
+            assert!(result.is_err(), "`call_once` should panic");
+
+            let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                O.call_once(|| {
+                    // no-op
+                });
+            }));
+            assert!(result.is_err(), "cell should be poisoned");
+
+            let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                O.call_once_force(|state| {
+                    assert!(state.is_poisoned());
+                });
+            }));
+            assert!(result.is_ok(), "`call_once_force` ignores poison");
+
+            let result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                O.call_once(|| unreachable!("previous call should have initialized the cell"));
+            }));
+            assert!(result.is_ok(), "cell should no longer be poisoned");
+        },
+        None,
+    );
+}


### PR DESCRIPTION
`Once` is a synchronization primitive often used in a static variable to
ensure some initialization logic runs at most once in the execution of a
program. To ensure that we support this pattern, we implement a new
global storage map that is empied across executions, and use it to
ensure that a `Once` cell's state resets across test executions. This
also means that multiple Shuttle tests running concurrently (e.g., under
the cargo test runner with a default config) will see independent
instances of a static Once cell and be properly isolated from each
other.

The storage map shares common logic with the TLS map we already have, so
this PR factors that map out into a single abstraction.

In a future PR we'll use Once to implement lazy_static, which will also
store its values into the global storage map.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
