### PR TITLE
Implement `RwLock::{try_read, try_write}`

### DIFF
--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -299,14 +299,20 @@ impl TaskSet {
         self.tasks.iter().all(|b| !*b)
     }
 
-    pub fn insert(&mut self, tid: TaskId) {
+    /// Add a task to the set. If the set did not have this value present, `true` is returned. If
+    /// the set did have this value present, `false` is returned.
+    pub fn insert(&mut self, tid: TaskId) -> bool {
         if tid.0 >= self.tasks.len() {
             self.tasks.resize(1 + tid.0, false);
         }
-        *self.tasks.get_mut(tid.0).unwrap() = true;
+        !std::mem::replace(&mut *self.tasks.get_mut(tid.0).unwrap(), true)
     }
 
+    /// Removes a value from the set. Returns whether the value was present in the set.
     pub fn remove(&mut self, tid: TaskId) -> bool {
+        if tid.0 >= self.tasks.len() {
+            return false;
+        }
         std::mem::replace(&mut self.tasks.get_mut(tid.0).unwrap(), false)
     }
 

--- a/tests/basic/rwlock.rs
+++ b/tests/basic/rwlock.rs
@@ -1,8 +1,9 @@
 use shuttle::scheduler::PctScheduler;
 use shuttle::sync::{mpsc::channel, RwLock};
-use shuttle::{check, check_random, thread, Runner};
+use shuttle::{check, check_dfs, check_random, thread, Runner};
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, TryLockError};
 use test_log::test;
 
 #[test]
@@ -124,7 +125,7 @@ fn rwlock_two_writers() {
 // This test should never deadlock.
 #[test]
 fn rwlock_allows_multiple_readers() {
-    shuttle::check_dfs(
+    check_dfs(
         || {
             let lock1 = Arc::new(RwLock::new(1));
             let lock2 = lock1.clone();
@@ -171,7 +172,7 @@ fn two_readers_and_one_writer() {
 
 #[test]
 fn rwlock_two_readers_and_one_writer_exhaustive() {
-    shuttle::check_dfs(two_readers_and_one_writer, None);
+    check_dfs(two_readers_and_one_writer, None);
 }
 
 #[test]
@@ -183,7 +184,7 @@ fn rwlock_default() {
         }
     }
 
-    shuttle::check_dfs(
+    check_dfs(
         || {
             let point: RwLock<Point> = Default::default();
 
@@ -197,7 +198,7 @@ fn rwlock_default() {
 
 #[test]
 fn rwlock_into_inner() {
-    shuttle::check_dfs(
+    check_dfs(
         || {
             let lock = Arc::new(RwLock::new(0u64));
 
@@ -216,6 +217,339 @@ fn rwlock_into_inner() {
 
             let lock = Arc::try_unwrap(lock).unwrap();
             assert_eq!(lock.into_inner().unwrap(), 2);
+        },
+        None,
+    )
+}
+
+/// Two concurrent threads trying to do an atomic increment using `try_write`.
+/// One `try_write` must succeed, while the other may or may not succeed.
+/// Thus we expect to see final values 1 and 2.
+#[test]
+fn concurrent_try_increment() {
+    let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let observed_values_clone = Arc::clone(&observed_values);
+
+    check_dfs(
+        move || {
+            let lock = Arc::new(RwLock::new(0usize));
+
+            let threads = (0..2)
+                .map(|_| {
+                    let lock = Arc::clone(&lock);
+                    thread::spawn(move || {
+                        match lock.try_write() {
+                            Ok(mut guard) => {
+                                *guard += 1;
+                            }
+                            Err(TryLockError::WouldBlock) => (),
+                            Err(_) => panic!("unexpected TryLockError"),
+                        };
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in threads {
+                thd.join().unwrap();
+            }
+
+            let value = Arc::try_unwrap(lock).unwrap().into_inner().unwrap();
+            observed_values_clone.lock().unwrap().insert(value);
+        },
+        None,
+    );
+
+    let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+    assert_eq!(observed_values, HashSet::from([1, 2]));
+}
+
+/// Run some threads that try to acquire the lock in both read and write modes, and check that any
+/// execution allowed by our `RwLock` implementation is allowed by `std`.
+#[test]
+fn try_lock_implies_std() {
+    check_random(
+        move || {
+            let lock = Arc::new(RwLock::new(()));
+            let reference_lock = Arc::new(std::sync::RwLock::new(()));
+
+            let threads = (0..3)
+                .map(|_| {
+                    let lock = Arc::clone(&lock);
+                    let reference_lock = Arc::clone(&reference_lock);
+                    thread::spawn(move || {
+                        for _ in 0..3 {
+                            {
+                                let _r = lock.try_read();
+                                if _r.is_ok() {
+                                    assert!(reference_lock.try_read().is_ok());
+                                }
+                            }
+                            {
+                                let _w = lock.try_write();
+                                if _w.is_ok() {
+                                    assert!(reference_lock.try_write().is_ok());
+                                }
+                            }
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in threads {
+                thd.join().unwrap();
+            }
+        },
+        5000,
+    );
+}
+
+/// Run some threads that try to acquire the lock in both read and write modes, and check that any
+/// execution allowed by `std` is allowed by our `RwLock` implementation. (This implication isn't
+/// true in general -- see `double_try_read` -- but is true for this test).
+#[test]
+fn try_lock_implied_by_std() {
+    check_random(
+        move || {
+            let lock = Arc::new(RwLock::new(()));
+            let reference_lock = Arc::new(std::sync::RwLock::new(()));
+
+            let threads = (0..3)
+                .map(|_| {
+                    let lock = Arc::clone(&lock);
+                    let reference_lock = Arc::clone(&reference_lock);
+                    thread::spawn(move || {
+                        for _ in 0..5 {
+                            {
+                                let _r = reference_lock.try_read();
+                                if _r.is_ok() {
+                                    assert!(lock.try_read().is_ok());
+                                }
+                            }
+                            {
+                                let _w = reference_lock.try_write();
+                                if _w.is_ok() {
+                                    assert!(lock.try_write().is_ok());
+                                }
+                            }
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in threads {
+                thd.join().unwrap();
+            }
+        },
+        5000,
+    );
+}
+
+/// Three concurrent threads, one doing an atomic increment by 1 using `write`, one trying to do an
+/// atomic increment by 1 followed by trying to do an atomic increment by 2 using `try_write`, and a
+/// third that peeks at the value using `try_read.` The `write` must succeed, while each `try_write`
+/// may or may not succeed.
+#[test]
+fn concurrent_write_try_write_try_read() {
+    let observed_values = Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let observed_values_clone = Arc::clone(&observed_values);
+
+    check_dfs(
+        move || {
+            let lock = Arc::new(RwLock::new(0usize));
+
+            let write_thread = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    *lock.write().unwrap() += 1;
+                })
+            };
+            let try_write_thread = {
+                let lock = Arc::clone(&lock);
+                thread::spawn(move || {
+                    for n in 1..3 {
+                        match lock.try_write() {
+                            Ok(mut guard) => {
+                                *guard += n;
+                            }
+                            Err(TryLockError::WouldBlock) => (),
+                            Err(_) => panic!("unexpected TryLockError"),
+                        };
+                    }
+                })
+            };
+
+            let read_value = match lock.try_read() {
+                Ok(guard) => Some(*guard),
+                Err(TryLockError::WouldBlock) => None,
+                Err(_) => panic!("unexpected TryLockError"),
+            };
+
+            write_thread.join().unwrap();
+            try_write_thread.join().unwrap();
+
+            let final_value = Arc::try_unwrap(lock).unwrap().into_inner().unwrap();
+            observed_values_clone.lock().unwrap().insert((final_value, read_value));
+        },
+        None,
+    );
+
+    let observed_values = Arc::try_unwrap(observed_values).unwrap().into_inner().unwrap();
+    // The idea here is that the `try_read` can interleave anywhere between the (successful) writes,
+    // but can also just fail.
+    let expected_values = HashSet::from([
+        // Both `try_write`s fail
+        (1, None),
+        (1, Some(0)),
+        (1, Some(1)),
+        // Second `try_write` fails
+        (2, None),
+        (2, Some(0)),
+        (2, Some(1)),
+        (2, Some(2)),
+        // First `try_write` fails
+        (3, None),
+        (3, Some(0)),
+        (3, Some(1)),
+        // (3, Some(2)), // If first `try_write` failed, the value of the lock is never 2
+        (3, Some(3)),
+        // Both `try_write`s succeed
+        (4, None),
+        (4, Some(0)),
+        (4, Some(1)),
+        (4, Some(2)),
+        (4, Some(3)),
+        (4, Some(4)),
+    ]);
+    assert_eq!(observed_values, expected_values);
+}
+
+/// This behavior is _sometimes_ allowed in `std`, but advised against, as it can lead to deadlocks
+/// on some platforms if the second `read` races with another thread's `write`. We conservatively
+/// rule it out in all cases to better detect potential deadlocks.
+#[test]
+#[should_panic(expected = "tried to acquire a RwLock it already holds")]
+fn double_read() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.read().unwrap();
+            let _guard_2 = rwlock.read();
+        },
+        None,
+    )
+}
+
+#[test]
+#[should_panic(expected = "tried to acquire a RwLock it already holds")]
+fn double_write() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.write().unwrap();
+            let _guard_2 = rwlock.write();
+        },
+        None,
+    )
+}
+
+#[test]
+#[should_panic(expected = "tried to acquire a RwLock it already holds")]
+fn read_upgrade() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.read().unwrap();
+            let _guard_2 = rwlock.write();
+        },
+        None,
+    )
+}
+
+#[test]
+#[should_panic(expected = "tried to acquire a RwLock it already holds")]
+fn write_downgrade() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.write().unwrap();
+            let _guard_2 = rwlock.read();
+        },
+        None,
+    )
+}
+
+/// This behavior isn't consistent with `std`, which seems to suggest that `try_read` succeeds if
+/// the current thread already holds a read lock. We assume it always fails so that we can more
+/// easily diagnose potential deadlocks, especially with async tasks that might migrate across
+/// threads in real implementations.
+#[test]
+fn double_try_read() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.try_read().unwrap();
+            assert!(matches!(rwlock.try_read(), Err(TryLockError::WouldBlock)));
+        },
+        None,
+    )
+}
+
+/// As with `double_try_read`, this isn't consistent with `std`.
+#[test]
+fn read_try_read() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.read().unwrap();
+            assert!(matches!(rwlock.try_read(), Err(TryLockError::WouldBlock)));
+        },
+        None,
+    )
+}
+
+#[test]
+fn double_try_write() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.try_write().unwrap();
+            assert!(matches!(rwlock.try_write(), Err(TryLockError::WouldBlock)));
+        },
+        None,
+    )
+}
+
+#[test]
+fn write_try_write() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.write().unwrap();
+            assert!(matches!(rwlock.try_write(), Err(TryLockError::WouldBlock)));
+        },
+        None,
+    )
+}
+
+#[test]
+fn try_read_upgrade() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.try_read().unwrap();
+            assert!(matches!(rwlock.try_write(), Err(TryLockError::WouldBlock)));
+        },
+        None,
+    )
+}
+
+#[test]
+fn try_write_downgrade() {
+    check_dfs(
+        || {
+            let rwlock = RwLock::new(());
+            let _guard_1 = rwlock.try_write().unwrap();
+            assert!(matches!(rwlock.try_read(), Err(TryLockError::WouldBlock)));
         },
         None,
     )

--- a/tests/demo/async_match_deadlock.rs
+++ b/tests/demo/async_match_deadlock.rs
@@ -74,5 +74,5 @@ fn async_match_deadlock() {
 fn asynch_match_deadlock_replay() {
     // Deterministically replay a deadlocking execution so we can, for example, single-step through
     // it in a debugger.
-    shuttle::replay(|| tokio::block_on(main()), "91010b98deab88a3ea91d6e001202808")
+    shuttle::replay(|| tokio::block_on(main()), "91010cbbc0daf8c5a5a9b162a08a08")
 }


### PR DESCRIPTION
This is a little tricky because `std` is unclear about whether a thread
can acquire the same read lock multiple times. For `read` it says:

> This function might panic when called if the lock is already held by
> the current thread.

So acquiring a second read lock _might_ fail. But for `try_read` it says:

> This function will return the WouldBlock error if the RwLock could not
> be acquired because it was already locked exclusively.

suggesting that `try_read` _must_ succeed the second time (the lock is
not held exclusively).

We resolve this ambiguity by choosing a conservative semantics that
always forbids a thread acquiring the read lock twice. This helps us
catch deadlocks, especially in async programs where a task might
nondeterministically migrate between threads and only deadlock if that
migration didn't happen.

Another difficulty with this change is that causality is pretty hairy
for the read side of a `RwLock`. In principle, concurrent readers
shouldn't inherit each other's causality, as they don't affect whether
the lock was readable or not. But that's really hard to implement,
especially with `try_write` in the picture too. So again we choose a
conservative implementation for our vector clocks that just always
inherits causality from all prior lock holders. This is likely too
strong, so we'd explore unnecessary symmetries, but I can't convince
myself of the correctness of a weaker implementation.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.