### PR TITLE
Friendlier error messages for re-entrancy failures

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -57,7 +57,9 @@ impl<T: ?Sized> Mutex<T> {
         state.waiters.insert(me);
         // If the lock is already held, then we are blocked
         if let Some(holder) = state.holder {
-            assert_ne!(holder, me);
+            if holder == me {
+                panic!("deadlock! task {:?} tried to acquire a Mutex it already holds", me);
+            }
             ExecutionState::with(|s| s.current_mut().block());
         }
         drop(state);

--- a/tests/demo/async_match_deadlock.rs
+++ b/tests/demo/async_match_deadlock.rs
@@ -1,0 +1,78 @@
+//! An example of a Rust footgun where the lifetime of a lock acquired as part of a match scrutinee
+//! is extended to the entire match statement, which makes it easy to deadlock.
+//!
+//! Drawn from https://fasterthanli.me/articles/a-rust-match-made-in-hell with slight changes to
+//! switch from `parking_lot` to `std` and from `tokio` to our futures executor.
+
+use shuttle::asynch as tokio;
+use shuttle::sync::{Arc, RwLock};
+use std::time::Duration;
+use test_log::test;
+
+/// We don't have an equivalent of `tokio::time::sleep`, but yielding has basically the same effect
+async fn sleep(_duration: Duration) {
+    shuttle::asynch::yield_now().await;
+}
+
+#[derive(Default)]
+struct State {
+    value: u64,
+}
+
+impl State {
+    fn foo(&self) -> bool {
+        self.value > 0
+    }
+
+    fn bar(&self) -> u64 {
+        self.value
+    }
+
+    fn update(&mut self) {
+        self.value += 1;
+    }
+}
+
+// #[tokio::main(worker_threads = 2)]
+async fn main() {
+    let state: Arc<RwLock<State>> = Default::default();
+
+    tokio::spawn({
+        let state = state.clone();
+        async move {
+            loop {
+                println!("updating...");
+                state.write().unwrap().update();
+                sleep(Duration::from_millis(1)).await;
+            }
+        }
+    });
+
+    for _ in 0..10 {
+        match state.read().unwrap().foo() {
+            true => {
+                println!("it's true!");
+                sleep(Duration::from_millis(1)).await;
+                println!("bar = {}", state.read().unwrap().bar());
+            }
+            false => {
+                println!("it's false!");
+            }
+        }
+    }
+    println!("okay done");
+}
+
+#[test]
+#[should_panic(expected = "tried to acquire a RwLock it already holds")]
+fn async_match_deadlock() {
+    shuttle::check_random(|| tokio::block_on(main()), 1000)
+}
+
+#[test]
+#[should_panic(expected = "tried to acquire a RwLock it already holds")]
+fn asynch_match_deadlock_replay() {
+    // Deterministically replay a deadlocking execution so we can, for example, single-step through
+    // it in a debugger.
+    shuttle::replay(|| tokio::block_on(main()), "91010b98deab88a3ea91d6e001202808")
+}

--- a/tests/demo/mod.rs
+++ b/tests/demo/mod.rs
@@ -1,1 +1,2 @@
+mod async_match_deadlock;
 mod bounded_buffer;


### PR DESCRIPTION
Currently, if code tries to re-acquire a lock it already holds, it
correctly panics but with an unhelpful error message about Shuttle's
internals. Instead, let's provide a nicer error message about why the
calling code is buggy.

This came up while trying out the super neat example from a
[fasterthanlime blog post], which Shuttle has no trouble finding the
deadlock in, but wasn't giving a helpful error message for.

[fasterthanlime blog post]: https://fasterthanli.me/articles/a-rust-match-made-in-hell

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.