### PR TITLE
Implement the `std::hint` module

### DIFF
--- a/src/hint.rs
+++ b/src/hint.rs
@@ -1,0 +1,14 @@
+//! Shuttle's implementation of [`std::hint`].
+
+pub use std::hint::*;
+
+use crate::thread;
+
+/// Emits a machine instruction to signal the processor that it is running in a busy-wait spin-loop
+/// (“spin lock”).
+pub fn spin_loop() {
+    // Probably not necessary, but let's emit it just in case
+    std::hint::spin_loop();
+
+    thread::yield_now();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@
 //! [pct]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/asplos277-pct.pdf
 
 pub mod asynch;
+pub mod hint;
 pub mod rand;
 pub mod sync;
 pub mod thread;

--- a/tests/asynch/mod.rs
+++ b/tests/asynch/mod.rs
@@ -1,5 +1,5 @@
 // It's convenient to not specify eval order for `await`s in our tests
-#![allow(clippy::eval_order_dependence)]
+#![allow(clippy::mixed_read_write_in_expression)]
 
 mod basic;
 mod channel;


### PR DESCRIPTION
The only thing we actually care about here is `hint::spin_loop`, which
we just treat the same way as `yield_now`.

Part of #75.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.