### PR TITLE
Bump `futures` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing = { version = "0.1.21", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
-futures = "0.3.5"
+futures = "0.3.15"
 proptest = "1.0.0"
 regex = "1.5.5"
 tempfile = "3.2.0"

--- a/tests/future/streams.rs
+++ b/tests/future/streams.rs
@@ -1,50 +1,57 @@
 use futures::{future::join_all, stream::FuturesUnordered, StreamExt};
 use shuttle::{
     check_dfs,
-    future::{block_on, spawn},
+    future::{block_on, spawn, JoinHandle},
 };
 
-fn futures_unordered_collect() {
-    block_on(async {
-        let tasks = (0..2).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
-
-        let _ = tasks.collect::<Vec<_>>().await;
-    });
+fn empty_tasks() -> FuturesUnordered<JoinHandle<()>> {
+    (0..2).map(|_| spawn(async move {})).collect()
 }
 
 #[test]
 fn collect_empty_tasks() {
-    check_dfs(futures_unordered_collect, None);
-}
+    check_dfs(
+        || {
+            block_on(async {
+                let tasks = empty_tasks();
 
-fn futures_unordered_next() {
-    block_on(async {
-        let mut tasks = (0..2).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
-
-        while let Some(result) = tasks.next().await {
-            result.unwrap();
-        }
-    });
+                let _ = tasks.collect::<Vec<_>>().await;
+            })
+        },
+        None,
+    );
 }
 
 #[test]
 fn next_empty_tasks() {
-    check_dfs(futures_unordered_next, None);
-}
+    check_dfs(
+        || {
+            block_on(async {
+                let mut tasks = empty_tasks();
 
-fn futures_join_all() {
-    block_on(async {
-        let tasks = (0..2).map(|_| spawn(async move {})).collect::<FuturesUnordered<_>>();
-
-        join_all(tasks)
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .unwrap();
-    });
+                while let Some(result) = tasks.next().await {
+                    result.unwrap();
+                }
+            })
+        },
+        None,
+    );
 }
 
 #[test]
 fn join_all_empty_tasks() {
-    check_dfs(futures_join_all, None);
+    check_dfs(
+        || {
+            block_on(async {
+                let tasks = empty_tasks();
+
+                join_all(tasks)
+                    .await
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+            })
+        },
+        None,
+    );
 }


### PR DESCRIPTION
We have a test that relies on `FuturesUnordered` implementing `IntoIter`, but this is only the case since 0.3.15 (https://github.com/rust-lang/futures-rs/blob/master/CHANGELOG.md#0315---2021-05-11).

I also refactored the `FuturesUnordered` tests a bit. I would have liked to further refactor to have a single function that takes a closure for the way we await on the `FuturesUnordered`, but async closures are still unstable.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.