### PR TITLE
Reexport lazy_static in lazy_static

### DIFF
--- a/src/lazy_static.rs
+++ b/src/lazy_static.rs
@@ -21,6 +21,9 @@ use crate::runtime::storage::StorageKey;
 use crate::sync::Once;
 use std::marker::PhantomData;
 
+// `use lazy_static::lazy_static;` is valid, thus `use shuttle::lazy_static::lazy_static;` should be as well.
+pub use crate::lazy_static;
+
 /// Shuttle's implementation of `lazy_static::Lazy` (aka the unstable `std::lazy::Lazy`).
 // Sadly, the fields of this thing need to be public because function pointers in const fns are
 // unstable, so an explicit instantiation is the only way to construct this struct. User code should

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -114,7 +114,7 @@ enum PanicHookState {
 }
 
 thread_local! {
-    static PANIC_HOOK: Mutex<PanicHookState> = Mutex::new(PanicHookState::Disarmed);
+    static PANIC_HOOK: Mutex<PanicHookState> = const { Mutex::new(PanicHookState::Disarmed) };
 }
 
 /// A guard that disarms the panic hook when dropped

--- a/tests/basic/tag.rs
+++ b/tests/basic/tag.rs
@@ -177,7 +177,7 @@ enum TaskType {
     Unset,
     Low,
     Mid,
-    Rest(u64),
+    Rest,
 }
 
 impl shuttle::current::Taggable for TaskType {}
@@ -188,7 +188,7 @@ impl TaskType {
             0 => TaskType::Unset,
             x if x < 3 => TaskType::Low,
             x if x < 5 => TaskType::Mid,
-            x => TaskType::Rest(x),
+            _x => TaskType::Rest,
         }
     }
 }


### PR DESCRIPTION
Currently `lazy_static` (the macro) is scoped under `shuttle`, but I believe it should be scoped under `lazy_static`. This makes it scoped under `lazy_static` as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.