### PR TITLE
Split schedule output over multiple lines

### DIFF
--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -72,7 +72,7 @@ fn persist_failure_inner(schedule: &Schedule, message: String, config: &Config) 
         }
     }
     format!(
-        "{}\nfailing schedule: \"{}\"\npass that string to `shuttle::replay` to replay the failure",
+        "{}\nfailing schedule:\n\"\n{}\n\"\npass that string to `shuttle::replay` to replay the failure",
         message, serialized_schedule
     )
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -111,8 +111,22 @@ mod parse_schedule {
     }
 
     pub(super) fn from_stdout<S: AsRef<String>>(output: S) -> Option<String> {
-        let string_regex = Regex::new("failing schedule: \"([0-9a-f]+)\"").unwrap();
-        let captures = string_regex.captures(output.as_ref().as_str())?;
-        Some(captures.get(1)?.as_str().to_string())
+        let mut schedule = String::new();
+        let mut lines = output.as_ref().lines();
+        for line in &mut lines {
+            if line.eq("failing schedule:") {
+                break;
+            }
+        }
+        assert_eq!(lines.next().unwrap(), "\"");
+        for line in lines {
+            if line.eq("\"") {
+                schedule.pop(); // trailing newline, if any
+                return Some(schedule);
+            }
+            schedule.push_str(line);
+            schedule.push('\n');
+        }
+        None
     }
 }


### PR DESCRIPTION
Failing schedules can be long, and printing them on a single long line can be a problem (e.g., #100).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.