### PR TITLE
Make {Mutex, Condvar, RwLock}::new const

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["concurrency", "lock", "thread", "async"]
 categories = ["asynchronous", "concurrency", "development-tools::testing"]
 
 [dependencies]
+assoc = "0.1.3"
 bitvec = "1.0.1"
 generator = "0.7.1"
 hex = "0.4.2"
@@ -17,7 +18,7 @@ rand_core = "0.6.4"
 rand = "0.8.5"
 rand_pcg = "0.3.1"
 scoped-tls = "1.0.0"
-smallvec = "1.6.1"
+smallvec = { version = "1.10.0", features = ["const_new"] }
 tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 
 [dev-dependencies]

--- a/src/runtime/task/clock.rs
+++ b/src/runtime/task/clock.rs
@@ -8,8 +8,10 @@ pub struct VectorClock {
 }
 
 impl VectorClock {
-    pub(crate) fn new() -> Self {
-        Self { time: SmallVec::new() }
+    pub(crate) const fn new() -> Self {
+        Self {
+            time: SmallVec::new_const(),
+        }
     }
 
     #[cfg(test)]

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -427,10 +427,8 @@ pub(crate) struct TaskSet {
 }
 
 impl TaskSet {
-    pub fn new() -> Self {
-        Self {
-            tasks: BitVec::from_bitslice(bits![0; DEFAULT_INLINE_TASKS]),
-        }
+    pub const fn new() -> Self {
+        Self { tasks: BitVec::EMPTY }
     }
 
     pub fn contains(&self, tid: TaskId) -> bool {
@@ -446,7 +444,7 @@ impl TaskSet {
     /// the set did have this value present, `false` is returned.
     pub fn insert(&mut self, tid: TaskId) -> bool {
         if tid.0 >= self.tasks.len() {
-            self.tasks.resize(1 + tid.0, false);
+            self.tasks.resize(DEFAULT_INLINE_TASKS.max(1 + tid.0), false);
         }
         !std::mem::replace(&mut *self.tasks.get_mut(tid.0).unwrap(), true)
     }

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -6,13 +6,12 @@ use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::ops::{Deref, DerefMut};
 use std::panic::{RefUnwindSafe, UnwindSafe};
-use std::rc::Rc;
 use std::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
 use tracing::trace;
 
 /// A mutex, the same as [`std::sync::Mutex`].
 pub struct Mutex<T: ?Sized> {
-    state: Rc<RefCell<MutexState>>,
+    state: RefCell<MutexState>,
     inner: std::sync::Mutex<T>,
 }
 
@@ -31,7 +30,7 @@ struct MutexState {
 
 impl<T> Mutex<T> {
     /// Creates a new mutex in an unlocked state ready for use.
-    pub fn new(value: T) -> Self {
+    pub const fn new(value: T) -> Self {
         let state = MutexState {
             holder: None,
             waiters: TaskSet::new(),
@@ -40,7 +39,7 @@ impl<T> Mutex<T> {
 
         Self {
             inner: std::sync::Mutex::new(value),
-            state: Rc::new(RefCell::new(state)),
+            state: RefCell::new(state),
         }
     }
 }


### PR DESCRIPTION
These constructors have been const since Rust 1.63
(https://github.com/rust-lang/rust/issues/93740). It's pretty easy for
us to make them const too, which allows code that relies on them being
const to correctly compile with Shuttle.

The one exception is that HashMap::new isn't const, and our Condvar
implementation uses a HashMap to track waiters. I took the easy way out
and just used a vector as an association list instead -- we shouldn't
expect large numbers of waiters on the same condvar, so this shouldn't
be too inefficient.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.