### PR TITLE
Fix how waiters are set and woken

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -120,10 +120,12 @@ where
 
                 *self.result.lock().unwrap() = Some(Ok(result));
 
-                // Unblock our waiter if we have one
+                // Unblock our waiter if we have one and it's still alive
                 ExecutionState::with(|state| {
                     if let Some(waiter) = state.current_mut().take_waiter() {
-                        state.get_mut(waiter).unblock();
+                        if !state.get_mut(waiter).finished() {
+                            state.get_mut(waiter).unblock();
+                        }
                     }
                 });
 

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -197,7 +197,10 @@ impl Task {
     /// waiter should block or not. If false, this task has already finished, and so the waiter need
     /// not block.
     pub(crate) fn set_waiter(&mut self, waiter: TaskId) -> bool {
-        assert!(self.waiter.is_none());
+        assert!(
+            self.waiter.is_none() || self.waiter == Some(waiter),
+            "Task cannot have more than one waiter"
+        );
         if self.finished() {
             false
         } else {


### PR DESCRIPTION
Currently, Shuttle does not allow a waiter to be set for a task if a waiter already exists. This may cause a problem when the waiting task wakes itself.
Additionally, it's possible for a waiter to be set for a task, then have the waiter finish before the other task resumes. This happens whenever the waiter wakes itself up. This PR fixes that issue by only waking async waiting tasks when they are blocked.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.