### PR TITLE
Add descriptive error message when PCT rejects tests without concurrency

### DIFF
--- a/src/scheduler/pct.rs
+++ b/src/scheduler/pct.rs
@@ -68,9 +68,10 @@ impl Scheduler for PctScheduler {
         self.steps = 0;
 
         // On the first iteration, we run a simple oldest-task-first scheduler to determine a
-        // bound on the maximum number of steps. Once we have that, we can initialize PCT.
+        // lower bound on the maximum number of steps. Once we have that, we can initialize PCT.
+        // Note that we dynamically update the bound if we discover an execution with more steps.
         if self.iterations > 0 {
-            assert!(self.max_steps > 0);
+            assert!(self.max_steps > 0, "test closure did not exercise any concurrency");
 
             // Priorities are always distinct
             debug_assert_eq!(

--- a/tests/basic/pct.rs
+++ b/tests/basic/pct.rs
@@ -1,6 +1,6 @@
 use shuttle::scheduler::PctScheduler;
 use shuttle::sync::Mutex;
-use shuttle::{check_random, thread, Config, MaxSteps, Runner};
+use shuttle::{check_pct, check_random, thread, Config, MaxSteps, Runner};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -244,4 +244,10 @@ fn figure_1c() {
             assert_eq!(*a + *b, 0);
         });
     });
+}
+
+#[test]
+#[should_panic(expected = "test closure did not exercise any concurrency")]
+fn no_concurrency() {
+    check_pct(|| {}, 10, 2);
 }


### PR DESCRIPTION
It is a sanity check to have some concurrency in every execution of the test closure. However, in PCT the assertion is really there to prevent an underflow. I'm not convinced that we should add similar assertions to other schedulers.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.