### PR TITLE
Fix dropping TLS for detached futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ rand_core = "0.6.4"
 rand = "0.8.5"
 rand_pcg = "0.3.1"
 scoped-tls = "1.0.0"
-smallvec = { version = "1.10.0", features = ["const_new"] }
-tracing = { version = "0.1.21", default-features = false, features = ["std"] }
+smallvec = { version = "1.11.2", features = ["const_new"] }
+tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }


### PR DESCRIPTION
When a detached future is being cleaned up after the end of an
execution, it won't be able to access the current task's storage any
more. We need to bail out early from the cleanup to avoid a panic.

I also fixed two small issues:
1. We accidentally took a dependency on tracing 0.1.36 by using a value type in a `Span::record` call, despite only specifying an earlier version.
2. The docs weren't building on older smallvec versions because of some const weirdness.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.