### PR TITLE
Implement `Mutex::try_lock`

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -61,13 +61,18 @@ impl<T: ?Sized> Mutex<T> {
                 panic!("deadlock! task {:?} tried to acquire a Mutex it already holds", me);
             }
             ExecutionState::with(|s| s.current_mut().block());
+            drop(state);
+
+            // Note that we only need a context switch when we are blocked, but not if the lock is
+            // available. Consider that there is another thread `t` that also wants to acquire the
+            // lock. At the last context switch (where we were chosen), `t` must have been already
+            // runnable and could have been chosen by the scheduler instead. Also, if we want to
+            // re-acquire the lock immediately after having it released, we know that the release
+            // had a context switch that allowed other threads to acquire in between.
+            thread::switch();
+            state = self.state.borrow_mut();
         }
-        drop(state);
 
-        // Acquiring a lock is a yield point
-        thread::switch();
-
-        let mut state = self.state.borrow_mut();
         // Once the scheduler has resumed this thread, we are clear to become its holder.
         assert!(state.waiters.remove(me));
         assert!(state.holder.is_none());
@@ -81,10 +86,13 @@ impl<T: ?Sized> Mutex<T> {
         }
         // Update acquiring thread's clock with the clock stored in the Mutex
         ExecutionState::with(|s| s.update_clock(&state.clock));
+        // Update the vector clock stored in the Mutex with this threads clock.
+        // Future threads that fail a `try_lock` have a causal dependency on this thread's acquire.
+        ExecutionState::with(|s| state.clock.update(s.get_clock(me)));
         drop(state);
 
         // Grab a `MutexGuard` from the inner lock, which we must be able to acquire here
-        match self.inner.try_lock() {
+        let result = match self.inner.try_lock() {
             Ok(guard) => Ok(MutexGuard {
                 inner: Some(guard),
                 mutex: self,
@@ -94,7 +102,15 @@ impl<T: ?Sized> Mutex<T> {
                 mutex: self,
             })),
             Err(TryLockError::WouldBlock) => panic!("mutex state out of sync"),
-        }
+        };
+
+        // We need to let other threads in here so they may fail a `try_lock`. This is the case
+        // because the current thread holding the lock might not have any further context switches
+        // until after releasing the lock. The `concurrent_lock_try_lock` test illustrates this
+        // scenario and would fail if this context switch is not here.
+        thread::switch();
+
+        result
     }
 
     /// Attempts to acquire this lock.
@@ -102,7 +118,68 @@ impl<T: ?Sized> Mutex<T> {
     /// If the lock could not be acquired at this time, then Err is returned. This function does not
     /// block.
     pub fn try_lock(&self) -> TryLockResult<MutexGuard<T>> {
-        unimplemented!()
+        let me = ExecutionState::me();
+
+        let mut state = self.state.borrow_mut();
+        trace!(holder=?state.holder, waiters=?state.waiters, "trying to acquire mutex {:p}", self);
+
+        // We don't need a context switch here. There are two cases to analyze.
+        // * Consider that `state.holder == None` so that we manage to acquire the lock, but that
+        //   there is another thread `t` that also wants to acquire. At the last context switch
+        //   (where we were chosen), `t` must have been already runnable and could have been chosen
+        //   by the scheduler instead. Then `t`'s acquire has a context switch that allows us to
+        //   run into the `WouldBlock` case.
+        // * Consider that `state.holder == Some(t)` so that we run into the `WouldBlock` case,
+        //   but that `t` wants to release. At the last context switch (where we were chosen), `t`
+        //   must have been already runnable and could have been chosen by the scheduler instead.
+        //   Then `t`'s release has a context switch that allows us to acquire the lock.
+
+        let result = if let Some(holder) = state.holder {
+            trace!("`try_lock` failed to acquire mutex {:p} held by {:?}", self, holder);
+            Err(TryLockError::WouldBlock)
+        } else {
+            state.holder = Some(me);
+
+            trace!("acquired mutex {:p}", self);
+
+            // Re-block all other waiting threads, since we won the race to take this lock
+            for tid in state.waiters.iter() {
+                ExecutionState::with(|s| s.get_mut(tid).block());
+            }
+
+            // Grab a `MutexGuard` from the inner lock, which we must be able to acquire here
+            match self.inner.try_lock() {
+                Ok(guard) => Ok(MutexGuard {
+                    inner: Some(guard),
+                    mutex: self,
+                }),
+                Err(TryLockError::Poisoned(guard)) => Err(TryLockError::Poisoned(PoisonError::new(MutexGuard {
+                    inner: Some(guard.into_inner()),
+                    mutex: self,
+                }))),
+                Err(TryLockError::WouldBlock) => panic!("mutex state out of sync"),
+            }
+        };
+
+        // Update the vector clock stored in the Mutex with this threads clock.
+        // Future threads that manage to acquire have a causal dependency on this thread's failed `try_lock`.
+        // Future threads that fail a `try_lock` have a causal dependency on this thread's successful `try_lock`.
+        ExecutionState::with(|s| state.clock.update(s.get_clock(me)));
+
+        // Update this thread's clock with the clock stored in the Mutex.
+        // We need to do the vector clock update even in the failing case, because there's a causal
+        // dependency: if the `try_lock` fails, the current thread `t1` knows that the thread `t2`
+        // that owns the lock is in its critical section, and therefore `t1` has a causal dependency
+        // on everything that happened before in `t2` (which is recorded in the Mutex's clock).
+        ExecutionState::with(|s| s.update_clock(&state.clock));
+        drop(state);
+
+        // We need to let other threads in here so they
+        // (a) may fail a `try_lock` (in case we acquired), or
+        // (b) may release the lock (in case we failed to acquire) so we can succeed in a subsequent `try_lock`.
+        thread::switch();
+
+        result
     }
 
     /// Consumes this mutex, returning the underlying data.
@@ -153,6 +230,12 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
 
 impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
     fn drop(&mut self) {
+        // We don't need a context switch here *before* releasing the lock. There are two cases to analyze.
+        // * Other threads that want to `lock` are still blocked at this point.
+        // * Other threads that want to `try_lock` and would fail at this point (but not after we release)
+        //   were already runnable at the last context switch (which could have been right after we acquired)
+        //   and could have been scheduled then to fail the `try_lock`.
+
         self.inner = None;
 
         let mut state = self.mutex.state.borrow_mut();

--- a/tests/basic/condvar.rs
+++ b/tests/basic/condvar.rs
@@ -279,7 +279,7 @@ fn check_producer_consumer_broken1() {
 
 #[test]
 #[should_panic(expected = "nothing to get")]
-fn replay_roducer_consumer_broken1() {
+fn replay_producer_consumer_broken1() {
     replay(
         producer_consumer_broken1,
         "910219ccf2ead7a59dee9e4590000282249100208904",
@@ -337,7 +337,7 @@ fn check_producer_consumer_broken2() {
 
 #[test]
 #[should_panic(expected = "deadlock")]
-fn replay_roducer_consumer_broken2() {
+fn replay_producer_consumer_broken2() {
     replay(producer_consumer_broken2, "91021499a0ee829bee85922b104410200052a404")
 }
 

--- a/tests/basic/condvar.rs
+++ b/tests/basic/condvar.rs
@@ -232,49 +232,57 @@ fn notify_one_order() {
 /// From "Operating Systems: Three Easy Pieces", Figure 30.8.
 /// Demonstrates why a waiter needs to check the condition in a `while` loop, not an if.
 /// http://pages.cs.wisc.edu/~remzi/OSTEP/threads-cv.pdf
-#[test]
-#[should_panic(expected = "nothing to get")]
 fn producer_consumer_broken1() {
-    replay(
-        || {
-            let lock = Arc::new(Mutex::new(()));
-            let cond = Arc::new(Condvar::new());
-            let count = Arc::new(AtomicUsize::new(0));
+    let lock = Arc::new(Mutex::new(()));
+    let cond = Arc::new(Condvar::new());
+    let count = Arc::new(AtomicUsize::new(0));
 
-            // Two consumers
-            for _ in 0..2 {
-                let lock = Arc::clone(&lock);
-                let cond = Arc::clone(&cond);
-                let count = Arc::clone(&count);
-                thread::spawn(move || {
-                    for _ in 0..2 {
-                        let mut guard = lock.lock().unwrap();
-                        if count.load(Ordering::SeqCst) == 0 {
-                            guard = cond.wait(guard).unwrap();
-                        }
-                        // get()
-                        assert_eq!(count.load(Ordering::SeqCst), 1, "nothing to get");
-                        count.store(0, Ordering::SeqCst);
-                        cond.notify_one();
-                        drop(guard); // explicit unlock to match the book
-                    }
-                });
-            }
-
-            // One producer
+    // Two consumers
+    for _ in 0..2 {
+        let lock = Arc::clone(&lock);
+        let cond = Arc::clone(&cond);
+        let count = Arc::clone(&count);
+        thread::spawn(move || {
             for _ in 0..2 {
                 let mut guard = lock.lock().unwrap();
-                if count.load(Ordering::SeqCst) == 1 {
+                if count.load(Ordering::SeqCst) == 0 {
                     guard = cond.wait(guard).unwrap();
                 }
-                // put()
-                assert_eq!(count.load(Ordering::SeqCst), 0, "no space to put");
-                count.store(1, Ordering::SeqCst);
+                // get()
+                assert_eq!(count.load(Ordering::SeqCst), 1, "nothing to get");
+                count.store(0, Ordering::SeqCst);
                 cond.notify_one();
-                drop(guard);
+                drop(guard); // explicit unlock to match the book
             }
-        },
-        "910215000000408224002229",
+        });
+    }
+
+    // One producer
+    for _ in 0..2 {
+        let mut guard = lock.lock().unwrap();
+        if count.load(Ordering::SeqCst) == 1 {
+            guard = cond.wait(guard).unwrap();
+        }
+        // put()
+        assert_eq!(count.load(Ordering::SeqCst), 0, "no space to put");
+        count.store(1, Ordering::SeqCst);
+        cond.notify_one();
+        drop(guard);
+    }
+}
+
+#[test]
+#[should_panic]
+fn check_producer_consumer_broken1() {
+    check_random(producer_consumer_broken1, 5000)
+}
+
+#[test]
+#[should_panic(expected = "nothing to get")]
+fn replay_roducer_consumer_broken1() {
+    replay(
+        producer_consumer_broken1,
+        "910219ccf2ead7a59dee9e4590000282249100208904",
     )
 }
 
@@ -282,50 +290,55 @@ fn producer_consumer_broken1() {
 /// with a while loop, not an if.
 /// Demonstrates why one condvar is not sufficient for a concurrent queue.
 /// http://pages.cs.wisc.edu/~remzi/OSTEP/threads-cv.pdf
-#[test]
-#[should_panic(expected = "deadlock")]
 fn producer_consumer_broken2() {
-    replay(
-        || {
-            let lock = Arc::new(Mutex::new(()));
-            let cond = Arc::new(Condvar::new());
-            let count = Arc::new(AtomicUsize::new(0));
+    let lock = Arc::new(Mutex::new(()));
+    let cond = Arc::new(Condvar::new());
+    let count = Arc::new(AtomicUsize::new(0));
 
-            // Two consumers
-            for _ in 0..2 {
-                let lock = Arc::clone(&lock);
-                let cond = Arc::clone(&cond);
-                let count = Arc::clone(&count);
-                thread::spawn(move || {
-                    for _ in 0..1 {
-                        let mut guard = lock.lock().unwrap();
-                        while count.load(Ordering::SeqCst) == 0 {
-                            guard = cond.wait(guard).unwrap();
-                        }
-                        // get()
-                        assert_eq!(count.load(Ordering::SeqCst), 1, "nothing to get");
-                        count.store(0, Ordering::SeqCst);
-                        cond.notify_one();
-                        drop(guard);
-                    }
-                });
-            }
-
-            // One producer
-            for _ in 0..2 {
+    // Two consumers
+    for _ in 0..2 {
+        let lock = Arc::clone(&lock);
+        let cond = Arc::clone(&cond);
+        let count = Arc::clone(&count);
+        thread::spawn(move || {
+            for _ in 0..1 {
                 let mut guard = lock.lock().unwrap();
-                while count.load(Ordering::SeqCst) == 1 {
+                while count.load(Ordering::SeqCst) == 0 {
                     guard = cond.wait(guard).unwrap();
                 }
-                // put()
-                assert_eq!(count.load(Ordering::SeqCst), 0, "no space to put");
-                count.store(1, Ordering::SeqCst);
+                // get()
+                assert_eq!(count.load(Ordering::SeqCst), 1, "nothing to get");
+                count.store(0, Ordering::SeqCst);
                 cond.notify_one();
                 drop(guard);
             }
-        },
-        "9102110090401004405202",
-    )
+        });
+    }
+
+    // One producer
+    for _ in 0..2 {
+        let mut guard = lock.lock().unwrap();
+        while count.load(Ordering::SeqCst) == 1 {
+            guard = cond.wait(guard).unwrap();
+        }
+        // put()
+        assert_eq!(count.load(Ordering::SeqCst), 0, "no space to put");
+        count.store(1, Ordering::SeqCst);
+        cond.notify_one();
+        drop(guard);
+    }
+}
+
+#[test]
+#[should_panic]
+fn check_producer_consumer_broken2() {
+    check_random(producer_consumer_broken2, 5000)
+}
+
+#[test]
+#[should_panic(expected = "deadlock")]
+fn replay_roducer_consumer_broken2() {
+    replay(producer_consumer_broken2, "91021499a0ee829bee85922b104410200052a404")
 }
 
 /// From "Operating Systems: Three Easy Pieces", Figure 30.12. Like `producer_consumer_broken2`, but

--- a/tests/basic/mutex.rs
+++ b/tests/basic/mutex.rs
@@ -1,7 +1,8 @@
 use shuttle::scheduler::PctScheduler;
 use shuttle::sync::Mutex;
-use shuttle::{check, check_random, thread, Runner};
-use std::sync::Arc;
+use shuttle::{check, check_dfs, check_random, thread, Runner};
+use std::collections::HashSet;
+use std::sync::{Arc, TryLockError};
 use test_log::test;
 
 #[test]
@@ -112,6 +113,221 @@ fn concurrent_increment() {
 
         assert_eq!(*lock.lock().unwrap(), 2);
     });
+}
+
+/// Two concurrent threads, one doing two successive atomic increments, the other doing
+/// an atomic multiplication by 2. The multiplication can go before, between, and after
+/// the increments. Thus we expect to see final values
+/// * 2 (`0 * 2 + 1 + 1`),
+/// * 3 (`(0 + 1) * 2 + 1`), and
+/// * 4 (`(0 + 1 + 1) * 2`).
+#[test]
+fn unlock_yields() {
+    let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let observed_values_clone = Arc::clone(&observed_values);
+
+    check_dfs(
+        move || {
+            let lock = Arc::new(Mutex::new(0usize));
+
+            let add_thread = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    *lock.lock().unwrap() += 1;
+                    *lock.lock().unwrap() += 1;
+                })
+            };
+            let mul_thread = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    *lock.lock().unwrap() *= 2;
+                })
+            };
+
+            add_thread.join().unwrap();
+            mul_thread.join().unwrap();
+
+            let value = *lock.try_lock().unwrap();
+            observed_values_clone.lock().unwrap().insert(value);
+        },
+        None,
+    );
+
+    let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+    assert_eq!(observed_values, HashSet::from([2, 3, 4]));
+}
+
+/// Similar to `unlock_yields`, but testing some interaction of `Mutex` with `RwLock`.
+#[test]
+fn mutex_rwlock_interaction() {
+    let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let observed_values_clone = Arc::clone(&observed_values);
+
+    check_dfs(
+        move || {
+            let lock = Arc::new(Mutex::new(()));
+            let rwlock = Arc::new(shuttle::sync::RwLock::new(()));
+            let value = Arc::new(std::sync::Mutex::new(0usize));
+
+            let add_thread = {
+                let lock = Arc::clone(&lock);
+                let value = Arc::clone(&value);
+                thread::spawn(move || {
+                    {
+                        let _guard = lock.lock().unwrap();
+                        *value.lock().unwrap() += 1;
+                    }
+                    {
+                        let _guard = rwlock.write().unwrap();
+                        if let Ok(_g) = lock.try_lock() {
+                            // In this case the multiplication in the other thread can go before,
+                            // after, or between +1/+2/+3, resulting in final values 6, 7, 9, and 12.
+                            *value.lock().unwrap() += 2;
+                        } else {
+                            // In this case the multiplication in the other thread can only go between
+                            // +1 and +6 or between +6 and +3, resulting in final values 11 and 17.
+                            // The multiplication cannot go first or last, which would be final values
+                            // 10 and 20.
+                            *value.lock().unwrap() += 6;
+                        }
+                    }
+                    {
+                        let _guard = lock.lock().unwrap();
+                        *value.lock().unwrap() += 3;
+                    }
+                })
+            };
+            let mul_thread = {
+                let lock = Arc::clone(&lock);
+                let log = Arc::clone(&value);
+                thread::spawn(move || {
+                    let _guard = lock.lock().unwrap();
+                    *log.lock().unwrap() *= 2;
+                })
+            };
+
+            add_thread.join().unwrap();
+            mul_thread.join().unwrap();
+
+            let value = Arc::try_unwrap(value).unwrap().into_inner().unwrap();
+            observed_values_clone.lock().unwrap().insert(value);
+        },
+        None,
+    );
+
+    let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+    assert_eq!(observed_values, HashSet::from([6, 7, 9, 12, 11, 17]));
+}
+
+/// Two concurrent threads trying to do an atomic increment using `try_lock`.
+/// One `try_lock` must succeed, while the other may or may not succeed.
+/// Thus we expect to see final values 1 and 2.
+#[test]
+fn concurrent_try_increment() {
+    let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let observed_values_clone = Arc::clone(&observed_values);
+
+    check_dfs(
+        move || {
+            let lock = Arc::new(Mutex::new(0usize));
+
+            let threads = (0..2)
+                .map(|_| {
+                    let lock = Arc::clone(&lock);
+                    thread::spawn(move || {
+                        match lock.try_lock() {
+                            Ok(mut guard) => {
+                                *guard += 1;
+                            }
+                            Err(TryLockError::WouldBlock) => (),
+                            Err(_) => panic!("unexpected TryLockError"),
+                        };
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in threads {
+                thd.join().unwrap();
+            }
+
+            let value = *lock.try_lock().unwrap();
+            observed_values_clone.lock().unwrap().insert(value);
+        },
+        None,
+    );
+
+    let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+    assert_eq!(observed_values, HashSet::from([1, 2]));
+}
+
+/// Two concurrent threads, one doing an atomic increment by 1 using `lock`,
+/// the other trying to do an atomic increment by 1 followed by trying to do
+/// an atomic increment by 2 using `try_lock`. The `lock` must succeed, while
+/// both `try_lock`s may or may not succeed. Thus we expect to see final values
+/// * 1 (both `try_lock`s fail),
+/// * 2 (second `try_lock` fails),
+/// * 3 (first `try_lock` fails), and
+/// * 4 (both `try_lock`s succeed).
+#[test]
+fn concurrent_lock_try_lock() {
+    let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let observed_values_clone = Arc::clone(&observed_values);
+
+    check_dfs(
+        move || {
+            let lock = Arc::new(Mutex::new(0usize));
+
+            let lock_thread = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    *lock.lock().unwrap() += 1;
+                })
+            };
+            let try_lock_thread = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    for n in 1..3 {
+                        match lock.try_lock() {
+                            Ok(mut guard) => {
+                                *guard += n;
+                            }
+                            Err(TryLockError::WouldBlock) => (),
+                            Err(_) => panic!("unexpected TryLockError"),
+                        };
+                    }
+                })
+            };
+
+            lock_thread.join().unwrap();
+            try_lock_thread.join().unwrap();
+
+            let value = *lock.try_lock().unwrap();
+            observed_values_clone.lock().unwrap().insert(value);
+        },
+        None,
+    );
+
+    let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+    assert_eq!(observed_values, HashSet::from([1, 2, 3, 4]));
+}
+
+#[test]
+#[should_panic(expected = "tried to acquire a Mutex it already holds")]
+fn double_lock() {
+    check(|| {
+        let mutex = Mutex::new(());
+        let _guard_1 = mutex.lock().unwrap();
+        let _guard_2 = mutex.lock();
+    })
+}
+
+#[test]
+fn double_try_lock() {
+    check(|| {
+        let mutex = Mutex::new(());
+        let _guard_1 = mutex.try_lock().unwrap();
+        assert!(matches!(mutex.try_lock(), Err(TryLockError::WouldBlock)));
+    })
 }
 
 // Check that we can safely execute the Drop handler of a Mutex without double-panicking

--- a/tests/basic/replay.rs
+++ b/tests/basic/replay.rs
@@ -100,7 +100,7 @@ fn deadlock_3() {
 #[should_panic(expected = "deadlock")]
 fn replay_deadlock3_block() {
     // Reproduce deadlock
-    let schedule = Schedule::new_from_task_ids(0, vec![0, 0, 1, 2, 1, 2, 0, 0]);
+    let schedule = Schedule::new_from_task_ids(0, vec![0, 0, 1, 2, 0, 0, 1, 2]);
     let scheduler = ReplayScheduler::new_from_schedule(schedule);
     let runner = Runner::new(scheduler, Default::default());
     runner.run(deadlock_3);

--- a/tests/demo/bounded_buffer.rs
+++ b/tests/demo/bounded_buffer.rs
@@ -227,5 +227,5 @@ fn test_bounded_buffer_minimal_deadlock() {
 #[test]
 #[should_panic(expected = "deadlock")]
 fn test_bounded_buffer_minimal_deadlock_replay() {
-    replay(bounded_buffer_minimal, "91022600006c50a6699b246d92166d5ba22801")
+    replay(bounded_buffer_minimal, "910219e6c5a886c7a1f2d29e01106050a42ddb12455102")
 }


### PR DESCRIPTION
Without `try_lock` it was easier to justify context switches, because
acquire was a right mover (we only needed a context switch before) and
release was a left mover (we only needed a context switch after).
However, with `try_lock` that is not the case anymore. This commit
argues why we need a context switch at the end of `lock` and `try_lock`
(both in the success and failure case), and why we do not need a context
switch at the beginning of `try_lock` and `MutexGuard::drop`.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.