### PR TITLE
Remove `ansi_term` and release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0 (September 30, 2022)
+
+* Depdendency updates
+
 # 0.3.0 (August 29, 2022)
 
 Note that clients using async primitives provided by Shuttle (task `spawn`, `block_on`, `yield_now`) will

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"
@@ -9,10 +9,10 @@ keywords = ["concurrency", "lock", "thread", "async"]
 categories = ["asynchronous", "concurrency", "development-tools::testing"]
 
 [dependencies]
-ansi_term = "0.12.1"
 bitvec = "1.0.1"
 generator = "0.7.1"
 hex = "0.4.2"
+owo-colors = "3.5.0"
 rand_core = "0.5.1"
 rand = "0.7.3"
 rand_pcg = "0.2.1"

--- a/src/sync/atomic/mod.rs
+++ b/src/sync/atomic/mod.rs
@@ -69,7 +69,7 @@ static PRINTED_ORDERING_WARNING: std::sync::atomic::AtomicBool = std::sync::atom
 
 #[inline]
 fn maybe_warn_about_ordering(order: Ordering) {
-    use ansi_term::Colour;
+    use owo_colors::OwoColorize;
 
     #[allow(clippy::collapsible_if)]
     if order != Ordering::SeqCst {
@@ -90,7 +90,7 @@ fn maybe_warn_about_ordering(order: Ordering) {
                 as if they were SeqCst. Bugs caused by weaker orderings like {:?} may be missed. \
                 See https://docs.rs/shuttle/*/shuttle/sync/atomic/index.html#warning-about-relaxed-behaviors \
                 for details or to disable this warning.",
-                Colour::Yellow.normal().paint("WARNING"),
+                "WARNING".yellow(),
                 order
             );
         }


### PR DESCRIPTION
We've been getting warnings about `ansi_term` being unmaintained. That's a bit silly as a security advisory, but it's easy enough to switch. We also need to release a new version so we can remove the `varmint` dependency (#82).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.