### PR TITLE
Bump dependencies and stop pinning minor versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,26 +9,26 @@ keywords = ["concurrency", "lock", "thread", "async"]
 categories = ["asynchronous", "concurrency", "development-tools::testing"]
 
 [dependencies]
-ansi_term = "~0.12.1"
-bitvec = "~0.21.0"
-generator = "~0.7.0"
-hex = "~0.4.2"
-rand_core = "~0.5.1"
-rand = "~0.7.3"
-rand_pcg = "~0.2.1"
-scoped-tls = "~1.0.0"
-smallvec = "~1.6.1"
-tracing = { version = "~0.1.21", default-features = false, features = ["std"] }
-varmint = "~0.1.3"
+ansi_term = "0.12.1"
+bitvec = "0.21.0"
+generator = "0.7.0"
+hex = "0.4.2"
+rand_core = "0.5.1"
+rand = "0.7.3"
+rand_pcg = "0.2.1"
+scoped-tls = "1.0.0"
+smallvec = "1.6.1"
+tracing = { version = "0.1.21", default-features = false, features = ["std"] }
+varmint = "0.1.3"
 
 [dev-dependencies]
-criterion = { version = "~0.3.4", features = ["html_reports"] }
-futures = "~0.3.5"
-proptest = "~0.10.1"
-regex = "~1.3.9"
-tempfile = "~3.2.0"
-test-log = { version = "~0.2.8", default-features = false, features = ["trace"] }
-tracing-subscriber = { version = "~0.3.1", features = ["env-filter"] }
+criterion = { version = "0.3.4", features = ["html_reports"] }
+futures = "0.3.5"
+proptest = "0.10.1"
+regex = "1.5.5"
+tempfile = "3.2.0"
+test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 
 [lib]
 bench = false


### PR DESCRIPTION
This bump addresses a rustsec issue. I also don't think it's worth pinning minor versions like this—they just create maintenance work for us, and since we're a library, they also end up pulling in extra versions for customers.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.