### PR TITLE
Fix spurious test failure in the uncontrolled nondeterminism tests

### DIFF
--- a/tests/basic/uncontrolled_nondeterminism.rs
+++ b/tests/basic/uncontrolled_nondeterminism.rs
@@ -90,11 +90,13 @@ fn spawn_random_amount_of_threads_dfs_shuttle_rand() {
 #[test]
 #[should_panic]
 fn spawn_random_amount_of_threads_dfs_regular_rand() {
-    let scheduler = DfsScheduler::new(None, true);
-    check_uncontrolled_nondeterminism_custom_scheduler_and_config(
-        || spawn_random_amount_of_threads(&rand::thread_rng, 10),
-        scheduler,
-    );
+    for _ in 0..10 {
+        let scheduler = DfsScheduler::new(None, true);
+        check_uncontrolled_nondeterminism_custom_scheduler_and_config(
+            || spawn_random_amount_of_threads(&rand::thread_rng, 10),
+            scheduler,
+        );
+    }
 }
 
 fn spawn_random_amount_of_threads_mutex_rng(rng: &Mutex<StdRng>, max_threads: u64) {


### PR DESCRIPTION
There is an a bit over 1% chance that the `spawn_random_amount_of_threads_dfs_regular_rand` will fail. This happens when the first and the second run happen to generate the same order of random numbers. This is most common when 0 is generated for both runs (1/10 * 1/10), but there is a small chance it will happen for other sequences as well. This PR changes the test so that it is run 10 times, which decreases the chance of failure to somewhere in the range of $0.01^{10}$ - $0.02^{10}$.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.