### PR TITLE
Determinism Check Scheduler

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,24 @@ where
     runner.run(f);
 }
 
+/// Run the given function under a scheduler that checks for determinism.
+/// iterations: total number of times to run the inner scheduler
+/// inner_iterations: number of times to test a recorded schedule
+pub fn check_determinism<F>(f: F, iterations: usize, inner_iterations: usize)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    use crate::scheduler::DeterminismCheckScheduler;
+    use crate::scheduler::RandomScheduler;
+
+    let inner = RandomScheduler::new(iterations);
+
+    let scheduler = DeterminismCheckScheduler::new(inner_iterations, inner);
+
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(f);
+}
+
 /// Run the given function according to a given encoded schedule, usually produced as the output of
 /// a failing Shuttle test case.
 ///

--- a/src/scheduler/determinism_check.rs
+++ b/src/scheduler/determinism_check.rs
@@ -4,25 +4,6 @@ use std::iter::FromIterator;
 use crate::runtime::task::TaskId;
 use crate::scheduler::{Schedule, Scheduler,ScheduleStep, ScheduleRecord};
 
-// #[derive(Clone, Debug, PartialEq, Eq)]
-// pub struct ScheduleRecordStep {
-//     step: ScheduleStep,
-//     options: HashSet<TaskId>
-// }
-
-// impl ScheduleRecordStep {
-//     /// Create a record step from the chosen task and options
-//     fn new(step: ScheduleStep, options_vec: &[TaskId]) -> Self {
-//         let mut new_record = Self { step, options: HashSet::new() };
-
-// 		for task_id in options_vec {
-// 			new_record.options.insert(task_id.clone());
-// 		}
-		
-// 		new_record
-//     }
-// }
-
 /// A `DeterminismCheckScheduler` wraps an inner `Scheduler`, and when given a program,
 /// decides whether the scheduling decisions can be deterministic or not.
 /// Inner scheduler can be RoundRobin, Random, or PCT
@@ -37,6 +18,7 @@ pub struct DeterminismCheckScheduler<S: ?Sized + Scheduler> {
 }
 
 impl<S: Scheduler> DeterminismCheckScheduler<S> {
+
     /// Create a new `DeterminismCheckScheduler` by wrapping the given `Scheduler` implementation.
     pub fn new(inner_iterations: usize,  inner: S) -> Self {
         Self {
@@ -48,12 +30,6 @@ impl<S: Scheduler> DeterminismCheckScheduler<S> {
 			current_step: 0
         }
     }
-
-	/// Record an instance of non-determinism
-	/// Should probably do something more informative here
-	pub fn log_error(&mut self, message: &str) {
-		assert!(false, "Found nondeterministic function! {}", message);
-	}
 }
 
 
@@ -65,6 +41,8 @@ impl<S: Scheduler> Scheduler for DeterminismCheckScheduler<S> {
 			self.recording = true;
 			self.original_schedule.clear();
 		} else {
+			// Create a new execution to test against prior recording
+			
 			if self.recording {
 				self.recording = false;
 			}
@@ -89,6 +67,7 @@ impl<S: Scheduler> Scheduler for DeterminismCheckScheduler<S> {
     ) -> Option<TaskId> {
 
 		if self.recording {
+
 			// Recording a schedule
 			let choice = self.inner.next_task(runnable_tasks, current_task, is_yielding).unwrap();
 			self.original_schedule.push(ScheduleRecord::new(ScheduleStep::Task(choice), runnable_tasks));
@@ -101,12 +80,11 @@ impl<S: Scheduler> Scheduler for DeterminismCheckScheduler<S> {
 			// Determine whether the state is the same
 
 			if self.current_step >= self.original_schedule.len() {
-				// Current run is longer than original recording
 				panic!("Current execution longer than expected. \n\tOriginal length: {}, acutal length: {}",
 															self.original_schedule.len(), self.current_step);
 			}
 
-			let expected = self.original_schedule.get(self.current_step).unwrap().clone();
+			let expected = self.original_schedule[self.current_step].clone();
 			let expected_step = expected.step;
 			let expected_options = expected.runnable_tasks;
 			let actual_options: HashSet<TaskId> = HashSet::from_iter(runnable_tasks.iter().cloned());
@@ -114,13 +92,13 @@ impl<S: Scheduler> Scheduler for DeterminismCheckScheduler<S> {
 			match expected_step {
 				ScheduleStep::Task(id) => { 
 					if !expected_options.contains(&id) {
-						panic!("\nTask chosen in recording is not currently runnable.\n\tExpected Task: {:?} \n\tActual options: {:?}\n",
-																		id, actual_options);
+						panic!("\nTask chosen in recording is not currently runnable.
+						\n\tExpected Task: {:?} \n\tActual options: {:?}\n", id, actual_options);
 					}
 
 					if expected_options != actual_options {
-						panic!("\nSet of runnable tasks is different than expected.\n\tExpected options: {:?} \n\tActual options: {:?}\n",
-																		expected_options, actual_options);
+						panic!("\nSet of runnable tasks is different than expected.
+						\n\tExpected options: {:?} \n\tActual options: {:?}\n", expected_options, actual_options);
 					}
 
 					self.current_step += 1;
@@ -146,6 +124,5 @@ impl<S: Scheduler> Scheduler for DeterminismCheckScheduler<S> {
 
 		self.current_step += 1;
 		self.inner.next_u64()
-
     }
 }

--- a/src/scheduler/determinism_check.rs
+++ b/src/scheduler/determinism_check.rs
@@ -1,0 +1,151 @@
+use std::collections::HashSet;
+use std::iter::FromIterator;
+
+use crate::runtime::task::TaskId;
+use crate::scheduler::{Schedule, Scheduler,ScheduleStep, ScheduleRecord};
+
+// #[derive(Clone, Debug, PartialEq, Eq)]
+// pub struct ScheduleRecordStep {
+//     step: ScheduleStep,
+//     options: HashSet<TaskId>
+// }
+
+// impl ScheduleRecordStep {
+//     /// Create a record step from the chosen task and options
+//     fn new(step: ScheduleStep, options_vec: &[TaskId]) -> Self {
+//         let mut new_record = Self { step, options: HashSet::new() };
+
+// 		for task_id in options_vec {
+// 			new_record.options.insert(task_id.clone());
+// 		}
+		
+// 		new_record
+//     }
+// }
+
+/// A `DeterminismCheckScheduler` wraps an inner `Scheduler`, and when given a program,
+/// decides whether the scheduling decisions can be deterministic or not.
+/// Inner scheduler can be RoundRobin, Random, or PCT
+#[derive(Debug)]
+pub struct DeterminismCheckScheduler<S: ?Sized + Scheduler> {
+    inner: Box<S>,
+	iterations: usize,
+	inner_iterations: usize,
+	recording: bool,
+	original_schedule: Vec<ScheduleRecord>,
+	current_step: usize
+}
+
+impl<S: Scheduler> DeterminismCheckScheduler<S> {
+    /// Create a new `DeterminismCheckScheduler` by wrapping the given `Scheduler` implementation.
+    pub fn new(inner_iterations: usize,  inner: S) -> Self {
+        Self {
+            inner: Box::new(inner),
+			iterations: 0,
+			inner_iterations,
+			original_schedule: Vec::new(),
+			recording: false,
+			current_step: 0
+        }
+    }
+
+	/// Record an instance of non-determinism
+	/// Should probably do something more informative here
+	pub fn log_error(&mut self, message: &str) {
+		assert!(false, "Found nondeterministic function! {}", message);
+	}
+}
+
+
+impl<S: Scheduler> Scheduler for DeterminismCheckScheduler<S> {
+    fn new_execution(&mut self) -> Option<Schedule> {
+
+		if self.iterations % self.inner_iterations == 0 {
+			// Start a new recording
+			self.recording = true;
+			self.original_schedule.clear();
+		} else {
+			if self.recording {
+				self.recording = false;
+			}
+
+			if self.current_step != self.original_schedule.len() {
+				panic!("Current execution ended earlier than original execution\n\tOriginal length: {}, acutal length: {}",
+																self.original_schedule.len(), self.current_step);
+			}
+		}
+
+		self.current_step = 0;
+		self.iterations += 1;
+
+        self.inner.new_execution()
+    }
+
+    fn next_task(
+        &mut self,
+        runnable_tasks: &[TaskId],
+        current_task: Option<TaskId>,
+        is_yielding: bool,
+    ) -> Option<TaskId> {
+
+		if self.recording {
+			// Recording a schedule
+			let choice = self.inner.next_task(runnable_tasks, current_task, is_yielding).unwrap();
+			self.original_schedule.push(ScheduleRecord::new(ScheduleStep::Task(choice), runnable_tasks));
+
+			self.current_step += 1;
+
+			Some(choice)
+				
+		} else {
+			// Determine whether the state is the same
+
+			if self.current_step >= self.original_schedule.len() {
+				// Current run is longer than original recording
+				panic!("Current execution longer than expected. \n\tOriginal length: {}, acutal length: {}",
+															self.original_schedule.len(), self.current_step);
+			}
+
+			let expected = self.original_schedule.get(self.current_step).unwrap().clone();
+			let expected_step = expected.step;
+			let expected_options = expected.runnable_tasks;
+			let actual_options: HashSet<TaskId> = HashSet::from_iter(runnable_tasks.iter().cloned());
+
+			match expected_step {
+				ScheduleStep::Task(id) => { 
+					if !expected_options.contains(&id) {
+						panic!("\nTask chosen in recording is not currently runnable.\n\tExpected Task: {:?} \n\tActual options: {:?}\n",
+																		id, actual_options);
+					}
+
+					if expected_options != actual_options {
+						panic!("\nSet of runnable tasks is different than expected.\n\tExpected options: {:?} \n\tActual options: {:?}\n",
+																		expected_options, actual_options);
+					}
+
+					self.current_step += 1;
+
+					Some(id)
+				},
+				ScheduleStep::Random => { panic!("Found context switch, but recording expected random number generation")},
+			}
+		}
+    }
+
+    fn next_u64(&mut self) -> u64 {
+
+		if self.recording {
+			// Recording a schedule
+			self.original_schedule.push(ScheduleRecord::new(ScheduleStep::Random, &Vec::new()));	
+		} else {
+			// Check that random step is recorded here
+			if let ScheduleStep::Task(_) = self.original_schedule[self.current_step].step {
+				panic!("Found random generation, but recording expected context switch");
+			}
+		}
+
+		self.current_step += 1;
+		self.inner.next_u64()
+
+    }
+}

--- a/src/scheduler/round_robin.rs
+++ b/src/scheduler/round_robin.rs
@@ -7,6 +7,7 @@ use crate::scheduler::{Schedule, Scheduler};
 #[derive(Debug)]
 pub struct RoundRobinScheduler {
     iterations: usize,
+    max_iterations: usize,
     data_source: RandomDataSource,
 }
 
@@ -16,6 +17,17 @@ impl RoundRobinScheduler {
     pub fn new() -> Self {
         Self {
             iterations: 0,
+            max_iterations: 1,
+            data_source: RandomDataSource::initialize(0),
+        }
+    }
+
+    /// Construct a new `RoundRobinScheduler` that will execute the test up to max_iteration times, scheduling its
+    /// tasks in a round-robin fashion.
+    pub fn new_multi_run(max_iterations : usize) -> Self {
+        Self {
+            iterations: 0,
+            max_iterations,
             data_source: RandomDataSource::initialize(0),
         }
     }
@@ -23,7 +35,7 @@ impl RoundRobinScheduler {
 
 impl Scheduler for RoundRobinScheduler {
     fn new_execution(&mut self) -> Option<Schedule> {
-        if self.iterations == 0 {
+        if self.iterations < self.max_iterations {
             self.iterations += 1;
             Some(Schedule::new(self.data_source.reinitialize()))
         } else {

--- a/tests/basic/determinism_check.rs
+++ b/tests/basic/determinism_check.rs
@@ -1,0 +1,94 @@
+// use crate::check_replay_roundtrip;
+use shuttle::rand::{thread_rng, Rng};
+// use shuttle::scheduler::RandomScheduler;
+use shuttle::sync::{Mutex, Arc};
+use shuttle::{check_determinism, thread};
+use test_log::test;
+
+
+#[test]
+#[should_panic]
+fn shuttle_determinism_test1() {
+    check_determinism(|| {
+
+        const NUM_THREADS: u32 = 10;
+
+        let lock = Arc::new(Mutex::new(0u64));
+        let threads: Vec<_> = (0..NUM_THREADS)
+        .map(|_| {
+
+            let my_lock = lock.clone();
+
+            thread::spawn(move || {
+                let x = thread_rng().gen::<u64>();
+
+				// Fail every x threads
+                if x % 1000 == 0 {
+                    let mut num = my_lock.lock().unwrap();
+                    *num += 1;
+                }
+            })
+        }).collect();
+
+        threads.into_iter().for_each(|t| t.join().expect("Failed"));
+
+        let num = lock.lock().unwrap(); 
+		println!("Lock accessed {} times", num);       
+    }, 1000, 10);
+}
+
+#[test]
+#[should_panic]
+fn shuttle_determinism_test2() {
+    shuttle::check_determinism(|| {
+        // Should fail
+        let num_threads: u64 = thread_rng().gen::<u64>() % 100;
+        println!("Number of threads: {}", num_threads);
+        let lock = Arc::new(Mutex::new(0u64));
+        let threads: Vec<_> = (0..num_threads)
+        .map(|_| {
+            let my_lock = lock.clone();
+
+            thread::spawn(move || {
+
+                let mut num = my_lock.lock().unwrap();
+                *num += 1;
+            })
+        }).collect();
+
+        threads.into_iter().for_each(|t| t.join().expect("Failed"));
+
+        let num = lock.lock().unwrap();     
+		assert!(*num == num_threads);
+     
+   
+    }, 100, 10);
+}
+
+#[test]
+fn shuttle_determinism_test3() {
+    shuttle::check_determinism(|| {
+        // Should pass
+        let num_threads: u64 = 100;
+        let lock = Arc::new(Mutex::new(0u64));
+        let threads: Vec<_> = (0..num_threads)
+        .map(|_| {
+            // To share the same cache across the threads, clone it.
+            // This is a cheap operation.
+            let my_lock = lock.clone();
+
+            thread::spawn(move || {
+
+                let mut num = my_lock.lock().unwrap();
+                *num += 1;
+                
+            })
+        }).collect();
+
+        threads.into_iter().for_each(|t| t.join().expect("Failed"));
+
+        let num = lock.lock().unwrap();   
+		assert!(*num == num_threads);
+     
+    }, 100, 10);
+}

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -3,6 +3,7 @@ mod barrier;
 mod clocks;
 mod condvar;
 mod config;
+mod determinism_check;
 mod dfs;
 mod execution;
 mod metrics;


### PR DESCRIPTION
Added a DeterminismCheckScheduler to check functions for determinism by recording runnable tasks at each step and comparing on future iterations of the scheduler. Wraps an inner scheduler, which can be Random, RoundRobin, or PCT. Added unit tests as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.