### PR TITLE
Expose DataSource trait and RandomDataSource implementation

### DIFF
--- a/src/scheduler/data/mod.rs
+++ b/src/scheduler/data/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 pub(crate) mod fixed;
 pub(crate) mod random;
+pub use random::RandomDataSource;
 
 /// A `DataSource` is an oracle for generating non-deterministic data to return to a task that asks
 /// for random values.

--- a/src/scheduler/data/random.rs
+++ b/src/scheduler/data/random.rs
@@ -5,7 +5,7 @@ use rand_pcg::Pcg64Mcg;
 /// A `RandomDataSource` generates non-deterministic data from a random number generator, and
 /// arranges to re-seed that RNG on each new execution to enable deterministic replay.
 #[derive(Debug)]
-pub(crate) struct RandomDataSource {
+pub struct RandomDataSource {
     rng: Pcg64Mcg,
     next_seed: Option<u64>,
 }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod serialization;
 
 pub use crate::runtime::task::TaskId;
 
+pub use data::{DataSource, RandomDataSource};
 pub use dfs::DfsScheduler;
 pub use pct::PctScheduler;
 pub use random::RandomScheduler;


### PR DESCRIPTION
Expose DataSource trait and RandomDataSource implementation outside of the crate.

This helps writing of custom randomized schedulers, and more generally supports the bring-your-own scheduler use case.

If you'd rather I not expose `RandomDataSource` and just expand the visibility of `DataSource` just let me know. Although I figured `RandomDataSource` is a pretty useful implementation to make public.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.