### PR TITLE
Implement `Drop` for async task `JoinHandle`

### DIFF
--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -42,6 +42,7 @@ pub(crate) const DEFAULT_INLINE_TASKS: usize = 16;
 pub(crate) struct Task {
     pub(super) id: TaskId,
     pub(super) state: TaskState,
+    pub(super) detached: bool,
     // We use this to check `block_unless_self_woken` is only called from a Future task
     task_type: TaskType,
 
@@ -87,6 +88,7 @@ impl Task {
             waiter: None,
             waker,
             woken_by_self: false,
+            detached: false,
             name,
             local_storage: LocalMap::new(),
         }
@@ -144,6 +146,10 @@ impl Task {
 
     pub(crate) fn finished(&self) -> bool {
         self.state == TaskState::Finished
+    }
+
+    pub(crate) fn detach(&mut self) {
+        self.detached = true;
     }
 
     pub(crate) fn waker(&self) -> Waker {

--- a/src/runtime/task/waker.rs
+++ b/src/runtime/task/waker.rs
@@ -28,6 +28,10 @@ unsafe fn raw_waker_clone(data: *const ()) -> RawWaker {
 unsafe fn raw_waker_wake(data: *const ()) {
     let task_id = TaskId::from(data as usize);
     ExecutionState::with(|state| {
+        if state.is_finished() {
+            return;
+        }
+
         let waiter = state.get_mut(task_id);
 
         if waiter.finished() {

--- a/tests/asynch/channel.rs
+++ b/tests/asynch/channel.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use test_env_log::test;
 
 #[test]
-fn oneshot_once() {
+fn oneshot_once_blocking() {
     check_dfs(
         || {
             let (tx, rx) = oneshot::channel();
@@ -22,6 +22,25 @@ fn oneshot_once() {
             });
 
             asynch::block_on(async {
+                let x = rx.await.unwrap();
+                assert_eq!(x, 42u32);
+            });
+        },
+        None,
+    )
+}
+
+#[test]
+fn oneshot_once() {
+    check_dfs(
+        || {
+            let (tx, rx) = oneshot::channel();
+
+            asynch::spawn(async move {
+                tx.send(42u32).unwrap();
+            });
+
+            asynch::spawn(async {
                 let x = rx.await.unwrap();
                 assert_eq!(x, 42u32);
             });

--- a/tests/asynch/countdown_timer.rs
+++ b/tests/asynch/countdown_timer.rs
@@ -52,12 +52,12 @@ fn timer_simple() {
             // Start 3 timers with delays 1,2,3 and values 10,20,40
             let timera = CountdownTimer::new(1, 10);
             let timerb = CountdownTimer::new(2, 20);
-            let timerc = CountdownTimer::new(4, 40);
+            let timerc = CountdownTimer::new(3, 40);
             let v1 = asynch::spawn(timera); // no need for async block
             let v2 = asynch::spawn(async move { timerb.await });
             let v3 = asynch::spawn(async move { timerc.await });
             // Spawn another task that waits for the timers and checks the return values
-            asynch::spawn(async move {
+            asynch::block_on(async move {
                 let sum = v1.await.unwrap() + v2.await.unwrap() + v3.await.unwrap();
                 assert_eq!(sum, 10 + 20 + 40);
             });


### PR DESCRIPTION
When an async task's `JoinHandle` is dropped, we mark the task as dropped. Dropped tasks are not allowed to force a deadlock, meaning that execution can end successfully when all tasks are either finished or dropped. At the same time, dropped tasks should still be runnable by the executor so long as some non-dropped task has not finished.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.