### PR TITLE
Clippy 1.79 new lint

### DIFF
--- a/src/scheduler/serialization.rs
+++ b/src/scheduler/serialization.rs
@@ -9,7 +9,7 @@ use bitvec::prelude::*;
 /// crate, used under the MIT license.
 mod varint {
     pub fn space_needed(val: u64) -> usize {
-        let used_bits = u64::min_value().leading_zeros() - val.leading_zeros();
+        let used_bits = u64::MIN.leading_zeros() - val.leading_zeros();
         std::cmp::max((used_bits + 6) as usize / 7, 1)
     }
 


### PR DESCRIPTION
New lint added in 1.79: https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.