### PR TITLE
Implement abort for JoinHandle

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -37,9 +37,13 @@ pub struct JoinHandle<T> {
 
 impl<T> JoinHandle<T> {
     /// Abort the task associated with the handle.
-    // TODO implement (only tokio provides this)
     pub fn abort(&self) {
-        unimplemented!();
+        ExecutionState::try_with(|state| {
+            if !state.is_finished() {
+                let task = state.get_mut(self.task_id);
+                task.detach();
+            }
+        });
     }
 }
 
@@ -53,12 +57,7 @@ pub enum JoinError {
 
 impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {
-        ExecutionState::try_with(|state| {
-            if !state.is_finished() {
-                let task = state.get_mut(self.task_id);
-                task.detach();
-            }
-        });
+        self.abort();
     }
 }
 


### PR DESCRIPTION
<!-- Enter your PR description here -->

In our code we actually call `abort` method on tokio's `JoinHandle` struct, once I tried to use shuttle, I saw that calling `abort` causes another panic

```bash
...
thread 'main' panicked at 'not implemented', /Users/koshelev/.cargo/registry/src/github.com-1ecc6299db9ec823/shuttle-0.4.1/src/future/mod.rs:42:9
stack backtrace:
```

Not sure if this is the right way to implement it, happy to iterate on that as well as adding more tests if required. I am not confident that `park` used inside the unit test does what I expect (park task , my flaky finder hasn't discovered any issues with it though:

```bash
flaky-finder -j3 -r500 --continue "cargo test --color=always --test mod future::basic::join_handle_abort"
>> Warming up...done.
  [00:01:06] [████████████████████████████████████████] (500/500, ETA 0s)
>> Nothing found 👍
```


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.