### PR TITLE
Fixed clippy and doc warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@
 //!   scheduler can be configured with a bound on the depth of schedules to explore.
 //!
 //! When these convenience methods do not provide enough control, Shuttle provides a [`Runner`]
-//! object for executing a test. A runner is constructed from a chosen [scheduler](scheduler), and
+//! object for executing a test. A runner is constructed from a chosen [scheduler], and
 //! then invoked with the [`Runner::run`] method. Shuttle also provides a [`PortfolioRunner`] object
 //! for running multiple schedulers, using parallelism to increase the number of test executions
 //! explored.

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -183,7 +183,7 @@ impl shuttle::current::Taggable for TaskType {}
 impl TaskType {
     fn new(i: u64) -> TaskType {
         match i {
-            x if x == 0 => TaskType::Unset,
+            0 => TaskType::Unset,
             x if x < 3 => TaskType::Low,
             x if x < 5 => TaskType::Mid,
             x => TaskType::Rest(x),


### PR DESCRIPTION
Fixes warnings reported by clippy (for test code) and cargo doc.  See [failing run](https://github.com/awslabs/shuttle/actions/runs/6462431834).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.