### PR TITLE
Impl Clone for ThreadRng

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -17,7 +17,7 @@ pub mod rngs {
     /// unlike in the `rand` crate, this RNG is not *actually* thread-local --- all threads share a
     /// single RNG. This RNG is automatically seeded by Shuttle, and cannot be re-seeded, so this
     /// sharing should be indistinguishable from truly thread-local behavior.
-    #[derive(Debug, Default)]
+    #[derive(Debug, Default, Clone)]
     pub struct ThreadRng;
 
     impl RngCore for ThreadRng {


### PR DESCRIPTION
`ThreadRng` is `Clone` in `rand`, so it should be here as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.