### PR TITLE
Implement `lazy_static` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.6.0 (January 24, 2023)
+
+This version renames the [`silence_atomic_ordering_warning` configuration option](https://docs.rs/shuttle/0.5.0/shuttle/struct.Config.html#structfield.silence_atomic_ordering_warning) to `silence_warnings`, as well as the corresponding environment variables, to enable future warnings to be controlled by the same mechanism.
+
+* Implement `lazy_static` support (#93)
+
 # 0.5.0 (November 22, 2022)
 
 This version updates the embedded `rand` library to v0.8.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"

--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -1,0 +1,82 @@
+//! Shuttle's implementation of the [`lazy_static`] crate, v1.4.0.
+//!
+//! Using this structure, it is possible to have `static`s that require code to be executed at
+//! runtime in order to be initialized. Lazy statics should be created with the
+//! [`lazy_static!`](crate::lazy_static!) macro.
+//!
+//! [`lazy_static`]: https://crates.io/crates/lazy_static
+
+use crate::runtime::execution::ExecutionState;
+use crate::runtime::storage::StorageKey;
+use crate::sync::Once;
+use std::marker::PhantomData;
+
+/// Shuttle's implementation of `lazy_static::Lazy` (aka the unstable `std::lazy::Lazy`).
+// Sadly, the fields of this thing need to be public because function pointers in const fns are
+// unstable, so an explicit instantiation is the only way to construct this struct. User code should
+// not rely on these fields.
+pub struct Lazy<T: Sync> {
+    #[doc(hidden)]
+    pub cell: Once,
+    #[doc(hidden)]
+    pub init: fn() -> T,
+    #[doc(hidden)]
+    pub _p: PhantomData<T>,
+}
+
+impl<T: Sync> std::fmt::Debug for Lazy<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Lazy").finish_non_exhaustive()
+    }
+}
+
+impl<T: Sync> Lazy<T> {
+    /// Get a reference to the lazy value, initializing it first if necessary.
+    pub fn get(&'static self) -> &T {
+        // Safety: see the usage below
+        unsafe fn extend_lt<'a, T>(t: &'a T) -> &'static T {
+            std::mem::transmute(t)
+        }
+
+        // We implement lazy statics by using a `Once` to mediate initialization of the static, just
+        // as the real implementation does. If two threads race on initializing the static, they
+        // will race on the `Once::call_once`, and only one of them will initialize the static. Once
+        // it's initialized, all future accesses can bypass the `Once` entirely and just access the
+        // storage cell.
+
+        let initialize = ExecutionState::with(|state| state.get_storage::<_, T>(self).is_none());
+
+        if initialize {
+            // There's not yet a value for this static, so try to initialize it (possibly racing)
+            self.cell.call_once(|| {
+                let value = (self.init)();
+                ExecutionState::with(|state| state.init_storage(self, value));
+            });
+        }
+
+        // At this point we're guaranteed that a value exists for this static, so read it
+        ExecutionState::with(|state| {
+            let value = state.get_storage(self).expect("should be initialized");
+            // Safety: this *isn't* safe. We are promoting to a `'static` lifetime here, but this
+            // object does not actually live that long. It would be possible for this reference to
+            // escape the client code and be used after it becomes invalid when the execution ends.
+            // But there's not really any way around this -- the semantics of static values and
+            // Shuttle executions are incompatible.
+            //
+            // In reality, this should be safe because any code that uses a Shuttle `lazy_static`
+            // probably uses a regular `lazy_static` in its non-test version, and if that version
+            // compiles then the Shuttle version is also safe. We choose this unsafe path because
+            // it's intended to be used only in testing code, which we want to remain as compatible
+            // with real-world code as possible and so needs to preserve the semantics of statics.
+            //
+            // See also https://github.com/tokio-rs/loom/pull/125
+            unsafe { extend_lt(value) }
+        })
+    }
+}
+
+impl<T: Sync> From<&Lazy<T>> for StorageKey {
+    fn from(lazy: &Lazy<T>) -> Self {
+        StorageKey(lazy as *const _ as usize, 0x3)
+    }
+}

--- a/src/sync/atomic/mod.rs
+++ b/src/sync/atomic/mod.rs
@@ -44,9 +44,8 @@
 //! correctness, the [Loom] crate provides support for reasoning about Acquire and Release orderings
 //! and partial support for Relaxed orderings.
 //!
-//! To disable the warning printed about this issue, set the `SHUTTLE_SILENCE_ORDERING_WARNING`
-//! environment variable to any value, or set the
-//! [`silence_atomic_ordering_warning`](crate::Config::silence_atomic_ordering_warning) field of
+//! To disable the warning printed about this issue, set the `SHUTTLE_SILENCE_WARNINGS` environment
+//! variable to any value, or set the [`silence_warnings`](crate::Config::silence_warnings) field of
 //! [`Config`](crate::Config) to true.
 //!
 //! [Loom]: https://crates.io/crates/loom
@@ -81,7 +80,7 @@ fn maybe_warn_about_ordering(order: Ordering) {
                 return;
             }
 
-            if ExecutionState::with(|state| state.config.silence_atomic_ordering_warning) {
+            if ExecutionState::with(|state| state.config.silence_warnings) {
                 return;
             }
 

--- a/tests/basic/lazy_static.rs
+++ b/tests/basic/lazy_static.rs
@@ -1,0 +1,226 @@
+use shuttle::scheduler::DfsScheduler;
+use shuttle::thread::ThreadId;
+use shuttle::{check_dfs, check_random, thread, Runner};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use test_log::test;
+
+#[test]
+fn basic() {
+    shuttle::lazy_static! {
+        static ref HASH_MAP: HashMap<u32, u32> = {
+            let mut m = HashMap::new();
+            m.insert(1, 1);
+            m
+        };
+    }
+
+    check_dfs(|| assert_eq!(HASH_MAP.get(&1), Some(&1)), None);
+}
+
+#[test]
+fn racing_init() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    shuttle::lazy_static! {
+        static ref HASH_MAP: HashMap<u32, u32> = {
+            let mut m = HashMap::new();
+            m.insert(1, 1);
+            COUNTER.fetch_add(1, Ordering::SeqCst);
+            m
+        };
+    }
+
+    check_dfs(
+        || {
+            let thds = (0..2)
+                .map(|_| {
+                    thread::spawn(move || {
+                        assert_eq!(HASH_MAP.get(&1), Some(&1));
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in thds {
+                thd.join().unwrap();
+            }
+
+            assert_eq!(COUNTER.swap(0, Ordering::SeqCst), 1);
+        },
+        None,
+    );
+}
+
+#[test]
+fn init_with_yield() {
+    shuttle::lazy_static! {
+        static ref THING: Arc<usize> = {
+            // check that it's valid to yield in the initializer
+            thread::yield_now();
+            Default::default()
+        };
+    }
+
+    check_dfs(
+        || {
+            let thd = thread::spawn(|| {
+                assert_eq!(**THING, 0);
+            });
+
+            assert_eq!(**THING, 0);
+
+            thd.join().unwrap();
+        },
+        None,
+    );
+}
+
+#[test]
+fn mutex_dfs() {
+    use std::sync::Mutex;
+
+    const NUM_THREADS: usize = 2;
+
+    shuttle::lazy_static! {
+        static ref THREADS: Mutex<Vec<ThreadId>> = Mutex::new(Vec::new());
+    }
+
+    let initializers = Arc::new(Mutex::new(HashSet::new()));
+    let initializers_clone = Arc::clone(&initializers);
+
+    check_dfs(
+        move || {
+            let thds = (0..NUM_THREADS)
+                .map(|_| {
+                    thread::spawn(|| {
+                        THREADS.lock().unwrap().push(thread::current().id());
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in thds {
+                thd.join().unwrap();
+            }
+
+            assert_eq!(THREADS.lock().unwrap().len(), NUM_THREADS);
+            initializers.lock().unwrap().insert(THREADS.lock().unwrap().clone());
+        },
+        None,
+    );
+
+    let initializers = Arc::try_unwrap(initializers_clone).unwrap().into_inner().unwrap();
+    assert_eq!(initializers.len(), (1..NUM_THREADS + 1).product::<usize>());
+}
+
+// Like `mutex_dfs` but with more threads, making it too expensive to do DFS
+#[test]
+fn mutex_random() {
+    use std::sync::Mutex;
+
+    const NUM_THREADS: usize = 4;
+
+    shuttle::lazy_static! {
+        static ref THREADS: Mutex<Vec<ThreadId>> = Mutex::new(Vec::new());
+    }
+
+    let initializers = Arc::new(Mutex::new(HashSet::new()));
+    let initializers_clone = Arc::clone(&initializers);
+
+    check_random(
+        move || {
+            let thds = (0..NUM_THREADS)
+                .map(|_| {
+                    thread::spawn(|| {
+                        THREADS.lock().unwrap().push(thread::current().id());
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            for thd in thds {
+                thd.join().unwrap();
+            }
+
+            assert_eq!(THREADS.lock().unwrap().len(), NUM_THREADS);
+            initializers.lock().unwrap().insert(THREADS.lock().unwrap().clone());
+        },
+        10000,
+    );
+
+    let initializers = Arc::try_unwrap(initializers_clone).unwrap().into_inner().unwrap();
+    // Not guaranteed, but should be pretty likely for 4 threads to see all 24 interleavings in
+    // 10000 iterations of a random scheduler
+    assert_eq!(initializers.len(), (1..NUM_THREADS + 1).product::<usize>());
+}
+
+#[test]
+fn chained() {
+    shuttle::lazy_static! {
+        static ref S1: Arc<usize> = Default::default();
+        static ref S2: Arc<usize> = Arc::new(**S1);
+    }
+
+    check_dfs(
+        move || {
+            let thd = thread::spawn(|| {
+                assert_eq!(**S2, 0);
+            });
+
+            assert_eq!(**S1, 0);
+
+            thd.join().unwrap();
+        },
+        None,
+    );
+}
+
+// Ensure that concurrent Shuttle tests see an isolated version of a lazy_static. This test is best
+// effort, as it spawns OS threads and hopes they race.
+#[test]
+fn shared_static() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    shuttle::lazy_static! {
+        static ref S: usize = {
+            COUNTER.fetch_add(1, Ordering::SeqCst);
+            0
+        };
+    }
+
+    let mut total_executions = 0;
+
+    // Try a bunch of times to provoke the race
+    for _ in 0..50 {
+        #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/7207
+        let threads = (0..3)
+            .map(|_| {
+                std::thread::spawn(move || {
+                    let scheduler = DfsScheduler::new(None, false);
+                    let runner = Runner::new(scheduler, Default::default());
+                    runner.run(move || {
+                        let thds = (0..2)
+                            .map(|_| {
+                                thread::spawn(move || {
+                                    assert_eq!(*S, 0);
+                                })
+                            })
+                            .collect::<Vec<_>>();
+
+                        for thd in thds {
+                            thd.join().unwrap();
+                        }
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        total_executions += threads.into_iter().map(|handle| handle.join().unwrap()).sum::<usize>();
+    }
+
+    // The static should be initialized exactly once per test execution, otherwise the tests are
+    // incorrectly sharing state
+    assert_eq!(total_executions, COUNTER.load(Ordering::SeqCst));
+}

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -5,6 +5,7 @@ mod condvar;
 mod config;
 mod dfs;
 mod execution;
+mod lazy_static;
 mod metrics;
 mod mpsc;
 mod mutex;


### PR DESCRIPTION
This change adds support for the `lazy_static` crate. It's mostly built around a `Once` cell for each static plus some global storage.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.