### PR TITLE
Update trace in schedule

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -696,7 +696,7 @@ impl ExecutionState {
         // Note also that changing this trace! statement requires changing the test `basic::labels::test_tracing_with_label_fn`
         // which relies on this trace reporting the `runnable` tasks.
         self.top_level_span
-            .in_scope(|| trace!(?runnable, next_task=?self.next_task));
+            .in_scope(|| trace!(i=self.current_schedule.len(), next_task=?self.next_task, ?runnable));
 
         Ok(())
     }


### PR DESCRIPTION
I have preferred this trace for debugging.

Adds `i` into the trace (it was in the span previously, but that implementation was broken. Currently not included as it does not work with `tracing_subscriber::fmt`), and reorders such that `next_task` comes before `runnable`. This fixes the "burying" of the next task which happens currently.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.