### PR TITLE
Release 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"
@@ -11,7 +11,7 @@ categories = ["asynchronous", "concurrency", "development-tools::testing"]
 [dependencies]
 assoc = "0.1.3"
 bitvec = "1.0.1"
-generator = "0.7.1"
+generator = "0.8.1"
 hex = "0.4.2"
 owo-colors = "3.5.0"
 rand_core = "0.6.4"


### PR DESCRIPTION
This is a breaking change from 0.6.1 because we changed `Tag` from a
struct to a label (even though we're about to deprecate it).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.