### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ bitvec = "1.0.1"
 generator = "0.7.1"
 hex = "0.4.2"
 owo-colors = "3.5.0"
-rand_core = "0.5.1"
-rand = "0.7.3"
-rand_pcg = "0.2.1"
+rand_core = "0.6.4"
+rand = "0.8.5"
+rand_pcg = "0.3.1"
 scoped-tls = "1.0.0"
 smallvec = "1.6.1"
 tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-criterion = { version = "0.3.4", features = ["html_reports"] }
+criterion = { version = "0.4.0", features = ["html_reports"] }
 futures = "0.3.5"
-proptest = "0.10.1"
+proptest = "1.0.0"
 regex = "1.5.5"
 tempfile = "3.2.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,9 +1,9 @@
-//! Shuttle's implementation of the [`rand`] crate, v0.7.
+//! Shuttle's implementation of the [`rand`] crate, v0.8.
 //!
 //! Shuttle captures and controls the nondeterminism introduced by randomness and allows it to be
 //! replayed deterministically.
 //!
-//! [`rand`]: https://docs.rs/rand/0.7.3/rand/index.html
+//! [`rand`]: https://docs.rs/rand/0.8.5/rand/index.html
 
 /// Random number generators and adapters
 pub mod rngs {

--- a/src/scheduler/pct.rs
+++ b/src/scheduler/pct.rs
@@ -112,7 +112,7 @@ impl Scheduler for PctScheduler {
         for new_task_id in max_known_task..1 + max_new_task {
             let new_task_id = TaskId::from(new_task_id);
             // Make sure there's a chance to give the new task the lowest priority
-            let target_task_id = TaskId::from(self.rng.gen_range(0, self.priorities.len()) + 1);
+            let target_task_id = TaskId::from(self.rng.gen_range(0..self.priorities.len()) + 1);
             let new_task_priority = if target_task_id == new_task_id {
                 self.next_priority
             } else {

--- a/tests/data/random.rs
+++ b/tests/data/random.rs
@@ -115,7 +115,7 @@ fn broken_atomic_counter_stress() {
     let counter = Arc::new(BrokenAtomicCounter::new());
     let truth = Arc::new(AtomicUsize::new(0));
 
-    let num_threads = thread_rng().gen_range(1usize, 4);
+    let num_threads = thread_rng().gen_range(1usize..4);
     let threads = (0..num_threads)
         .map(|_| {
             let counter = counter.clone();
@@ -123,7 +123,7 @@ fn broken_atomic_counter_stress() {
 
             thread::spawn(move || {
                 let mut rng = thread_rng();
-                let num_steps = rng.gen_range(1, 10);
+                let num_steps = rng.gen_range(1..10);
                 for _ in 0..num_steps {
                     if rng.gen::<bool>() {
                         counter.inc();

--- a/tests/demo/bounded_buffer.rs
+++ b/tests/demo/bounded_buffer.rs
@@ -149,10 +149,10 @@ fn test_bounded_buffer_find_deadlock_configuration() {
         move || {
             let mut rng = thread_rng();
 
-            let buffer_size = rng.gen_range(0usize, 5) + 1;
-            let readers = rng.gen_range(0usize, 5) + 1;
-            let writers = rng.gen_range(0usize, 5) + 1;
-            let iterations = rng.gen_range(0usize, 10) + 1;
+            let buffer_size = rng.gen_range(0usize..5) + 1;
+            let readers = rng.gen_range(0usize..5) + 1;
+            let writers = rng.gen_range(0usize..5) + 1;
+            let iterations = rng.gen_range(0usize..10) + 1;
             let total_iterations = iterations * readers;
             let writer_iterations = total_iterations / writers;
             let remainder = total_iterations % writers;


### PR DESCRIPTION
<!-- Enter your PR description here -->

Projects that use latest version of `rand` crate are largely unable
    to use deterministic random generators from shuttle because `RngCore`
    and friends are incompatible between the latest version (0.6.4) and version
    that Shuttle uses (0.5.1).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.