### PR TITLE
Make `asynch::block_on` run on the current thread

### DIFF
--- a/tests/asynch/basic.rs
+++ b/tests/asynch/basic.rs
@@ -234,30 +234,6 @@ fn test_try_join() {
     );
 }
 
-// Check that when we block on a future, it gets executed in both executions
-// (block_on task finishing first and main task finishing first).
-#[test]
-fn block_shuttle_future() {
-    let orderings = Arc::new(AtomicUsize::new(0));
-    let async_accesses = Arc::new(AtomicUsize::new(0));
-    let orderings_clone = orderings.clone();
-    let async_accesses_clone = async_accesses.clone();
-
-    check_dfs(
-        move || {
-            orderings.fetch_add(1, Ordering::SeqCst);
-            let async_accesses = async_accesses.clone();
-            asynch::block_on(async move {
-                async_accesses.fetch_add(1, Ordering::SeqCst);
-            });
-        },
-        None,
-    );
-
-    assert_eq!(2, orderings_clone.load(Ordering::SeqCst));
-    assert_eq!(2, async_accesses_clone.load(Ordering::SeqCst));
-}
-
 // Check that a task may not run if its JoinHandle is dropped
 #[test]
 fn drop_shuttle_future() {


### PR DESCRIPTION
`block_on` is supposed to run a future to completion *on the current
thread*. This is visible in the type signature for `block_on` in other
futures executors, which do not require the future to be `Send`. We were
instead implementing `block_on` using `spawn`, and so required the
future to be `Send`.

This change makes `block_on` truly run the future to completion on the
current thread, by just running poll in a loop (with the appropriate
yield points inserted).

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
