### PR TITLE
Fix new warning on Rust 1.58.1

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -159,7 +159,6 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
 /// Yields execution back to the scheduler.
 ///
 /// Borrowed from the Tokio implementation.
-#[must_use = "yield_now does nothing unless polled/`await`-ed"]
 pub async fn yield_now() {
     /// Yield implementation
     struct YieldNow {


### PR DESCRIPTION
This `must_use` is redundant because Rust will already warn about unused
`Future`s.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.