### PR TITLE
Support spurious wakeups for `thread::park`

### DIFF
--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -76,7 +76,7 @@ impl Barrier {
         if state.waiters.len() + 1 < state.bound {
             // Block current thread
             assert!(state.waiters.insert(me)); // current thread shouldn't already be in the set
-            ExecutionState::with(|s| s.current_mut().block());
+            ExecutionState::with(|s| s.current_mut().block(false));
             trace!(leader=?state.leader, waiters=?state.waiters, "blocked on barrier {:?}", self);
         } else {
             trace!(leader=?state.leader, waiters=?state.waiters, "releasing waiters on barrier {:?}", self);

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -170,7 +170,7 @@ impl<T> Channel<T> {
                 me,
                 self,
             );
-            ExecutionState::with(|s| s.current_mut().block());
+            ExecutionState::with(|s| s.current_mut().block(false));
             drop(state);
 
             thread::switch();
@@ -283,7 +283,7 @@ impl<T> Channel<T> {
                 me,
                 self,
             );
-            ExecutionState::with(|s| s.current_mut().block());
+            ExecutionState::with(|s| s.current_mut().block(false));
             drop(state);
 
             thread::switch();

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -68,7 +68,7 @@ impl<T: ?Sized> Mutex<T> {
             // runnable and could have been chosen by the scheduler instead. Also, if we want to
             // re-acquire the lock immediately after releasing it, we know that the release had a
             // context switch that allowed other threads to acquire in between.
-            ExecutionState::with(|s| s.current_mut().block());
+            ExecutionState::with(|s| s.current_mut().block(false));
             thread::switch();
             state = self.state.borrow_mut();
 
@@ -84,7 +84,7 @@ impl<T: ?Sized> Mutex<T> {
         ExecutionState::with(|s| {
             // Re-block all other waiting threads, since we won the race to take this lock
             for tid in state.waiters.iter() {
-                s.get_mut(tid).block();
+                s.get_mut(tid).block(false);
             }
 
             // Update acquiring thread's clock with the clock stored in the Mutex
@@ -151,7 +151,7 @@ impl<T: ?Sized> Mutex<T> {
             // Re-block all other waiting threads, since we won the race to take this lock
             ExecutionState::with(|s| {
                 for tid in state.waiters.iter() {
-                    s.get_mut(tid).block();
+                    s.get_mut(tid).block(false);
                 }
             });
 

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -194,7 +194,7 @@ impl<T: ?Sized> RwLock<T> {
                 if *writer == me {
                     panic!("deadlock! task {:?} tried to acquire a RwLock it already holds", me);
                 }
-                ExecutionState::with(|s| s.current_mut().block());
+                ExecutionState::with(|s| s.current_mut().block(false));
                 true
             }
             RwLockHolder::Read(readers) => {
@@ -202,7 +202,7 @@ impl<T: ?Sized> RwLock<T> {
                     panic!("deadlock! task {:?} tried to acquire a RwLock it already holds", me);
                 }
                 if typ == RwLockType::Write {
-                    ExecutionState::with(|s| s.current_mut().block());
+                    ExecutionState::with(|s| s.current_mut().block(false));
                     true
                 } else {
                     false
@@ -344,13 +344,13 @@ impl<T: ?Sized> RwLock<T> {
         if typ == RwLockType::Write {
             for tid in state.waiting_readers.iter() {
                 assert_ne!(tid, me);
-                ExecutionState::with(|s| s.get_mut(tid).block());
+                ExecutionState::with(|s| s.get_mut(tid).block(false));
             }
         }
         // Always block any waiting writers
         for tid in state.waiting_writers.iter() {
             assert_ne!(tid, me);
-            ExecutionState::with(|s| s.get_mut(tid).block());
+            ExecutionState::with(|s| s.get_mut(tid).block(false));
         }
     }
 

--- a/tests/future/basic.rs
+++ b/tests/future/basic.rs
@@ -1,6 +1,5 @@
 use futures::{try_join, Future};
-use shuttle::sync::Mutex;
-use shuttle::thread::park;
+use shuttle::sync::{Barrier, Mutex};
 use shuttle::{check_dfs, check_random, future, scheduler::PctScheduler, thread, Runner};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -188,7 +187,7 @@ fn join_handle_abort() {
             let t1 = future::spawn({
                 let counter = Arc::clone(&counter);
                 async move {
-                    park();
+                    Barrier::new(2).wait();
                     counter.fetch_add(1, Ordering::SeqCst)
                 }
             });


### PR DESCRIPTION
The documentation for `std::thread::park`
(https://doc.rust-lang.org/stable/std/thread/fn.park.html) has the following sentences regarding spurious wakeups:

> The `thread::park` function blocks the current thread unless or
> until the token is available for its thread handle, at which point
> it atomically consumes the token. It may also return spuriously,
> without consuming the token.

The documentation goes on to state:

> Notice that being unblocked does not imply any synchronization with
> someone that unparked this thread, it could also be spurious. For
> example, it would be a valid, but inefficient, implementation to
> make both park and unpark return immediately without doing anything.

Shuttle does not currently implement spurious wakeups for `thread::park`, making it possible for Shuttle to miss bugs in programs that (erroneously) rely on spurious wakeups not happening.

As an example, take the following code from
`tests/basic/thread.rs:thread_park`.  The test assumes that when `park` returns, the `flag` will have been set to true by the main thread. This is not correct since `park` can spuriously wakeup and should not be used for synchronization.  Shuttle does not find this case because it doesn't support spurious wakeups.

```rust
let flag = Arc::new(AtomicBool::new(false));
let thd = {
    let flag = Arc::clone(&flag);
    thread::spawn(move || {
        thread::park();
        assert!(flag.load(Ordering::SeqCst));
    })
};

flag.store(true, Ordering::SeqCst);
thd.thread().unpark();
thd.join().unwrap();
```

This commit adds support to Shuttle for spuriously waking up blocked threads. Not all causes of blocking can have spurious wakeups---for now, only `thread::park` is allowed to do so.

Spurious wakeup support is implemented by treating a subset of blocked tasks as being runnable from the perspective of the scheduler. However, unlike regular runnable threads, blocked threads that could be spuriously woken up do not count as being live for the purposes of deadlock detection. This is because spurious wakeups are not _guaranteed_ to happen, and correct programs should not rely on spurious wakeups to get out of deadlocks.

This commit updates the tests in `tests/basic/thread.rs` and adds a few new ones related to the spurious wakeup case. The erroneous test described above has been changed to `#[must_panic]`, an there is now a separate "fixed" version of the test that checks the flag in a loop.

Follow-up work:

- We should also change `Condvar::wait` to allow for spurious wakeups.

- We could change `thread::park_timeout` so that Shuttle won't treat it as a deadlock if there are threads blocked in `park_timeout` under the assumption the timeout will eventually fire. (This commit does not change the behavior compared to the previous logic, which treats `park_timeout` exactly like `park`.)

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.