### PR TITLE
Fix thread_local to actually be static

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,7 +428,7 @@ macro_rules! thread_local {
 #[macro_export]
 macro_rules! __thread_local_inner {
     ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty, $init:expr) => {
-        $(#[$attr])* $vis const $name: $crate::thread::LocalKey<$t> =
+        $(#[$attr])* $vis static $name: $crate::thread::LocalKey<$t> =
             $crate::thread::LocalKey {
                 init: || { $init },
                 _p: std::marker::PhantomData,

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -222,6 +222,10 @@ pub struct LocalKey<T: 'static> {
     pub _p: PhantomData<T>,
 }
 
+// Safety: `LocalKey` implements thread-local storage; each thread sees its own value of the type T.
+unsafe impl<T> Send for LocalKey<T> {}
+unsafe impl<T> Sync for LocalKey<T> {}
+
 impl<T: 'static> std::fmt::Debug for LocalKey<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LocalKey").finish_non_exhaustive()

--- a/tests/basic/thread.rs
+++ b/tests/basic/thread.rs
@@ -348,4 +348,31 @@ mod thread_local {
             None,
         );
     }
+
+    #[test]
+    fn multiple_accesses() {
+        shuttle::thread_local! {
+            static LOCAL: RefCell<usize> = RefCell::new(0);
+        }
+
+        fn increment() {
+            LOCAL.with(|local| {
+                *local.borrow_mut() += 1;
+            });
+        }
+
+        fn check() {
+            LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+            });
+        }
+
+        check_dfs(
+            || {
+                increment();
+                check();
+            },
+            None,
+        )
+    }
 }


### PR DESCRIPTION
Not tally sure what's going on here, but I've seen tests where a single
`thread_local` somehow got multiple versions of a `LocalKey` (one per
callsite). My guess is that we need to make them `static` instead of
just `const`, but I don't really understand why. Making this change at
least forces us to also implement Send/Sync for `LocalKey`, whereas
before the compiler didn't ask for it, which suggests the `LocalKey`s
weren't being shared like we expected them to be.

I wasn't able to write a test that actually exposed the buggy behavior,
though -- I can only reproduce it in a release build, which suggests it
might be a codegen problem or something.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.