### PR TITLE
Add `is_finished` method to `JoinHandle`

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -63,6 +63,17 @@ impl<T> JoinHandle<T> {
             }
         });
     }
+
+    /// Returns `true` if this task is finished, otherwise returns `false`.
+    ///
+    /// ## Panics
+    /// Panics if called outside of shuttle context, i.e. if there is no execution context.
+    pub fn is_finished(&self) -> bool {
+        ExecutionState::with(|state| {
+            let task = state.get(self.task_id);
+            task.finished()
+        })
+    }
 }
 
 // TODO: need to work out all the error cases here


### PR DESCRIPTION
Make Shuttle's `JoinHandle` even more compatible with its Tokio counterpart: https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html#method.is_finished

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.