### PR TITLE
Add tag

### DIFF
--- a/src/current.rs
+++ b/src/current.rs
@@ -34,8 +34,11 @@ pub fn clock_for(task_id: TaskId) -> VectorClock {
 }
 
 /// Sets the `tag` field of the current task.
-pub fn set_tag_for_current_task(tag: Tag) {
+/// Returns the `tag` which was there previously.
+pub fn set_tag_for_current_task(tag: Tag) -> Tag {
+    let old_tag = get_tag_for_current_task();
     ExecutionState::set_tag_for_current_task(tag);
+    old_tag
 }
 
 /// Gets the `tag` field of the current task.

--- a/src/current.rs
+++ b/src/current.rs
@@ -22,7 +22,7 @@ pub fn context_switches() -> usize {
 
 /// Get the current thread's vector clock
 pub fn clock() -> VectorClock {
-    crate::runtime::execution::ExecutionState::with(|state| {
+    ExecutionState::with(|state| {
         let me = state.current();
         state.get_clock(me.id()).clone()
     })
@@ -36,9 +36,7 @@ pub fn clock_for(task_id: TaskId) -> VectorClock {
 /// Sets the `tag` field of the current task.
 /// Returns the `tag` which was there previously.
 pub fn set_tag_for_current_task(tag: Tag) -> Tag {
-    let old_tag = get_tag_for_current_task();
-    ExecutionState::set_tag_for_current_task(tag);
-    old_tag
+    ExecutionState::set_tag_for_current_task(tag)
 }
 
 /// Gets the `tag` field of the current task.
@@ -46,8 +44,7 @@ pub fn get_tag_for_current_task() -> Tag {
     ExecutionState::get_tag_for_current_task()
 }
 
-/// Gets the `TaskId` of the current task
-/// NOTE: Will panic if there is no current task.
-pub fn get_current_task() -> TaskId {
-    ExecutionState::me()
+/// Gets the `TaskId` of the current task, or `None` if there is no current task.
+pub fn get_current_task() -> Option<TaskId> {
+    ExecutionState::with(|s| Some(s.try_current()?.id()))
 }

--- a/src/current.rs
+++ b/src/current.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::clock::VectorClock;
-use crate::runtime::task::TaskId;
+pub use crate::runtime::task::{Tag, TaskId};
 
 /// The number of context switches that happened so far in the current Shuttle execution.
 ///
@@ -31,4 +31,19 @@ pub fn clock() -> VectorClock {
 /// Gets the clock for the thread with the given task ID
 pub fn clock_for(task_id: TaskId) -> VectorClock {
     ExecutionState::with(|state| state.get_clock(task_id).clone())
+}
+
+/// Sets the `tag` field of the current task.
+pub fn set_tag_for_current_task(tag: Tag) {
+    ExecutionState::set_tag_for_current_task(tag);
+}
+
+/// Gets the `tag` field of the current task.
+pub fn get_tag_for_current_task() -> Tag {
+    ExecutionState::get_tag_for_current_task()
+}
+
+/// Gets the `TaskId` of the current task
+pub fn get_current_task() -> TaskId {
+    ExecutionState::me()
 }

--- a/src/current.rs
+++ b/src/current.rs
@@ -44,6 +44,7 @@ pub fn get_tag_for_current_task() -> Tag {
 }
 
 /// Gets the `TaskId` of the current task
+/// NOTE: Will panic if there is no current task.
 pub fn get_current_task() -> TaskId {
     ExecutionState::me()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,13 +395,13 @@ where
 }
 
 /// Sets the `tag` field of the current task.
-pub fn set_tag(tag: i64) {
+pub fn set_tag(tag: u64) {
     use runtime::execution::ExecutionState;
     ExecutionState::set_tag(tag);
 }
 
 /// Gets the `tag` field of the current task.
-pub fn get_tag() -> i64 {
+pub fn get_tag() -> u64 {
     use runtime::execution::ExecutionState;
     ExecutionState::get_tag()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,30 +394,6 @@ where
     runner.run(f);
 }
 
-/// Sets the `tag` field of the current task.
-pub fn set_tag(tag: u64) {
-    use runtime::execution::ExecutionState;
-    ExecutionState::set_tag(tag);
-}
-
-/// Gets the `tag` field of the current task.
-pub fn get_tag() -> u64 {
-    use runtime::execution::ExecutionState;
-    ExecutionState::get_tag()
-}
-
-/// Gets the current step count.
-pub fn step_cnt() -> usize {
-    use runtime::execution::ExecutionState;
-    ExecutionState::step_cnt()
-}
-
-/// Gets the current step count.
-pub fn current_task_as_string() -> String {
-    use runtime::execution::ExecutionState;
-    ExecutionState::current_task_as_string()
-}
-
 /// Declare a new thread local storage key of type [`LocalKey`](crate::thread::LocalKey).
 #[macro_export]
 macro_rules! thread_local {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,6 +394,30 @@ where
     runner.run(f);
 }
 
+/// Sets the `tag` field of the current task.
+pub fn set_tag(tag: i64) {
+    use runtime::execution::ExecutionState;
+    ExecutionState::set_tag(tag);
+}
+
+/// Gets the `tag` field of the current task.
+pub fn get_tag() -> i64 {
+    use runtime::execution::ExecutionState;
+    ExecutionState::get_tag()
+}
+
+/// Gets the current step count.
+pub fn step_cnt() -> usize {
+    use runtime::execution::ExecutionState;
+    ExecutionState::step_cnt()
+}
+
+/// Gets the current step count.
+pub fn current_task_as_string() -> String {
+    use runtime::execution::ExecutionState;
+    ExecutionState::current_task_as_string()
+}
+
 /// Declare a new thread local storage key of type [`LocalKey`](crate::thread::LocalKey).
 #[macro_export]
 macro_rules! thread_local {

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -608,24 +608,24 @@ impl ExecutionState {
         });
     }
 
-    fn set_tag_internal(&mut self, tag: i64) {
+    fn set_tag_internal(&mut self, tag: u64) {
         self.current_mut().set_tag(tag);
     }
 
-    pub(crate) fn set_tag(tag: i64) {
+    pub(crate) fn set_tag(tag: u64) {
         ExecutionState::with(|s| {
             s.set_tag_internal(tag);
         });
     }
 
-    fn get_tag_internal(&self) -> i64 {
+    fn get_tag_internal(&self) -> u64 {
         match self.try_current() {
             Some(current) => current.get_tag(),
             None => 0,
         }
     }
 
-    pub(crate) fn get_tag() -> i64 {
+    pub(crate) fn get_tag() -> u64 {
         ExecutionState::with(|s| s.get_tag_internal())
     }
 

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -609,14 +609,14 @@ impl ExecutionState {
         });
     }
 
-    fn set_tag_for_current_task_internal(&mut self, tag: Tag) {
-        self.current_mut().set_tag(tag);
+    // Sets the `tag` field of the current task.
+    // Returns the `tag` which was there previously.
+    fn set_tag_for_current_task_internal(&mut self, tag: Tag) -> Tag {
+        self.current_mut().set_tag(tag)
     }
 
-    pub(crate) fn set_tag_for_current_task(tag: Tag) {
-        ExecutionState::with(|s| {
-            s.set_tag_for_current_task_internal(tag);
-        });
+    pub(crate) fn set_tag_for_current_task(tag: Tag) -> Tag {
+        ExecutionState::with(|s| s.set_tag_for_current_task_internal(tag))
     }
 
     fn get_tag_or_default_for_current_task(&self) -> Tag {

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -283,6 +283,7 @@ impl ExecutionState {
                 .map(|t| t.span.clone())
                 .unwrap_or_else(tracing::Span::current);
             let task_id = TaskId(state.tasks.len());
+            let tag = state.get_tag_internal();
             let clock = state.increment_clock_mut(); // Increment the parent's clock
             clock.extend(task_id); // and extend it with an entry for the new task
 
@@ -294,6 +295,7 @@ impl ExecutionState {
                 clock.clone(),
                 parent_span,
                 schedule_len,
+                tag,
             );
 
             state.tasks.push(task);
@@ -312,7 +314,7 @@ impl ExecutionState {
     {
         Self::with(|state| {
             let task_id = TaskId(state.tasks.len());
-
+            let tag = state.get_tag_internal();
             let clock = if let Some(ref mut clock) = initial_clock {
                 clock
             } else {
@@ -328,7 +330,7 @@ impl ExecutionState {
                 .try_current()
                 .map(|t| t.span.clone())
                 .unwrap_or_else(tracing::Span::current);
-            let task = Task::from_closure(f, stack_size, task_id, name, clock, parent_span, schedule_len);
+            let task = Task::from_closure(f, stack_size, task_id, name, clock, parent_span, schedule_len, tag);
             state.tasks.push(task);
             task_id
         })
@@ -604,6 +606,35 @@ impl ExecutionState {
                 self.current_schedule.push_task(tid);
             }
         });
+    }
+
+    fn set_tag_internal(&mut self, tag: i64) {
+        self.current_mut().set_tag(tag);
+    }
+
+    pub(crate) fn set_tag(tag: i64) {
+        ExecutionState::with(|s| {
+            s.set_tag_internal(tag);
+        });
+    }
+
+    fn get_tag_internal(&self) -> i64 {
+        match self.try_current() {
+            Some(current) => current.get_tag(),
+            None => 0,
+        }
+    }
+
+    pub(crate) fn get_tag() -> i64 {
+        ExecutionState::with(|s| s.get_tag_internal())
+    }
+
+    pub(crate) fn step_cnt() -> usize {
+        ExecutionState::with(|s| s.current_schedule.len())
+    }
+
+    pub(crate) fn current_task_as_string() -> String {
+        format!("{:?}", ExecutionState::me())
     }
 }
 

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -351,8 +351,10 @@ impl Task {
         self.tag
     }
 
-    pub(crate) fn set_tag(&mut self, tag: Tag) {
-        self.tag = tag;
+    /// Sets the `tag` field of the current task.
+    /// Returns the `tag` which was there previously.
+    pub(crate) fn set_tag(&mut self, tag: Tag) -> Tag {
+        std::mem::replace(&mut self.tag, tag)
     }
 }
 

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -59,6 +59,9 @@ pub(crate) struct Task {
 
     local_storage: StorageMap,
     pub(super) span: tracing::Span,
+
+    // Arbitrarily settable tag which is inherited from the parent.
+    tag: i64,
 }
 
 impl Task {
@@ -71,6 +74,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
+        tag: i64,
     ) -> Self
     where
         F: FnOnce() + Send + 'static,
@@ -100,6 +104,7 @@ impl Task {
             name,
             span,
             local_storage: StorageMap::new(),
+            tag,
         }
     }
 
@@ -111,11 +116,12 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
+        tag: i64,
     ) -> Self
     where
         F: FnOnce() + Send + 'static,
     {
-        Self::new(f, stack_size, id, name, clock, parent_span, schedule_len)
+        Self::new(f, stack_size, id, name, clock, parent_span, schedule_len, tag)
     }
 
     pub(crate) fn from_future<F>(
@@ -126,6 +132,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
+        tag: i64,
     ) -> Self
     where
         F: Future<Output = ()> + Send + 'static,
@@ -147,6 +154,7 @@ impl Task {
             clock,
             parent_span,
             schedule_len,
+            tag,
         )
     }
 
@@ -334,6 +342,14 @@ impl Task {
             // the token already is available, then this does nothing.
             self.park_state.token_available = true;
         }
+    }
+
+    pub(crate) fn get_tag(&self) -> i64 {
+        self.tag
+    }
+
+    pub(crate) fn set_tag(&mut self, tag: i64) {
+        self.tag = tag;
     }
 }
 

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -66,6 +66,7 @@ pub(crate) struct Task {
 
 impl Task {
     /// Create a task from a continuation
+    #[allow(clippy::too_many_arguments)]
     fn new<F>(
         f: F,
         stack_size: usize,
@@ -108,6 +109,7 @@ impl Task {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_closure<F>(
         f: F,
         stack_size: usize,
@@ -124,6 +126,7 @@ impl Task {
         Self::new(f, stack_size, id, name, clock, parent_span, schedule_len, tag)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_future<F>(
         future: F,
         stack_size: usize,

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -61,7 +61,7 @@ pub(crate) struct Task {
     pub(super) span: tracing::Span,
 
     // Arbitrarily settable tag which is inherited from the parent.
-    tag: u64,
+    tag: Tag,
 }
 
 impl Task {
@@ -74,7 +74,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
-        tag: u64,
+        tag: Tag,
     ) -> Self
     where
         F: FnOnce() + Send + 'static,
@@ -116,7 +116,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
-        tag: u64,
+        tag: Tag,
     ) -> Self
     where
         F: FnOnce() + Send + 'static,
@@ -132,7 +132,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
-        tag: u64,
+        tag: Tag,
     ) -> Self
     where
         F: Future<Output = ()> + Send + 'static,
@@ -344,12 +344,28 @@ impl Task {
         }
     }
 
-    pub(crate) fn get_tag(&self) -> u64 {
+    pub(crate) fn get_tag(&self) -> Tag {
         self.tag
     }
 
-    pub(crate) fn set_tag(&mut self, tag: u64) {
+    pub(crate) fn set_tag(&mut self, tag: Tag) {
         self.tag = tag;
+    }
+}
+
+/// A `Tag` is an arbitrarily settable value for each task.
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default, Hash, PartialOrd, Ord)]
+pub struct Tag(u64);
+
+impl From<u64> for Tag {
+    fn from(tag: u64) -> Self {
+        Tag(tag)
+    }
+}
+
+impl From<Tag> for u64 {
+    fn from(tag: Tag) -> u64 {
+        tag.0
     }
 }
 

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -61,7 +61,7 @@ pub(crate) struct Task {
     pub(super) span: tracing::Span,
 
     // Arbitrarily settable tag which is inherited from the parent.
-    tag: i64,
+    tag: u64,
 }
 
 impl Task {
@@ -74,7 +74,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
-        tag: i64,
+        tag: u64,
     ) -> Self
     where
         F: FnOnce() + Send + 'static,
@@ -116,7 +116,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
-        tag: i64,
+        tag: u64,
     ) -> Self
     where
         F: FnOnce() + Send + 'static,
@@ -132,7 +132,7 @@ impl Task {
         clock: VectorClock,
         parent_span: tracing::Span,
         schedule_len: usize,
-        tag: i64,
+        tag: u64,
     ) -> Self
     where
         F: Future<Output = ()> + Send + 'static,
@@ -344,11 +344,11 @@ impl Task {
         }
     }
 
-    pub(crate) fn get_tag(&self) -> i64 {
+    pub(crate) fn get_tag(&self) -> u64 {
         self.tag
     }
 
-    pub(crate) fn set_tag(&mut self, tag: i64) {
+    pub(crate) fn set_tag(&mut self, tag: u64) {
         self.tag = tag;
     }
 }

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -16,6 +16,7 @@ mod portfolio;
 mod replay;
 mod rwlock;
 mod shrink;
+mod tag;
 mod thread;
 mod timeout;
 mod uncontrolled_nondeterminism;

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -2,10 +2,10 @@ use futures::future::join_all;
 use shuttle::{check_random, future::block_on, get_tag, set_tag, thread};
 use test_log::test;
 
-fn spawn_some_futures_and_set_tag<F: (Fn(i64, i64) -> i64) + Send + Sync>(
-    tag_on_entry: i64,
+fn spawn_some_futures_and_set_tag<F: (Fn(u64, u64) -> u64) + Send + Sync>(
+    tag_on_entry: u64,
     f: &'static F,
-    num_threads: i64,
+    num_threads: u64,
 ) {
     let threads: Vec<_> = (0..num_threads)
         .map(|i| {
@@ -20,10 +20,10 @@ fn spawn_some_futures_and_set_tag<F: (Fn(i64, i64) -> i64) + Send + Sync>(
     block_on(join_all(threads));
 }
 
-fn spawn_some_threads_and_set_tag<F: (Fn(i64, i64) -> i64) + Send + Sync>(
-    tag_on_entry: i64,
+fn spawn_some_threads_and_set_tag<F: (Fn(u64, u64) -> u64) + Send + Sync>(
+    tag_on_entry: u64,
     f: &'static F,
-    num_threads: i64,
+    num_threads: u64,
 ) {
     let threads: Vec<_> = (0..num_threads)
         .map(|i| {
@@ -40,7 +40,7 @@ fn spawn_some_threads_and_set_tag<F: (Fn(i64, i64) -> i64) + Send + Sync>(
     assert!(get_tag() == tag_on_entry);
 }
 
-fn spawn_threads_which_spawn_more_threads(tag_on_entry: i64, num_threads: i64) {
+fn spawn_threads_which_spawn_more_threads(tag_on_entry: u64, num_threads: u64) {
     let threads: Vec<_> = (0..num_threads)
         .map(|i| {
             thread::spawn(move || {
@@ -49,11 +49,11 @@ fn spawn_threads_which_spawn_more_threads(tag_on_entry: i64, num_threads: i64) {
                 assert!(get_tag() == i);
                 spawn_some_threads_and_set_tag(i, &|_, _| 123, 13);
                 assert!(get_tag() == i);
-                spawn_some_threads_and_set_tag(i, &|_, x| x * -13, 7);
+                spawn_some_threads_and_set_tag(i, &|_, x| x * 13, 7);
                 assert!(get_tag() == i);
                 spawn_some_threads_and_set_tag(i, &|p, x| (p << 4) + x, 19);
                 assert!(get_tag() == i);
-                spawn_some_futures_and_set_tag(i, &|p, x| -(p << 4) + x, 17);
+                spawn_some_futures_and_set_tag(i, &|p, x| (p << 4) & x, 17);
                 assert!(get_tag() == i);
             })
         })

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -1,70 +1,111 @@
 use futures::future::join_all;
-use shuttle::{check_random, future::block_on, get_tag, set_tag, thread};
+use shuttle::{
+    check_random,
+    current::{get_tag_for_current_task, set_tag_for_current_task, Tag},
+    future::block_on,
+    thread,
+};
 use test_log::test;
 
-fn spawn_some_futures_and_set_tag<F: (Fn(u64, u64) -> u64) + Send + Sync>(
-    tag_on_entry: u64,
+fn spawn_some_futures_and_set_tag<F: (Fn(Tag, u64) -> Tag) + Send + Sync>(
+    tag_on_entry: Tag,
     f: &'static F,
     num_threads: u64,
 ) {
     let threads: Vec<_> = (0..num_threads)
         .map(|i| {
             shuttle::future::spawn(async move {
-                assert!(get_tag() == tag_on_entry);
-                set_tag(f(tag_on_entry, i));
-                assert!(get_tag() == f(tag_on_entry, i));
+                assert_eq!(get_tag_for_current_task(), tag_on_entry);
+                let new_tag = f(tag_on_entry, i);
+                set_tag_for_current_task(new_tag);
+                assert_eq!(get_tag_for_current_task(), new_tag);
             })
         })
         .collect();
 
     block_on(join_all(threads));
+
+    assert_eq!(get_tag_for_current_task(), tag_on_entry);
 }
 
-fn spawn_some_threads_and_set_tag<F: (Fn(u64, u64) -> u64) + Send + Sync>(
-    tag_on_entry: u64,
+fn spawn_some_threads_and_set_tag<F: (Fn(Tag, u64) -> Tag) + Send + Sync>(
+    tag_on_entry: Tag,
     f: &'static F,
     num_threads: u64,
 ) {
     let threads: Vec<_> = (0..num_threads)
         .map(|i| {
             thread::spawn(move || {
-                assert!(get_tag() == tag_on_entry);
-                set_tag(f(tag_on_entry, i));
-                assert!(get_tag() == f(tag_on_entry, i));
+                assert_eq!(get_tag_for_current_task(), tag_on_entry);
+                let new_tag = f(tag_on_entry, i);
+                set_tag_for_current_task(new_tag);
+                assert_eq!(get_tag_for_current_task(), new_tag);
             })
         })
         .collect();
 
     threads.into_iter().for_each(|t| t.join().expect("Failed"));
 
-    assert!(get_tag() == tag_on_entry);
+    assert_eq!(get_tag_for_current_task(), tag_on_entry);
 }
 
-fn spawn_threads_which_spawn_more_threads(tag_on_entry: u64, num_threads: u64) {
-    let threads: Vec<_> = (0..num_threads)
+fn spawn_threads_which_spawn_more_threads(
+    tag_on_entry: Tag,
+    num_threads_first_block: u64,
+    num_threads_second_block: u64,
+) {
+    let mut threads: Vec<_> = (0..num_threads_first_block)
         .map(|i| {
             thread::spawn(move || {
-                assert!(get_tag() == tag_on_entry);
-                set_tag(i);
-                assert!(get_tag() == i);
-                spawn_some_threads_and_set_tag(i, &|_, _| 123, 13);
-                assert!(get_tag() == i);
-                spawn_some_threads_and_set_tag(i, &|_, x| x * 13, 7);
-                assert!(get_tag() == i);
-                spawn_some_threads_and_set_tag(i, &|p, x| (p << 4) + x, 19);
-                assert!(get_tag() == i);
-                spawn_some_futures_and_set_tag(i, &|p, x| (p << 4) & x, 17);
-                assert!(get_tag() == i);
+                assert_eq!(get_tag_for_current_task(), tag_on_entry);
+                let new_tag = i.into();
+                set_tag_for_current_task(new_tag);
+                assert_eq!(get_tag_for_current_task(), new_tag);
+                spawn_some_threads_and_set_tag(new_tag, &|_, _| 123.into(), 13);
+                assert_eq!(get_tag_for_current_task(), new_tag);
+                spawn_some_threads_and_set_tag(new_tag, &|_, x| (x * 13).into(), 7);
+                assert_eq!(get_tag_for_current_task(), new_tag);
+                spawn_some_threads_and_set_tag(new_tag, &|p, x| ((u64::from(p) << 4) + x).into(), 19);
+                assert_eq!(get_tag_for_current_task(), new_tag);
+                spawn_some_futures_and_set_tag(new_tag, &|p, x| ((u64::from(p) << 4) & x).into(), 17);
+                assert_eq!(get_tag_for_current_task(), new_tag);
             })
         })
         .collect();
 
+    assert_eq!(get_tag_for_current_task(), tag_on_entry);
+
+    let new_tag_main_thread = 987654321.into();
+    set_tag_for_current_task(new_tag_main_thread);
+    assert_eq!(get_tag_for_current_task(), new_tag_main_thread);
+
+    threads.extend(
+        (0..num_threads_second_block)
+            .map(|i| {
+                thread::spawn(move || {
+                    assert_eq!(get_tag_for_current_task(), new_tag_main_thread);
+                    let new_tag = i.into();
+                    set_tag_for_current_task(new_tag);
+                    assert_eq!(get_tag_for_current_task(), new_tag);
+                    spawn_some_threads_and_set_tag(new_tag, &|_, _| 123.into(), 13);
+                    assert_eq!(get_tag_for_current_task(), new_tag);
+                    spawn_some_threads_and_set_tag(new_tag, &|_, x| (x * 13).into(), 7);
+                    assert_eq!(get_tag_for_current_task(), new_tag);
+                    spawn_some_threads_and_set_tag(new_tag, &|p, x| ((u64::from(p) << 4) + x).into(), 19);
+                    assert_eq!(get_tag_for_current_task(), new_tag);
+                    spawn_some_futures_and_set_tag(new_tag, &|p, x| ((u64::from(p) << 4) & x).into(), 17);
+                    assert_eq!(get_tag_for_current_task(), new_tag);
+                })
+            })
+            .collect::<Vec<_>>(),
+    );
+
     threads.into_iter().for_each(|t| t.join().expect("Failed"));
 
-    assert!(get_tag() == tag_on_entry);
+    assert_eq!(get_tag_for_current_task(), new_tag_main_thread);
 }
 
 #[test]
 fn threads_which_spawn_threads_which_spawn_threads() {
-    check_random(|| spawn_threads_which_spawn_more_threads(0, 15), 10)
+    check_random(|| spawn_threads_which_spawn_more_threads(Tag::default(), 15, 10), 10)
 }

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -1,6 +1,6 @@
 use futures::future::join_all;
 use shuttle::{
-    check_random,
+    check_dfs, check_random,
     current::{get_tag_for_current_task, set_tag_for_current_task, Tag},
     future::block_on,
     thread,
@@ -114,7 +114,7 @@ fn threads_which_spawn_threads_which_spawn_threads() {
 fn spawn_thread_and_set_tag(tag_on_entry: Tag, new_tag: Tag) -> JoinHandle<u64> {
     thread::spawn(move || {
         assert_eq!(get_tag_for_current_task(), tag_on_entry);
-        set_tag_for_current_task(new_tag);
+        assert_eq!(set_tag_for_current_task(new_tag), tag_on_entry); // NOTE: Assertion with side effect
         assert_eq!(get_tag_for_current_task(), new_tag);
         new_tag.into()
     })
@@ -131,5 +131,5 @@ fn spawn_and_join() {
 
 #[test]
 fn test_spawn_and_join() {
-    check_random(spawn_and_join, 20)
+    check_dfs(spawn_and_join, None);
 }

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -1,0 +1,70 @@
+use futures::future::join_all;
+use shuttle::{check_random, future::block_on, get_tag, set_tag, thread};
+use test_log::test;
+
+fn spawn_some_futures_and_set_tag<F: (Fn(i64, i64) -> i64) + Send + Sync>(
+    tag_on_entry: i64,
+    f: &'static F,
+    num_threads: i64,
+) {
+    let threads: Vec<_> = (0..num_threads)
+        .map(|i| {
+            shuttle::future::spawn(async move {
+                assert!(get_tag() == tag_on_entry);
+                set_tag(f(tag_on_entry, i));
+                assert!(get_tag() == f(tag_on_entry, i));
+            })
+        })
+        .collect();
+
+    block_on(join_all(threads));
+}
+
+fn spawn_some_threads_and_set_tag<F: (Fn(i64, i64) -> i64) + Send + Sync>(
+    tag_on_entry: i64,
+    f: &'static F,
+    num_threads: i64,
+) {
+    let threads: Vec<_> = (0..num_threads)
+        .map(|i| {
+            thread::spawn(move || {
+                assert!(get_tag() == tag_on_entry);
+                set_tag(f(tag_on_entry, i));
+                assert!(get_tag() == f(tag_on_entry, i));
+            })
+        })
+        .collect();
+
+    threads.into_iter().for_each(|t| t.join().expect("Failed"));
+
+    assert!(get_tag() == tag_on_entry);
+}
+
+fn spawn_threads_which_spawn_more_threads(tag_on_entry: i64, num_threads: i64) {
+    let threads: Vec<_> = (0..num_threads)
+        .map(|i| {
+            thread::spawn(move || {
+                assert!(get_tag() == tag_on_entry);
+                set_tag(i);
+                assert!(get_tag() == i);
+                spawn_some_threads_and_set_tag(i, &|_, _| 123, 13);
+                assert!(get_tag() == i);
+                spawn_some_threads_and_set_tag(i, &|_, x| x * -13, 7);
+                assert!(get_tag() == i);
+                spawn_some_threads_and_set_tag(i, &|p, x| (p << 4) + x, 19);
+                assert!(get_tag() == i);
+                spawn_some_futures_and_set_tag(i, &|p, x| -(p << 4) + x, 17);
+                assert!(get_tag() == i);
+            })
+        })
+        .collect();
+
+    threads.into_iter().for_each(|t| t.join().expect("Failed"));
+
+    assert!(get_tag() == tag_on_entry);
+}
+
+#[test]
+fn threads_which_spawn_threads_which_spawn_threads() {
+    check_random(|| spawn_threads_which_spawn_more_threads(0, 15), 10)
+}

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -108,7 +108,7 @@ fn spawn_threads_which_spawn_more_threads(
 
 #[test]
 fn threads_which_spawn_threads_which_spawn_threads() {
-    check_random(|| spawn_threads_which_spawn_more_threads(Tag::default(), 15, 10), 10)
+    check_random(|| spawn_threads_which_spawn_more_threads(Tag::default(), 3, 2), 10)
 }
 
 fn spawn_thread_and_set_tag(tag_on_entry: Tag, new_tag: Tag) -> JoinHandle<u64> {


### PR DESCRIPTION
### The general idea: 
Have each task store a tag which it inherits from its parent. This tag can then be used for debugging to track parenthood and to turn on/off printing (ie set tag once done with setup, set tag when entering/leaving a critical section, set tags for different kinds of tasks to track them differently, etc).

In addition to general debugging, there are a fair amount of things which can be built upon tags. 

One example is a "tag-aware" scheduler (or extending the current to be "tag-aware") which could enable encoding fairness or precedence properties (ie: if there exists a task with [such-and-such tag] then it will be scheduled [at least every N steps]) or custom deadlock properties (if there are no tasks with [such-and-such tag] which are scheduleable, then that is to be considered a deadlock). 

Another example is to be able to model partial failures, by crashing/aborting/not scheduling tasks with certain tags.

### About the current solution:

Currently adds what I think is roughly the minimal needed to be useful. Decided on `u64` because 1: fixed number of bits is nice for parenthood encoding schemes and 2: @jorajeev convinced me that signed integers are actually Not Good 3: something bigger/arbitrary boxed data etc. seems like overkill.

It also exposes `step_cnt` and `current_task_as_string`, which I have found super useful to have access to when debugging. For a bit more context, this started as a hack where I exposed `ExecutionState` and did something ala:
```rust
pub fn task_info() -> String {
        format!(
            "T: {} S: {} I: {:?} ",
            ExecutionState::get_tag(),
            ExecutionState::step_cnt(),
            ExecutionState::me()
        )
}

#[macro_export]
macro_rules! task_info {
    ($($tts:tt)*) => {{
        use $crate::runtime::execution::ExecutionState;
        print!(ExecutionState::task_info());
        print!($($tts)*);
    }};
}

#[macro_export]
macro_rules! prnt {
    ($test:expr, $($tts:tt)*) => {{
        use $crate::task_info;
        if $test {
            task_info!($($tts)*);
        }
    }};
}

#[macro_export]
macro_rules! prntln {
    ($test:expr, $($tts:tt)*) => {{
        use $crate::prnt;
        if $test {
            prnt!($test,$($tts)*);
            println!();
        }
    }};
}

#[macro_export]
macro_rules! t {
    () => {
        ExecutionState::get_colour()
    };
}
```

And then something ala `prntln!(t!() > 0, "GETTING LOCK")` at interesting points in the code.

As for the included test: fairly simple test which tests that tags are inherited and that tags don't "bleed", as well as a few different ways of setting the tags. Tests tags both for futures and threads.

Finally, one thing which was considered was to store a closure of type `u64 -> u64` which specifies how to generate the tag of the child, and then having it default to the identity function. Decided against it for now, as I have not needed it yet. There might be patterns where this could be useful, but I think the scheme of setting the tag immediately after a spawn is easier to comprehend, less error prone, more versatile, and not so much work that it is an issue.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.