### PR TITLE
Implement Error trait for JoinError

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -8,9 +8,9 @@
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::TaskId;
 use crate::runtime::thread;
+use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
-use std::error::Error;
 use std::pin::Pin;
 use std::result::Result;
 use std::sync::Arc;
@@ -76,12 +76,12 @@ pub enum JoinError {
 impl Display for JoinError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            JoinError::Cancelled => write!(f, "task was cancelled")
+            JoinError::Cancelled => write!(f, "task was cancelled"),
         }
     }
 }
 
-impl Error for JoinError { }
+impl Error for JoinError {}
 
 impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -8,7 +8,9 @@
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::TaskId;
 use crate::runtime::thread;
+use std::fmt::{Display, Formatter};
 use std::future::Future;
+use std::error::Error;
 use std::pin::Pin;
 use std::result::Result;
 use std::sync::Arc;
@@ -70,6 +72,16 @@ pub enum JoinError {
     /// Task was aborted
     Cancelled,
 }
+
+impl Display for JoinError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JoinError::Cancelled => write!(f, "task was cancelled")
+        }
+    }
+}
+
+impl Error for JoinError { }
 
 impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {


### PR DESCRIPTION
It makes it a drop-in replacement for tokio::task::JoinError. Currently it is not possible to use with frameworks like `anyhow` because their derived `from` implementation requires `as_dyn_error` method

This implementation is consistent with how Tokio implemented `Display`.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.