### PR TITLE
Release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.7.1 (May 31, 2024)
+
+* Implement `try_send` and iterators for `mpsc` channels (#120)
+* Implement `get_mut` for `Mutex` and `RwLock` (#120)
+
 # 0.7.0 (March 7, 2024)
 
 * Add support for task labels. These replace task tags, which are deprecated and will be removed in a future release. (#138)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"


### PR DESCRIPTION
Mostly to release #120, but also some other small compatibility stuff.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.