### PR TITLE
Add `as_any` to Tag trait

### DIFF
--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -44,7 +44,19 @@ pub(crate) const DEFAULT_INLINE_TASKS: usize = 16;
 /// identify tasks in failing Shuttle tests. A task's [Tag] can be set with the
 /// [set_tag_for_current_task](crate::current::set_tag_for_current_task) function. Newly spawned
 /// threads and futures inherit the tag of their parent at spawn time.
-pub trait Tag: Debug {}
+pub trait Tag: Debug {
+    /// Return the tag as `Any`, typically so that it can be downcast to a known concrete type
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T> Tag for T
+where
+    T: Debug + Any,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 /// A `Task` represents a user-level unit of concurrency. Each task has an `id` that is unique within
 /// the execution, and a `state` reflecting whether the task is runnable (enabled) or not.

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -19,8 +19,6 @@ use tracing::{Event, Id, Metadata, Subscriber};
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default, Hash, PartialOrd, Ord)]
 pub struct Tag(u64);
 
-impl shuttle::current::Tag for Tag {}
-
 impl From<u64> for Tag {
     fn from(tag: u64) -> Self {
         Tag(tag)
@@ -76,12 +74,15 @@ fn spawn_some_threads_and_set_tag<F: (Fn(Tag, u64) -> Tag) + Send + Sync>(
 }
 
 fn convert_to_tag(tag: Arc<dyn shuttle::current::Tag>) -> Tag {
-    let ptr = Arc::into_raw(tag).cast::<Tag>();
-    *unsafe { Arc::from_raw(ptr) }
+    *tag.as_any().downcast_ref::<Tag>().unwrap()
 }
 
 fn curr_tag() -> Tag {
-    convert_to_tag(get_tag_for_current_task().unwrap())
+    *get_tag_for_current_task()
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Tag>()
+        .unwrap()
 }
 
 fn spawn_threads_which_spawn_more_threads(num_threads_first_block: u64, num_threads_second_block: u64) {
@@ -174,8 +175,6 @@ enum TaskType {
     Mid,
     Rest(u64),
 }
-
-impl shuttle::current::Tag for TaskType {}
 
 impl TaskType {
     fn new(i: u64) -> TaskType {


### PR DESCRIPTION
This enables downcasting dynamic trait to concrete types to get detailed tag info from a task

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.