### PR TITLE
Bump `tracing-subscriber` to v0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ proptest = "~0.10.1"
 regex = "~1.3.9"
 tempfile = "~3.2.0"
 test-env-log = { version = "~0.2.2", default-features = false, features = ["trace"] }
-tracing-subscriber = "~0.2.12"
+tracing-subscriber = { version = "~0.3.1", features = ["env-filter"] }
 
 [lib]
 bench = false


### PR DESCRIPTION
This picks up the fix for [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159) in `chrono`.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
