### PR TITLE
Allow getting and setting of task tags for arbitrary task IDs

### DIFF
--- a/src/current.rs
+++ b/src/current.rs
@@ -49,3 +49,13 @@ pub fn get_tag_for_current_task() -> Option<Arc<dyn Tag>> {
 pub fn get_current_task() -> Option<TaskId> {
     ExecutionState::with(|s| Some(s.try_current()?.id()))
 }
+
+/// Gets the `tag` field of the specified task.
+pub fn get_tag_for_task(task: TaskId) -> Option<Arc<dyn Tag>> {
+    ExecutionState::get_tag_for_task(task)
+}
+
+/// Sets the `tag` field of the specified task.
+pub fn set_tag_for_task(task: TaskId, tag: Arc<dyn Tag>) -> Option<Arc<dyn Tag>> {
+    ExecutionState::set_tag_for_task(task, tag)
+}

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -633,6 +633,14 @@ impl ExecutionState {
     pub(crate) fn get_tag_for_current_task() -> Option<Arc<dyn Tag>> {
         ExecutionState::with(|s| s.get_tag_or_default_for_current_task())
     }
+
+    pub(crate) fn get_tag_for_task(task: TaskId) -> Option<Arc<dyn Tag>> {
+        ExecutionState::with(|s| s.get(task).get_tag())
+    }
+
+    pub(crate) fn set_tag_for_task(task: TaskId, tag: Arc<dyn Tag>) -> Option<Arc<dyn Tag>> {
+        ExecutionState::with(|s| s.get_mut(task).set_tag(tag))
+    }
 }
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
This is most useful for manipulating task tags from within a scheduler

Perhaps a niche use case, but being able to set non-current task tags helps in the case of a custom application-aware scheduler that needs to make decisions based on the info encoded in task tags.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.