### PR TITLE
Move clock functions into their own module

### DIFF
--- a/src/current.rs
+++ b/src/current.rs
@@ -1,0 +1,34 @@
+//! Information about the current thread and current Shuttle execution.
+//!
+//! This module provides access to information about the current Shuttle execution. It is useful for
+//! building tools that need to exploit Shuttle's total ordering of concurrent operations; for
+//! example, a tool that wants to check linearizability might want access to a global timestamp for
+//! events, which the [`context_switches`] function provides.
+
+use crate::runtime::execution::ExecutionState;
+use crate::runtime::task::clock::VectorClock;
+use crate::runtime::task::TaskId;
+
+/// The number of context switches that happened so far in the current Shuttle execution.
+///
+/// Note that this is the number of *possible* context switches, i.e., including times when the
+/// scheduler decided to continue with the same task. This means the result can be used as a
+/// timestamp for atomic actions during an execution.
+///
+/// Panics if called outside of a Shuttle execution.
+pub fn context_switches() -> usize {
+    ExecutionState::context_switches()
+}
+
+/// Get the current thread's vector clock
+pub fn clock() -> VectorClock {
+    crate::runtime::execution::ExecutionState::with(|state| {
+        let me = state.current();
+        state.get_clock(me.id()).clone()
+    })
+}
+
+/// Gets the clock for the thread with the given task ID
+pub fn clock_for(task_id: TaskId) -> VectorClock {
+    ExecutionState::with(|state| state.get_clock(task_id).clone())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub mod rand;
 pub mod sync;
 pub mod thread;
 
+pub mod current;
 pub mod scheduler;
 
 mod runtime;
@@ -370,29 +371,6 @@ where
     let scheduler = ReplayScheduler::new_from_file(path).expect("could not load schedule from file");
     let runner = Runner::new(scheduler, Default::default());
     runner.run(f);
-}
-
-/// The number of context switches that happened so far in the current Shuttle execution.
-///
-/// Note that this is the number of *possible* context switches, i.e., including times when the
-/// scheduler decided to continue with the same task.
-///
-/// Panics if called outside of a Shuttle execution.
-pub fn context_switches() -> usize {
-    crate::runtime::execution::ExecutionState::context_switches()
-}
-
-/// Gets the current thread's vector clock
-pub fn my_clock() -> crate::runtime::task::clock::VectorClock {
-    crate::runtime::execution::ExecutionState::with(|state| {
-        let me = state.current();
-        state.get_clock(me.id()).clone()
-    })
-}
-
-/// Gets the clock for the thread with the given task_id
-pub fn get_clock(task_id: crate::runtime::task::TaskId) -> crate::runtime::task::clock::VectorClock {
-    crate::runtime::execution::ExecutionState::with(|state| state.get_clock(task_id).clone())
 }
 
 /// Declare a new thread local storage key of type [`LocalKey`](crate::thread::LocalKey).

--- a/src/sync/condvar.rs
+++ b/src/sync/condvar.rs
@@ -1,4 +1,4 @@
-use crate::my_clock;
+use crate::current;
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::clock::VectorClock;
 use crate::runtime::task::TaskId;
@@ -205,7 +205,7 @@ impl Condvar {
         for (tid, status) in state.waiters.iter_mut() {
             assert_ne!(*tid, me);
 
-            let clock = my_clock();
+            let clock = current::clock();
             match status {
                 CondvarWaitStatus::Waiting => {
                     let mut epochs = VecDeque::new();
@@ -240,7 +240,7 @@ impl Condvar {
 
         for (tid, status) in state.waiters.iter_mut() {
             assert_ne!(*tid, me);
-            *status = CondvarWaitStatus::Broadcast(my_clock());
+            *status = CondvarWaitStatus::Broadcast(current::clock());
             // Note: the task might have been unblocked by a previous signal
             ExecutionState::with(|s| s.get_mut(*tid).unblock());
         }

--- a/tests/basic/mpsc.rs
+++ b/tests/basic/mpsc.rs
@@ -234,7 +234,7 @@ fn mpsc_bounded_sum() {
             let handle = thread::spawn(move || {
                 let mut sum = 0;
                 for _ in 0..5 {
-                    let c1 = shuttle::my_clock().get(1); // save knowledge of sender's clock
+                    let c1 = shuttle::current::clock().get(1); // save knowledge of sender's clock
                     sum += rx.recv().unwrap();
                     check_clock(|i, c| (i != 1) || (c > c1)); // sender's clock must have increased
                 }


### PR DESCRIPTION
Just an effort to not pollute the top-level namespace too much. Putting
these into their own module gives us a place to put future functions
that also reveal information about the current execution.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.