### PR TITLE
Small cleanups

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -79,7 +79,7 @@ impl Schedule {
 /// state and strategically explore different schedules. At the start of each test execution, the
 /// executor calls `new_execution()` to inform the scheduler that a new execution is starting. Then,
 /// for each scheduling decision, the executor calls `next_task` to determine which task to run.
-pub trait Scheduler: Debug {
+pub trait Scheduler {
     /// Inform the `Scheduler` that a new execution is about to begin. If this function returns
     /// None, the test will end rather than performing another execution. If it returns
     /// `Some(schedule)`, the returned `Schedule` can be used to initialize a `ReplayScheduler` for

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -26,7 +26,6 @@ where
             let mut config = Config::new();
             config.failure_persistence = FailurePersistence::Print;
             let runner = Runner::new(scheduler, config);
-            #[allow(clippy::redundant_closure)] // Clippy is wrong: https://github.com/rust-lang/rust-clippy/issues/8073
             runner.run(move || test_func())
         })
         .expect_err("test should panic")
@@ -42,8 +41,7 @@ where
             config.failure_persistence = FailurePersistence::Print;
             let scheduler = ReplayScheduler::new_from_encoded(&schedule);
             let runner = Runner::new(scheduler, config);
-            #[allow(clippy::redundant_closure)]
-            // Clippy is wrong: https://github.com/rust-lang/rust-clippy/issues/8073
+
             runner.run(move || test_func());
         })
         .expect_err("replay should panic")
@@ -74,7 +72,6 @@ where
             let mut config = Config::new();
             config.failure_persistence = FailurePersistence::File(Some(tempdir_path));
             let runner = Runner::new(scheduler, config);
-            #[allow(clippy::redundant_closure)] // Clippy is wrong: https://github.com/rust-lang/rust-clippy/issues/8073
             runner.run(move || test_func())
         })
         .expect_err("test should panic")
@@ -86,7 +83,6 @@ where
     // to test the `replay_from_file` function directly, so this time we'll default to printing the
     // schedule to stdout.
     let result = {
-        #[allow(clippy::redundant_closure)] // Clippy is wrong: https://github.com/rust-lang/rust-clippy/issues/8073
         panic::catch_unwind(move || replay_from_file(move || test_func(), schedule_file))
             .expect_err("replay should panic")
     };


### PR DESCRIPTION
Just a couple of small things: removing the `Debug` bound from the `Scheduler` trait, and removing some clippy allows that are now fixed upstream.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.