### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.0 (April 5, 2022)
+
+* Implement `Condvar::wait_while` and `Condvar::wait_timeout_while` (#59)
+* Remove implicit `Sized` bounds on `Mutex` and `RwLock` (#62)
+* Dependency updates (#58, #60)
+
 # 0.0.7 (September 21, 2021)
 
 * Fix a number of issues in support for async tasks (#50, #51, #52, #54)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.0.7"
+version = "0.1.0"
 edition = "2018"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"


### PR DESCRIPTION
I think the fact that we haven't changed the API in > 6 months suggests it's stable enough for a 0.1.0 release.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.