### PR TITLE
Enable getting a Task's Tag while inside the ExecutionState

### DIFF
--- a/src/current.rs
+++ b/src/current.rs
@@ -5,7 +5,7 @@
 //! example, a tool that wants to check linearizability might want access to a global timestamp for
 //! events, which the [`context_switches`] function provides.
 
-use crate::runtime::execution::ExecutionState;
+use crate::runtime::execution::{ExecutionState, TASK_ID_TO_TAGS};
 use crate::runtime::task::clock::VectorClock;
 pub use crate::runtime::task::{Tag, Taggable, TaskId};
 use std::sync::Arc;
@@ -51,8 +51,11 @@ pub fn get_current_task() -> Option<TaskId> {
 }
 
 /// Gets the `tag` field of the specified task.
-pub fn get_tag_for_task(task: TaskId) -> Option<Arc<dyn Tag>> {
-    ExecutionState::get_tag_for_task(task)
+pub fn get_tag_for_task(task_id: TaskId) -> Option<Arc<dyn Tag>> {
+    TASK_ID_TO_TAGS.with(|cell| {
+        let map = cell.borrow();
+        map.get(&task_id).cloned()
+    })
 }
 
 /// Sets the `tag` field of the specified task.

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -681,10 +681,6 @@ impl ExecutionState {
         ExecutionState::with(|s| s.get_tag_or_default_for_current_task())
     }
 
-    pub(crate) fn get_tag_for_task(task: TaskId) -> Option<Arc<dyn Tag>> {
-        ExecutionState::with(|s| s.get(task).get_tag())
-    }
-
     pub(crate) fn set_tag_for_task(task: TaskId, tag: Arc<dyn Tag>) -> Option<Arc<dyn Tag>> {
         ExecutionState::with(|s| s.get_mut(task).set_tag(tag))
     }


### PR DESCRIPTION
The current version of `get_tag_for_task ` requires borrowing the `ExecutionState`. This means the `Tag` cannot be gotten if the `ExecutionState` is already borrowed (such as when doing scheduling). This change makes it possible to get a `Task`'s `Tag` while having a borrow to `ExecutionState`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.