### PR TITLE
Enable custom tracing of TaskId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ pub mod scheduler;
 
 mod runtime;
 
+use current::{Tag, TaskId};
 pub use runtime::runner::{PortfolioRunner, Runner};
 
 /// Configuration parameters for Shuttle
@@ -220,6 +221,13 @@ pub struct Config {
     ///    may miss bugs
     /// 2. [`lazy_static` values are dropped](mod@crate::lazy_static) at the end of an execution
     pub silence_warnings: bool,
+
+    /// When Shuttle does calls to `trace!` or `panic!` on something which contains a `TaskId`, we
+    /// send the `TaskId` and the `Tag` of the associated `Task` through the closure. This enables
+    /// the user to both be able to print the `Tag` if they are utilizing tags, and to map the `Tag`
+    /// to something which is easier to read.
+    /// Defaults to returning the debug formatted version of the `TaskId`.
+    pub task_id_and_tag_to_string: fn(TaskId, Tag) -> String,
 }
 
 impl Config {
@@ -231,6 +239,7 @@ impl Config {
             max_steps: MaxSteps::FailAfter(1_000_000),
             max_time: None,
             silence_warnings: false,
+            task_id_and_tag_to_string: |task_id, _| format!("{task_id:?}"),
         }
     }
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -6,7 +6,7 @@ mod condvar;
 pub mod mpsc;
 mod mutex;
 mod once;
-mod rwlock;
+pub(crate) mod rwlock;
 
 pub use barrier::{Barrier, BarrierWaitResult};
 pub use condvar::{Condvar, WaitTimeoutResult};


### PR DESCRIPTION
NOTE: See https://github.com/awslabs/shuttle/pull/111 first. This is the old proposal.

Note: I think the better design probably is to move `Tag`s out of `Task` and store a separate mapping from `TaskId` to `Tag` which is globally accessible (optionally not moving `Tag`s out, and just double-storing if the closure is a `Some`), and then overriding `Debug` for `TaskId` in the case the closure is a `Some`.

Putting this PR out there in case people have opinions on the matter. Maybe others prefer this solution.

## What is this PR?

This PR adds a new field to `Config`: `task_id_and_tag_to_string: fn(TaskId, Tag) -> String`, and changes all calls to `trace!` and `panic!` to invoke this closure on the fields which contain a `TaskId`.

The motivation behind this change is to enable more meaningful traces and panics when using `Tag`s. For instance, before this change, you might see something like:
```
2023-05-30T15:33:28.688495Z TRACE execution{i=9}:step{i=4 task=3}:outer{tid=2}: shuttle::runtime::execution: runnable=[TaskId(1), TaskId(2), TaskId(3)] next_task=Some(TaskId(2))
```
And after this change you could have it say something along the lines of:
```
2023-05-30T15:33:28.688495Z TRACE execution{i=9}:step{i=4 task=3}:outer{tid=2}: shuttle::runtime::execution: runnable=[MAIN_TASK, BACKGROUND_TASK, UNTAGGED_TASK] next_task=BACKGROUND_TASK
```

## A slight "regression"

Tracing before and after this change with the default `Config` looks basically the same, except that the parts which are formatted with `{:?}` in the `format_` functions now have `""`s around them. Oh well.

## Alternative designs

For the field in the `Config`:
This has to be a closure to enable the use case where `Tag`s are dynamically generated (if not, then one could just provide a `HashMap` and look up into that). There is a case to be made for having it return something which implements `Debug`, as that would result in a bit less code + allows the user to be a bit more lazy when making the closure.

For the design over all:
There exists a different design which in some ways is better, but I cannot see a way to do it without either moving `ExecutionState` into an `UnsafeCell` (or do some other unsafe shenanigans), through moving `tasks` out of `ExecutionState`, or through moving `Tag`s out of `Task`. The idea is then to implement `Debug` for `TaskId`, and have it check 1. Whether a custom `task_id_and_tag_to_string` has been set. 2. If it has, then look up into the `tasks` to get its own `Tag`, and then call the `task_id_and_tag_to_string` closure, else do debug as it is now.

I made the start of the design which moves `tasks` out of `ExecutionState` here: https://github.com/sarsko/shuttle/commit/a03c199461191a612bf1f7d3fc1552a4be1b24f7, but it became ugly because I could not find a way to enforce that `ExecutionState` lives at least as long as the `tasks`, which meant that one cannot give out mutable borrows to parts of `tasks` if one has access to `ExecutionState`, which meant that I would have to rewrite a bunch of code.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.