### PR TITLE
Api parity improvements

### DIFF
--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -418,7 +418,6 @@ impl<T> Receiver<T> {
 
     /// Returns an iterator that will block waiting for messages, but never
     /// [`panic!`]. It will return [`None`] when the channel has hung up.
-    /// ```
     pub fn iter(&self) -> Iter<'_, T> {
         Iter { rx: self }
     }
@@ -427,7 +426,6 @@ impl<T> Receiver<T> {
     /// It will return `None` if there are no more pending values or if the
     /// channel has hung up. The iterator will never [`panic!`] or block the
     /// user by waiting for values.
-    /// ```
     pub fn try_iter(&self) -> TryIter<'_, T> {
         TryIter { rx: self }
     }

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -227,8 +227,6 @@ impl<T> Channel<T> {
                     s.update_clock(&recv_clock);
                 }
             });
-        } else {
-            assert!(!is_rendezvous); // Sender on a rendezvous channel is only unblocked if there's a waiting receiver
         }
         // Check and unblock the next the waiting sender, if eligible
         if let Some(&tid) = state.waiting_senders.first() {

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -587,10 +587,14 @@ impl<T> SyncSender<T> {
         self.inner.send(t)
     }
 
-    /// Sends a value on this synchronous channel.
+    /// Attempts to send a value on this channel without blocking.
     ///
-    /// This function will *block* until space in the internal buffer becomes
-    /// available or a receiver is available to hand off the message to.
+    /// This method differs from [`send`] by returning immediately if the
+    /// channel's buffer is full or no receiver is waiting to acquire some
+    /// data. Compared with [`send`], this function has two failure cases
+    /// instead of one (one for disconnection, one for a full buffer).
+    ///
+    /// [`send`]: Self::send
     pub fn try_send(&self, t: T) -> Result<(), TrySendError<T>> {
         self.inner.try_send(t)
     }

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -192,6 +192,15 @@ impl<T: ?Sized> Mutex<T> {
         result
     }
 
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `Mutex` mutably, no actual locking needs to
+    /// take place---the mutable borrow statically guarantees no locks exist.
+    #[inline]
+    pub fn get_mut(&mut self) -> LockResult<&mut T> {
+        self.inner.get_mut()
+    }
+
     /// Consumes this mutex, returning the underlying data.
     pub fn into_inner(self) -> LockResult<T>
     where

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -149,6 +149,15 @@ impl<T: ?Sized> RwLock<T> {
         }
     }
 
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `RwLock` mutably, no actual locking needs to
+    /// take place---the mutable borrow statically guarantees no locks exist.
+    #[inline]
+    pub fn get_mut(&mut self) -> LockResult<&mut T> {
+        self.inner.get_mut()
+    }
+
     /// Consumes this `RwLock`, returning the underlying data
     pub fn into_inner(self) -> LockResult<T>
     where

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -6,7 +6,7 @@ use crate::runtime::thread;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-pub use std::thread::{Result, panicking};
+pub use std::thread::{panicking, Result};
 
 /// A unique identifier for a running thread
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/tests/basic/mpsc.rs
+++ b/tests/basic/mpsc.rs
@@ -718,5 +718,3 @@ fn mpsc_try_send_permutations_no_drop_rendezvous() {
 fn mpsc_try_send_permutations_drop_rendezvous() {
     mpsc_try_send_permutations(true, true);
 }
-
-// #[test]


### PR DESCRIPTION
Improves the API parity by:

* Expose `panicking` and `Result` from the thread module
* Implement `get_mut` for rwlock & mutex
* Implement `try_send` and iterators for mpsc channels

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.