### PR TITLE
Rust 2021 conversion and dependency bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "shuttle"
 version = "0.2.0"
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"
 repository = "https://github.com/awslabs/shuttle"
@@ -10,8 +10,8 @@ categories = ["asynchronous", "concurrency", "development-tools::testing"]
 
 [dependencies]
 ansi_term = "0.12.1"
-bitvec = "0.21.0"
-generator = "0.7.0"
+bitvec = "1.0.1"
+generator = "0.7.1"
 hex = "0.4.2"
 rand_core = "0.5.1"
 rand = "0.7.3"

--- a/src/runtime/thread/continuation.rs
+++ b/src/runtime/thread/continuation.rs
@@ -70,6 +70,9 @@ impl Continuation {
             let function = function.clone();
 
             Gn::new_opt(stack_size, move || {
+                // Move the whole `ContinuationFunction`, not just its field (Rust 2021 thing)
+                let _ = &function;
+
                 loop {
                     // Tell the caller we've finished the previous user function (or if this is our
                     // first time around the loop, the caller below expects us to pretend we've

--- a/src/scheduler/serialization.rs
+++ b/src/scheduler/serialization.rs
@@ -30,7 +30,7 @@ pub(crate) fn serialize_schedule(schedule: &Schedule) -> String {
     let task_id_bits = std::mem::size_of_val(&max_task_id) * 8 - usize::from(max_task_id).leading_zeros() as usize;
     let task_id_bits = task_id_bits.max(1);
 
-    let mut encoded = bitvec![Lsb0, u8; 0; schedule.steps.len() * (1 + task_id_bits)];
+    let mut encoded = bitvec![u8, Lsb0; 0; schedule.steps.len() * (1 + task_id_bits)];
     let mut offset = 0usize;
     for step in &schedule.steps {
         match step {
@@ -73,7 +73,7 @@ pub(crate) fn deserialize_schedule(str: &str) -> Option<Schedule> {
     let schedule_len = bytes.read_usize_varint().ok()?;
     let seed = bytes.read_u64_varint().ok()?;
 
-    let encoded = BitSlice::<Lsb0, _>::from_slice(bytes).unwrap();
+    let encoded = BitSlice::<_, Lsb0>::from_slice(bytes);
     let mut offset = 0usize;
     let mut steps = Vec::with_capacity(schedule_len);
     while steps.len() < schedule_len {

--- a/tests/asynch/mod.rs
+++ b/tests/asynch/mod.rs
@@ -1,5 +1,5 @@
 // It's convenient to not specify eval order for `await`s in our tests
-#![allow(clippy::eval_order_dependence)]
+#![allow(clippy::mixed_read_write_in_expression)]
 
 mod basic;
 mod channel;


### PR DESCRIPTION
Mostly to pick up the new `generator` version, which fixes a bug with
floating point on aarch64.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.