### PR TITLE
Fix tracing spans

### DIFF
--- a/src/runtime/runner.rs
+++ b/src/runtime/runner.rs
@@ -52,6 +52,7 @@ impl<S: Scheduler + 'static> Runner<S> {
             let start = Instant::now();
 
             let mut i = 0;
+
             loop {
                 if self.config.max_time.map(|t| start.elapsed() > t).unwrap_or(false) {
                     break;

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -125,12 +125,12 @@ impl Task {
         name: Option<String>,
         clock: VectorClock,
         parent_span: &tracing::Span,
+        schedule_len: usize,
     ) -> Self
     where
         F: Future<Output = ()> + Send + 'static,
     {
         let mut future = Box::pin(future);
-        let schedule_len = ExecutionState::with(|state| state.current_schedule.len());
 
         Self::new(
             move || {

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -69,7 +69,7 @@ impl Task {
         id: TaskId,
         name: Option<String>,
         clock: VectorClock,
-        parent_span: &tracing::Span,
+        parent_span: tracing::Span,
         schedule_len: usize,
     ) -> Self
     where
@@ -82,7 +82,7 @@ impl Task {
         let continuation = Rc::new(RefCell::new(continuation));
 
         let span = if name == Some("main-thread".to_string()) {
-            parent_span.clone()
+            parent_span
         } else {
             tracing::info_span!(parent: parent_span.id(), "step", i = schedule_len, task = id.0)
         };
@@ -109,7 +109,7 @@ impl Task {
         id: TaskId,
         name: Option<String>,
         clock: VectorClock,
-        parent_span: &tracing::Span,
+        parent_span: tracing::Span,
         schedule_len: usize,
     ) -> Self
     where
@@ -124,7 +124,7 @@ impl Task {
         id: TaskId,
         name: Option<String>,
         clock: VectorClock,
-        parent_span: &tracing::Span,
+        parent_span: tracing::Span,
         schedule_len: usize,
     ) -> Self
     where

--- a/tests/basic/uncontrolled_nondeterminism.rs
+++ b/tests/basic/uncontrolled_nondeterminism.rs
@@ -227,36 +227,3 @@ fn iterate_over_hash_set(num_entries: u64) {
 fn hashset_without_set_seed() {
     check_uncontrolled_nondeterminism(|| iterate_over_hash_set(10), 1000);
 }
-
-use shuttle::check_random;
-use tracing::{warn, warn_span};
-
-#[test]
-fn tracing_nested_spans() {
-    check_random(
-        || {
-            let lock = Arc::new(Mutex::new(0));
-            let threads: Vec<_> = (0..3)
-                .map(|i| {
-                    let lock = lock.clone();
-                    thread::spawn(move || {
-                        let outer = warn_span!("outer", tid = i);
-                        let _outer = outer.enter();
-                        {
-                            let mut locked = lock.lock().unwrap();
-                            let inner = warn_span!("inner", tid = i);
-                            let _inner = inner.enter();
-                            warn!("incrementing from {}", *locked);
-                            *locked += 1;
-                        }
-                    })
-                })
-                .collect();
-
-            for thread in threads {
-                thread.join().unwrap();
-            }
-        },
-        10,
-    )
-}

--- a/tests/basic/uncontrolled_nondeterminism.rs
+++ b/tests/basic/uncontrolled_nondeterminism.rs
@@ -227,3 +227,36 @@ fn iterate_over_hash_set(num_entries: u64) {
 fn hashset_without_set_seed() {
     check_uncontrolled_nondeterminism(|| iterate_over_hash_set(10), 1000);
 }
+
+use shuttle::check_random;
+use tracing::{warn, warn_span};
+
+#[test]
+fn tracing_nested_spans() {
+    check_random(
+        || {
+            let lock = Arc::new(Mutex::new(0));
+            let threads: Vec<_> = (0..3)
+                .map(|i| {
+                    let lock = lock.clone();
+                    thread::spawn(move || {
+                        let outer = warn_span!("outer", tid = i);
+                        let _outer = outer.enter();
+                        {
+                            let mut locked = lock.lock().unwrap();
+                            let inner = warn_span!("inner", tid = i);
+                            let _inner = inner.enter();
+                            warn!("incrementing from {}", *locked);
+                            *locked += 1;
+                        }
+                    })
+                })
+                .collect();
+
+            for thread in threads {
+                thread.join().unwrap();
+            }
+        },
+        10,
+    )
+}


### PR DESCRIPTION
I guess this is easiest described by showing the output. Two lines of output with`RUST_LOG=trace` turned on before this change:
```
2023-03-30T01:30:25.407978Z TRACE execution{i=0}:spawn_some_futures_and_set_tag{num_threads=0}:spawn_some_threads_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=4}:spawn_some_threads_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=6}:spawn_some_threads_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=7}:spawn_some_futures_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=10}:spawn_some_threads_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=12}:spawn_some_threads_and_set_tag{num_threads=9}:spawn_some_threads_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=13}:spawn_some_threads_and_set_tag{num_threads=4}:spawn_some_threads_and_set_tag{num_threads=14}:spawn_some_threads_and_set_tag{num_threads=16}:spawn_some_threads_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=18}:spawn_some_threads_and_set_tag{num_threads=17}:spawn_some_threads_and_set_tag{num_threads=15}:spawn_some_threads_and_set_tag{num_threads=19}:spawn_some_futures_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=4}:spawn_some_threads_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=6}:spawn_some_futures_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=7}:spawn_some_threads_and_set_tag{num_threads=9}:spawn_some_futures_and_set_tag{num_threads=4}:spawn_some_futures_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=10}:spawn_some_threads_and_set_tag{num_threads=7}:spawn_some_threads_and_set_tag{num_threads=6}:spawn_some_threads_and_set_tag{num_threads=16}:spawn_some_threads_and_set_tag{num_threads=14}:spawn_some_threads_and_set_tag{num_threads=9}:spawn_some_threads_and_set_tag{num_threads=15}:spawn_some_threads_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=12}:spawn_some_futures_and_set_tag{num_threads=7}:spawn_some_futures_and_set_tag{num_threads=6}:spawn_some_threads_and_set_tag{num_threads=10}:spawn_some_threads_and_set_tag{num_threads=13}:spawn_some_threads_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=17}:spawn_some_threads_and_set_tag{num_threads=18}:spawn_some_futures_and_set_tag{num_threads=9}:spawn_some_threads_and_set_tag{num_threads=19}:spawn_some_threads_and_set_tag{num_threads=16}:spawn_some_threads_and_set_tag{num_threads=14}:spawn_some_futures_and_set_tag{num_threads=10}:spawn_some_futures_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=15}:spawn_some_futures_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=12}:spawn_some_threads_and_set_tag{num_threads=13}: shuttle::thread: done dropping thread locals
2023-03-30T01:30:25.410818Z TRACE execution{i=0}:spawn_some_futures_and_set_tag{num_threads=0}:spawn_some_threads_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=4}:spawn_some_threads_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=6}:spawn_some_threads_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=7}:spawn_some_futures_and_set_tag{num_threads=1}:spawn_some_threads_and_set_tag{num_threads=10}:spawn_some_threads_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=12}:spawn_some_threads_and_set_tag{num_threads=9}:spawn_some_threads_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=13}:spawn_some_threads_and_set_tag{num_threads=4}:spawn_some_threads_and_set_tag{num_threads=14}:spawn_some_threads_and_set_tag{num_threads=16}:spawn_some_threads_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=18}:spawn_some_threads_and_set_tag{num_threads=17}:spawn_some_threads_and_set_tag{num_threads=15}:spawn_some_threads_and_set_tag{num_threads=19}:spawn_some_futures_and_set_tag{num_threads=2}:spawn_some_threads_and_set_tag{num_threads=4}:spawn_some_threads_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=6}:spawn_some_futures_and_set_tag{num_threads=3}:spawn_some_threads_and_set_tag{num_threads=7}:spawn_some_threads_and_set_tag{num_threads=9}:spawn_some_futures_and_set_tag{num_threads=4}:spawn_some_futures_and_set_tag{num_threads=5}:spawn_some_threads_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=10}:spawn_some_threads_and_set_tag{num_threads=7}:spawn_some_threads_and_set_tag{num_threads=6}:spawn_some_threads_and_set_tag{num_threads=16}:spawn_some_threads_and_set_tag{num_threads=14}:spawn_some_threads_and_set_tag{num_threads=9}:spawn_some_threads_and_set_tag{num_threads=15}:spawn_some_threads_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=12}:spawn_some_futures_and_set_tag{num_threads=7}:spawn_some_futures_and_set_tag{num_threads=6}:spawn_some_threads_and_set_tag{num_threads=10}:spawn_some_threads_and_set_tag{num_threads=13}:spawn_some_threads_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=17}:spawn_some_threads_and_set_tag{num_threads=18}:spawn_some_futures_and_set_tag{num_threads=9}:spawn_some_threads_and_set_tag{num_threads=19}:spawn_some_threads_and_set_tag{num_threads=16}:spawn_some_threads_and_set_tag{num_threads=14}:spawn_some_futures_and_set_tag{num_threads=10}:spawn_some_futures_and_set_tag{num_threads=11}:spawn_some_threads_and_set_tag{num_threads=15}:spawn_some_futures_and_set_tag{num_threads=8}:spawn_some_threads_and_set_tag{num_threads=12}:spawn_some_threads_and_set_tag{num_threads=13}: shuttle::runtime::execution: runnable=[TaskId(0), TaskId(48), TaskId(56), TaskId(67), TaskId(73), TaskId(91), TaskId(110), TaskId(112), TaskId(113), TaskId(600)] next_task=Some(TaskId(113))
```

and after:

```
2023-03-30T01:33:26.796829Z TRACE spawn_some_futures_and_set_tag{num_threads=19}: shuttle::runtime::execution: runnable=[TaskId(51), TaskId(106), TaskId(123), TaskId(130), TaskId(133), TaskId(705), TaskId(706), TaskId(707), TaskId(708)] next_task=Some(TaskId(51))
2023-03-30T01:33:26.796928Z TRACE spawn_some_threads_and_set_tag{num_threads=15}: shuttle::runtime::execution: runnable=[TaskId(51), TaskId(106), TaskId(123), TaskId(130), TaskId(133), TaskId(705), TaskId(706), TaskId(707), TaskId(708)] next_task=Some(TaskId(130))
```

As for testing: I did start making the test which I used during development into a test where everything was automatic by turning on tracing and then capturing the output. This turned out to be quite hacky and required pulling in dependencies, so I decided to abandon it. If this code should break for some reason, then that does not pose a correctness issue, so no big need to have a test.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.