### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ which included some breaking changes.
 
 # 0.4.0 (September 30, 2022)
 
-* Depdendency updates
+* Dependency updates
 
 # 0.3.0 (August 29, 2022)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub enum FailurePersistence {
 pub enum MaxSteps {
     /// Do not enforce any bound on the maximum number of steps
     None,
-    /// Fail the test (by panicing) after the given number of steps
+    /// Fail the test (by panicking) after the given number of steps
     FailAfter(usize),
     /// When the given number of steps is reached, stop the current iteration of the test and
     /// begin a new iteration

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -254,7 +254,7 @@ impl ExecutionState {
         Self::try_with(f).expect("Shuttle internal error: cannot access ExecutionState. are you trying to access a Shuttle primitive from outside a Shuttle test?")
     }
 
-    /// Like `with`, but returns None instead of panicing if there is no current ExecutionState or
+    /// Like `with`, but returns None instead of panicking if there is no current ExecutionState or
     /// if the current ExecutionState is already borrowed.
     #[inline]
     pub(crate) fn try_with<F, T>(f: F) -> Option<T>

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -9,7 +9,7 @@
 //! 1. If a panic occurs within `ExecutionState`, the panic hook might not be able to access the
 //!    execution state to retrieve the failing schedule, so we need to be careful about accessing it
 //!    and try to recover from this problem when the panic is later caught in
-//!    `ExecutionState::step`. We try wherever possible to avoid panicing in this state, but if it
+//!    `ExecutionState::step`. We try wherever possible to avoid panicking in this state, but if it
 //!    does happen we want to get useful output and not crash.
 //! 2. In addition to simply printing the failing schedule, we want to include it in the panic
 //!    payload wherever possible, so that we can parse it back out in tests (essentially we are

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -389,7 +389,7 @@ pub(crate) enum TaskState {
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub(crate) struct ParkState {
-    /// Whether the task's park token is curently available. If it's available, then the next time
+    /// Whether the task's park token is currently available. If it's available, then the next time
     /// the task calls `park`, the token will be atomically consumed and the task will continue
     /// executing. If it's not available, then the task will block until either another task makes
     /// it available with `unpark`, or a spurious wakeup occurs.

--- a/tests/basic/thread.rs
+++ b/tests/basic/thread.rs
@@ -602,7 +602,7 @@ fn thread_double_unpark() {
     assert_eq!(seen_unparks, HashSet::from([0, 1, 2]));
 }
 
-// Test that `unpark` won't unblock a thread for resons other than `park`, even if the blocked
+// Test that `unpark` won't unblock a thread for reasons other than `park`, even if the blocked
 // thread had called `park` before (and possible spuriously woke up).
 #[test]
 fn thread_unpark_after_spurious_wakeup() {


### PR DESCRIPTION
Fixes some typos found by `typos`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.