### PR TITLE
Re-export `std::sync::Weak` (until true `Arc` support is implemented)

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -22,4 +22,4 @@ pub use rwlock::RwLockReadGuard;
 pub use rwlock::RwLockWriteGuard;
 
 // TODO implement true support for `Arc`
-pub use std::sync::Arc;
+pub use std::sync::{Arc, Weak};


### PR DESCRIPTION
<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.