### PR TITLE
Fix FuturesUnordered

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -131,9 +131,10 @@ where
                     drop(local);
                 }
 
-                self.inner.lock().unwrap().result = Some(Ok(result));
+                let mut lock = self.inner.lock().unwrap();
+                lock.result = Some(Ok(result));
 
-                if let Some(waker) = self.inner.lock().unwrap().waker.take() {
+                if let Some(waker) = lock.waker.take() {
                     waker.wake();
                 }
 

--- a/tests/future/mod.rs
+++ b/tests/future/mod.rs
@@ -2,4 +2,5 @@ mod basic;
 mod channel;
 mod countdown_timer;
 mod pct;
+mod streams;
 mod waker;

--- a/tests/future/streams.rs
+++ b/tests/future/streams.rs
@@ -1,12 +1,12 @@
 use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
 use shuttle::{
-    check_random,
+    check_dfs,
     future::{block_on, spawn},
 };
 
 fn futures_unordered_collect() {
     block_on(async {
-        let tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
+        let tasks = (0..2).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
 
         let _ = tasks.collect::<Vec<_>>().await;
     });
@@ -14,12 +14,12 @@ fn futures_unordered_collect() {
 
 #[test]
 fn collect_empty_tasks() {
-    check_random(futures_unordered_collect, 100);
+    check_dfs(futures_unordered_collect, None);
 }
 
 fn futures_unordered_next() {
     block_on(async {
-        let mut tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
+        let mut tasks = (0..2).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
 
         while let Some(result) = tasks.next().await {
             result.unwrap();
@@ -29,12 +29,12 @@ fn futures_unordered_next() {
 
 #[test]
 fn next_empty_tasks() {
-    check_random(futures_unordered_next, 100);
+    check_dfs(futures_unordered_next, None);
 }
 
 fn futures_join_all() {
     block_on(async {
-        let tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
+        let tasks = (0..2).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
 
         join_all(tasks)
             .await
@@ -46,5 +46,5 @@ fn futures_join_all() {
 
 #[test]
 fn join_all_empty_tasks() {
-    check_random(futures_join_all, 100);
+    check_dfs(futures_join_all, None);
 }

--- a/tests/future/streams.rs
+++ b/tests/future/streams.rs
@@ -1,0 +1,50 @@
+use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
+use shuttle::{
+    check_random,
+    future::{block_on, spawn},
+};
+
+fn futures_unordered_collect() {
+    block_on(async {
+        let tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
+
+        let _ = tasks.collect::<Vec<_>>().await;
+    });
+}
+
+#[test]
+fn collect_empty_tasks() {
+    check_random(futures_unordered_collect, 100);
+}
+
+fn futures_unordered_next() {
+    block_on(async {
+        let mut tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
+
+        while let Some(result) = tasks.next().await {
+            result.unwrap();
+        }
+    });
+}
+
+#[test]
+fn next_empty_tasks() {
+    check_random(futures_unordered_next, 100);
+}
+
+fn futures_join_all() {
+    block_on(async {
+        let tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
+
+        join_all(tasks)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+    });
+}
+
+#[test]
+fn join_all_empty_tasks() {
+    check_random(futures_join_all, 100);
+}


### PR DESCRIPTION
Currently, code using FuturesUnordered has a chance to cause Shuttle to erroneously report a deadlock.

For instance, if we take the following code:
```rust
  shuttle::future::block_on(async {
        let mut tasks = (0..100).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();

        while let Some(result) = tasks.next().await {
            result.unwrap();
        }
    });
```
When we call `next()` on a task, that task gets dequeued from the `ready_to_run_queue` inside `FuturesUnordered`. If that task is `Poll::Ready`, then all is fine. If it is `Poll::Pending` (in the case where we call `next()` before the `spawn` has had a chance to execute) however, then the task is never polled again, as we don't wake the associated waker.

This PR seeks to solve this issue by waking the waker, which is stored together with the result in the `Wrapper`.

Currently the test suite is a bit lacking, and only contains three tests of common patterns with futures that don't do anything.  I have some more tests locally, but they are really just reskins of existing tests, so I am not entirely sure they check any interesting behaviour. I want to add some more interesting tests, so going to look at that next. If anyone has any suggestions, then I am all ears. Also putting this out here to get feedback on the solution in general.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.