### PR TITLE
Run TLS destructors for the main thread

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -4,6 +4,7 @@ use crate::runtime::task::clock::VectorClock;
 use crate::runtime::task::{Task, TaskId, DEFAULT_INLINE_TASKS};
 use crate::runtime::thread::continuation::PooledContinuation;
 use crate::scheduler::{Schedule, Scheduler};
+use crate::thread::thread_fn;
 use crate::{Config, MaxSteps};
 use scoped_tls::scoped_thread_local;
 use smallvec::SmallVec;
@@ -63,7 +64,7 @@ impl Execution {
         EXECUTION_STATE.set(&state, move || {
             // Spawn `f` as the first task
             ExecutionState::spawn_thread(
-                f,
+                move || thread_fn(f, Default::default()),
                 config.stack_size,
                 Some("main-thread".to_string()),
                 Some(VectorClock::new()),


### PR DESCRIPTION
We weren't running the same TLS destructor logic for the main thread as
all other threads. This meant a thread-local on the main thread wouldn't
be dropped until the entire test finished, causing spurious deadlocks or
other confusion.

Fixes #86.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
