### PR TITLE
Batch semaphore, causality tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ regex = "1.5.5"
 tempfile = "3.2.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+pin-project = "1.1.3"
 
 [lib]
 bench = false

--- a/src/future/batch_semaphore.rs
+++ b/src/future/batch_semaphore.rs
@@ -1,0 +1,361 @@
+//! A counting semaphore supporting both async and sync operations.
+use crate::runtime::execution::ExecutionState;
+use crate::runtime::task::TaskId;
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::task::{Context, Poll, Waker};
+use tracing::trace;
+
+#[derive(Debug)]
+struct Waiter {
+    task_id: TaskId,
+    num_permits: usize,
+    is_queued: AtomicBool,
+    has_permits: AtomicBool,
+    waker: Mutex<Option<Waker>>,
+}
+
+impl Waiter {
+    fn new(num_permits: usize) -> Self {
+        Self {
+            task_id: ExecutionState::me(),
+            num_permits,
+            is_queued: AtomicBool::new(false),
+            has_permits: AtomicBool::new(false),
+            waker: Mutex::new(None),
+        }
+    }
+}
+
+/// A counting semaphore which permits waiting on multiple permits at once,
+/// and supports both asychronous and synchronous blocking operations.
+///
+/// The semaphore is strictly fair, so earlier requesters always get priority
+/// over later ones.
+///
+/// TODO: Provide an option to support weaker models for fairness.
+#[derive(Debug)]
+struct BatchSemaphoreState {
+    // Key invariants:
+    //
+    // (1) if `waiters` is nonempty and the head waiter is `H`,
+    // then `H.num_permits > permits_available`.  (In other words, we are
+    // never in a state where there are enough permits available for the
+    // first waiter.  This invariant is ensured by the `drop` handler below.)
+    //
+    // (2) W is in waiters iff W.is_queued
+    //
+    // (3) W.is_queued ==> !W.has_permits
+    // Note: the converse is not true.  We can have !W.has_permits && !W.is_queued
+    // when the Acquire is created but not yet polled.
+    //
+    // (4) closed ==> waiters.is_empty()
+    waiters: VecDeque<Arc<Waiter>>,
+    permits_available: usize,
+    closed: bool,
+}
+
+impl BatchSemaphoreState {
+    fn acquire_permits(&mut self, num_permits: usize) -> Result<(), TryAcquireError> {
+        if self.closed {
+            Err(TryAcquireError::Closed)
+        } else if self.waiters.is_empty() && num_permits <= self.permits_available {
+            // No one is waiting and there are enough permits available
+            self.permits_available -= num_permits;
+            Ok(())
+        } else {
+            Err(TryAcquireError::NoPermits)
+        }
+    }
+}
+
+/// Counting semaphore
+#[derive(Debug)]
+pub struct BatchSemaphore {
+    state: RefCell<BatchSemaphoreState>,
+}
+
+/// Error returned from the [`BatchSemaphore::try_acquire`] function.
+#[derive(Debug, PartialEq, Eq)]
+pub enum TryAcquireError {
+    /// The semaphore has been closed and cannot issue new permits.
+    Closed,
+
+    /// The semaphore has no available permits.
+    NoPermits,
+}
+
+/// Error returned from the [`BatchSemaphore::acquire`] function.
+///
+/// An `acquire*` operation can only fail if the semaphore has been
+/// closed.
+#[derive(Debug)]
+pub struct AcquireError(());
+
+impl AcquireError {
+    fn closed() -> AcquireError {
+        AcquireError(())
+    }
+}
+
+impl fmt::Display for AcquireError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "semaphore closed")
+    }
+}
+
+impl std::error::Error for AcquireError {}
+
+impl BatchSemaphore {
+    /// Creates a new semaphore with the initial number of permits.
+    pub fn new(num_permits: usize) -> Self {
+        let state = RefCell::new(BatchSemaphoreState {
+            waiters: VecDeque::new(),
+            permits_available: num_permits,
+            closed: false,
+        });
+        Self { state }
+    }
+
+    /// Creates a new semaphore with the initial number of permits.
+    pub const fn const_new(num_permits: usize) -> Self {
+        let state = RefCell::new(BatchSemaphoreState {
+            waiters: VecDeque::new(),
+            permits_available: num_permits,
+            closed: false,
+        });
+        Self { state }
+    }
+
+    /// Returns the current number of available permits.
+    pub fn available_permits(&self) -> usize {
+        let state = self.state.borrow();
+        state.permits_available
+    }
+
+    /// Closes the semaphore. This prevents the semaphore from issuing new
+    /// permits and notifies all pending waiters.
+    pub fn close(&self) {
+        let mut state = self.state.borrow_mut();
+        state.closed = true;
+        // Wake up all the waiters.  Since we've marked the state as closed, they
+        // will all return `AcquireError::closed` from their acquire calls.
+        let ptr = &*state as *const BatchSemaphoreState;
+        for waiter in state.waiters.drain(..) {
+            trace!(
+                "semaphore {:p} removing and waking up waiter {:?} on close",
+                ptr,
+                waiter,
+            );
+            assert!(waiter.is_queued.swap(false, Ordering::SeqCst));
+            assert!(!waiter.has_permits.load(Ordering::SeqCst)); // sanity check
+            ExecutionState::with(|exec_state| {
+                if !exec_state.in_cleanup() {
+                    exec_state.get_mut(waiter.task_id).unblock();
+                }
+            });
+            let mut maybe_waker = waiter.waker.lock().unwrap();
+            if let Some(waker) = maybe_waker.take() {
+                waker.wake();
+            }
+        }
+    }
+
+    /// Returns true iff the semaphore is closed.
+    pub fn is_closed(&self) -> bool {
+        let state = self.state.borrow();
+        state.closed
+    }
+
+    /// Try to acquire the specified number of permits from the Semaphore.
+    /// If the permits are available, returns Ok(())
+    /// If the semaphore is closed, returns `Err(TryAcquireError::Closed)`
+    /// If there aren't enough permits, returns `Err(TryAcquireError::NoPermits)`
+    pub fn try_acquire(&self, num_permits: usize) -> Result<(), TryAcquireError> {
+        let mut state = self.state.borrow_mut();
+        state.acquire_permits(num_permits)
+    }
+
+    fn enqueue_waiter(&self, waiter: &Arc<Waiter>) {
+        let mut state = self.state.borrow_mut();
+
+        trace!("enqueuing waiter {:?} for semaphore {:p}", waiter, &self.state);
+        state.waiters.push_back(waiter.clone());
+
+        assert!(!waiter.has_permits.load(Ordering::SeqCst));
+        assert!(!waiter.is_queued.swap(true, Ordering::SeqCst));
+    }
+
+    fn remove_waiter(&self, waiter: &Arc<Waiter>) {
+        let mut state = self.state.borrow_mut();
+
+        trace!(waiters = ?state.waiters, "removing waiter {:?} from semaphore {:p}", waiter, &self.state);
+
+        // sanity checks
+        assert!(!state.closed);
+        assert!(!waiter.has_permits.load(Ordering::SeqCst));
+
+        let index = state
+            .waiters
+            .iter()
+            .position(|x| Arc::ptr_eq(x, waiter))
+            .expect("did not find waiter");
+
+        state.waiters.remove(index).unwrap();
+        assert!(waiter.is_queued.swap(false, Ordering::SeqCst));
+    }
+
+    /// Acquire the specified number of permits (async API)
+    pub fn acquire(&self, num_permits: usize) -> Acquire<'_> {
+        Acquire::new(self, num_permits)
+    }
+
+    /// Acquire the specified number of permits (blocking API)
+    pub fn acquire_blocking(&self, num_permits: usize) -> Result<(), AcquireError> {
+        crate::future::block_on(self.acquire(num_permits))
+    }
+
+    /// Release `num_permits` back to the Semaphore
+    pub fn release(&self, num_permits: usize) {
+        if num_permits == 0 {
+            return;
+        }
+
+        if ExecutionState::should_stop() {
+            return;
+        }
+
+        let mut state = self.state.borrow_mut();
+
+        // Permits released into the semaphore reflect the releasing thread's
+        // clock; future acquires of those permits are causally dependent on
+        // this event.
+        ExecutionState::with(|s| {
+            let clock = s.increment_clock();
+            state.permits_available.release(num_permits, clock.clone());
+        });
+
+        let me = ExecutionState::me();
+        trace!(task = ?me, avail = ?state.permits_available, waiters = ?state.waiters, "released {} permits for semaphore {:p}", num_permits, &self.state);
+
+        while let Some(front) = state.waiters.front() {
+            if front.num_permits <= state.permits_available {
+                trace!("granted {:?} permits to waiter {:?}", front.num_permits, front);
+                state.permits_available -= front.num_permits;
+                let waiter = state.waiters.pop_front().unwrap();
+                // Update waiter state as it is no longer in the queue
+                assert!(waiter.is_queued.swap(false, Ordering::SeqCst));
+                assert!(!waiter.has_permits.swap(true, Ordering::SeqCst));
+                ExecutionState::with(|s| {
+                    let task = s.get_mut(waiter.task_id);
+                    assert!(!task.finished());
+                    task.unblock();
+                });
+                let mut maybe_waker = waiter.waker.lock().unwrap();
+                if let Some(waker) = maybe_waker.take() {
+                    waker.wake();
+                }
+            } else {
+                break;
+            }
+        }
+        drop(state);
+
+        // Releasing a semaphore is a yield point
+        crate::runtime::thread::switch();
+    }
+}
+
+// Safety: Semaphore is never actually passed across true threads, only across continuations. The
+// RefCell<_> type therefore can't be preempted mid-bookkeeping-operation.
+// TODO we shouldn't need to do this, but RefCell is not Send, and anything we put within a Semaphore
+// TODO needs to be Send.
+unsafe impl Send for BatchSemaphore {}
+unsafe impl Sync for BatchSemaphore {}
+
+impl Default for BatchSemaphore {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+/// The future that results from async calls to `acquire*`.
+/// Callers must `await` on this future to obtain the necessary permits.
+#[derive(Debug)]
+pub struct Acquire<'a> {
+    waiter: Arc<Waiter>,
+    semaphore: &'a BatchSemaphore,
+    completed: bool, // Has the future completed yet?
+}
+
+impl<'a> Acquire<'a> {
+    fn new(semaphore: &'a BatchSemaphore, num_permits: usize) -> Self {
+        let waiter = Arc::new(Waiter::new(num_permits));
+        Self {
+            waiter,
+            semaphore,
+            completed: false,
+        }
+    }
+}
+
+impl Future for Acquire<'_> {
+    type Output = Result<(), AcquireError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        assert!(!self.completed);
+        if self.waiter.has_permits.load(Ordering::SeqCst) {
+            assert!(!self.waiter.is_queued.load(Ordering::SeqCst));
+            self.completed = true;
+            trace!("Acquire::poll for waiter {:?} with permits", self.waiter);
+            Poll::Ready(Ok(()))
+        } else if self.semaphore.is_closed() {
+            assert!(!self.waiter.is_queued.load(Ordering::SeqCst));
+            self.completed = true;
+            trace!("Acquire::poll for waiter {:?} with closed", self.waiter);
+            Poll::Ready(Err(AcquireError::closed()))
+        } else if self.waiter.is_queued.load(Ordering::SeqCst) {
+            trace!("Acquire::poll for waiter {:?} already queued", self.waiter);
+            assert!(self.waiter.waker.lock().unwrap().is_some());
+            Poll::Pending
+        } else {
+            match self.semaphore.try_acquire(self.waiter.num_permits) {
+                Ok(()) => {
+                    assert!(!self.waiter.is_queued.load(Ordering::SeqCst));
+                    self.waiter.has_permits.store(true, Ordering::SeqCst);
+                    self.completed = true;
+                    trace!("Acquire::poll for waiter {:?} that got permits", self.waiter);
+                    crate::runtime::thread::switch();
+                    Poll::Ready(Ok(()))
+                }
+                Err(TryAcquireError::NoPermits) => {
+                    let mut maybe_waker = self.waiter.waker.lock().unwrap();
+                    *maybe_waker = Some(cx.waker().clone());
+                    self.semaphore.enqueue_waiter(&self.waiter);
+                    trace!("Acquire::poll for waiter {:?} that is enqueued", self.waiter);
+                    Poll::Pending
+                }
+                Err(TryAcquireError::Closed) => unreachable!(),
+            }
+        }
+    }
+}
+
+impl Drop for Acquire<'_> {
+    fn drop(&mut self) {
+        trace!("Acquire::drop for Acquire {:p} with waiter {:?}", self, self.waiter);
+        if self.waiter.is_queued.load(Ordering::SeqCst) {
+            // If the associated waiter is in the wait list, remove it
+            self.semaphore.remove_waiter(&self.waiter);
+        } else if self.waiter.has_permits.load(Ordering::SeqCst) && !self.completed {
+            // If the waiter was granted permits, release them
+            self.semaphore.release(self.waiter.num_permits);
+        }
+    }
+}

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -16,6 +16,8 @@ use std::result::Result;
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 
+pub mod batch_semaphore;
+
 /// Spawn a new async task that the executor will run to completion.
 pub fn spawn<T, F>(fut: F) -> JoinHandle<T>
 where

--- a/tests/basic/mod.rs
+++ b/tests/basic/mod.rs
@@ -1,6 +1,6 @@
 mod atomic;
 mod barrier;
-mod clocks;
+pub(crate) mod clocks;
 mod condvar;
 mod config;
 mod dfs;

--- a/tests/future/batch_semaphore.rs
+++ b/tests/future/batch_semaphore.rs
@@ -1,0 +1,402 @@
+use futures::stream::FuturesUnordered;
+use futures::{FutureExt, StreamExt};
+use shuttle::check_dfs;
+use shuttle::future::{self, batch_semaphore::*};
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
+use test_log::test;
+
+#[test]
+fn batch_semaphore_basic() {
+    check_dfs(
+        || {
+            let s = BatchSemaphore::new(3);
+
+            future::spawn(async move {
+                s.acquire(2).await.unwrap();
+                s.acquire(1).await.unwrap();
+                let r = s.try_acquire(1);
+                assert_eq!(r, Err(TryAcquireError::NoPermits));
+                s.release(1);
+                s.acquire(1).await.unwrap();
+            });
+        },
+        None,
+    );
+}
+
+// Create a semaphore with `num_permits` permits and spawn a bunch of tasks that each
+// try to grab a bunch of permits.  Task i sets the i'th bit in a shared atomic counter.
+// Afterwards, we'll see which combinations were allowable over a full dfs run.
+async fn semtest(num_permits: usize, counts: Vec<usize>, states: &Arc<Mutex<HashSet<(usize, usize)>>>) {
+    let s = Arc::new(BatchSemaphore::new(num_permits));
+    let r = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+    for (i, &c) in counts.iter().enumerate() {
+        let s = s.clone();
+        let r = r.clone();
+        let states = states.clone();
+        let val = 1usize << i;
+        handles.push(future::spawn(async move {
+            s.acquire(c).await.unwrap();
+            let v = r.fetch_add(val, Ordering::SeqCst);
+            future::yield_now().await;
+            let _ = r.fetch_sub(val, Ordering::SeqCst);
+            states.lock().unwrap().insert((i, v));
+            s.release(c);
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+}
+
+#[test]
+fn batch_semaphore_test_1() {
+    let states = Arc::new(Mutex::new(HashSet::new()));
+    let states2 = states.clone();
+    check_dfs(
+        move || {
+            let states2 = states2.clone();
+            future::block_on(async move {
+                semtest(5, vec![3, 3, 3], &states2).await;
+            });
+        },
+        None,
+    );
+
+    let states = Arc::try_unwrap(states).unwrap().into_inner().unwrap();
+    assert_eq!(states, HashSet::from([(0, 0), (1, 0), (2, 0)]));
+}
+
+#[test]
+fn batch_semaphore_test_2() {
+    let states = Arc::new(Mutex::new(HashSet::new()));
+    let states2 = states.clone();
+    check_dfs(
+        move || {
+            let states2 = states2.clone();
+            future::block_on(async move {
+                semtest(5, vec![3, 3, 2], &states2).await;
+            });
+        },
+        None,
+    );
+
+    let states = Arc::try_unwrap(states).unwrap().into_inner().unwrap();
+    assert_eq!(
+        states,
+        HashSet::from([(0, 0), (1, 0), (2, 0), (0, 4), (1, 4), (2, 1), (2, 2)])
+    );
+}
+
+#[test]
+fn batch_semaphore_signal() {
+    // Use a semaphore for signaling
+    check_dfs(
+        move || {
+            let sem = Arc::new(BatchSemaphore::new(0));
+            let sem2 = sem.clone();
+            let r = Arc::new(AtomicUsize::new(0));
+            let r2 = r.clone();
+            future::spawn(async move {
+                sem.acquire(1).await.unwrap();
+                let v = r2.load(Ordering::SeqCst);
+                assert!(v > 0);
+                sem.acquire(1).await.unwrap();
+                let v = r2.load(Ordering::SeqCst);
+                assert!(v > 1);
+            });
+            r.store(1, Ordering::SeqCst);
+            sem2.release(1);
+            r.store(2, Ordering::SeqCst);
+            sem2.release(1);
+        },
+        None,
+    );
+}
+
+#[test]
+fn batch_semaphore_close_acquire() {
+    // Check that closing a semaphore is handled gracefully
+    check_dfs(
+        || {
+            future::block_on(async {
+                let tx = Arc::new(BatchSemaphore::new(1));
+                let rx = Arc::new(BatchSemaphore::new(0));
+                let tx2 = tx.clone();
+                let rx2 = rx.clone();
+
+                let h = future::spawn(async move {
+                    tx2.acquire(1).await.unwrap();
+                    rx2.release(1);
+                    let s = tx2.acquire(1).await;
+                    assert!(s.is_err());
+                    assert!(matches!(tx2.try_acquire(1), Err(TryAcquireError::Closed)));
+                });
+
+                rx.acquire(1).await.unwrap();
+                tx.close();
+                h.await.unwrap();
+            });
+        },
+        None,
+    );
+}
+
+#[test]
+fn batch_semaphore_drop_sender() {
+    struct Sender {
+        sem: Arc<BatchSemaphore>,
+    }
+
+    impl Drop for Sender {
+        fn drop(&mut self) {
+            self.sem.close();
+        }
+    }
+
+    // Check that closing a semaphore is handled gracefully
+    check_dfs(
+        || {
+            future::block_on(async {
+                let sem = Arc::new(BatchSemaphore::new(0));
+                let sender = Sender { sem: sem.clone() };
+
+                future::spawn(async move {
+                    let r = sem.acquire(2).await;
+                    assert!(r.is_err());
+                });
+
+                future::spawn(async move {
+                    sender.sem.release(1);
+                    // sender is dropped here which will cause the semaphore to be closed
+                });
+            });
+        },
+        None,
+    );
+}
+
+// Created to catch an issue where we would dequeue the wrong waiter from the `BatchSemaphore`.
+//
+// The idea of the test is to hit the following (or equivalent):
+//
+// 1. `TaskId(0)` (main thread) `lock`s and gets the `Guard`.
+// 2. `handle.await.unwrap()`. We wait for the following to happen:
+// 3. `lock_future1` (`TaskId(1)`) tries to `lock` and gets enequeued on the semaphore.
+// 4. `lock_future2` (`TaskId(1)`) tries to `lock` and gets enequeued on the semaphore.
+// 5. `empty_future` gets hit, and we return.
+//
+// At this point everything inside `handle` block will get dropped.
+// This should result in the dequeueing of the waiters for `lock_future1` and `lock_future2`.
+// What instead would happen is the following:
+// - `lock_future2` gets dropped, and `lock_future1` gets dequeued erroneously.
+// - `lock_future1` gets dropped, resulting in a no-op, as it is not enqueued.
+// This means that the permit is held by `TaskId(0)`, and `lock_future2`(`TaskId(1)`) enqueued.
+//
+// 6. `guard` is dropped by `TaskId(0)`
+// This releases the permit, giving it to `lock_future2`(`TaskId(1)`) erroneously.
+// 7. `TaskId(0)` (main thread) tries to `lock` and gets enqueued on the semaphore.
+// 8. Deadlock.
+#[test]
+fn bugged_cleanup_would_cause_deadlock() {
+    struct Guard {
+        sem: Arc<BatchSemaphore>,
+    }
+
+    async fn lock(sem: &Arc<BatchSemaphore>) -> Guard {
+        let _ = sem.acquire(1).await;
+        Guard { sem: sem.clone() }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            self.sem.release(1);
+        }
+    }
+
+    check_dfs(
+        || {
+            let sem = Arc::new(BatchSemaphore::new(1));
+            let sem2 = sem.clone();
+
+            future::block_on(async move {
+                let handle = future::spawn(async move {
+                    let mut futunord = FuturesUnordered::new();
+
+                    let lock_future1 = async {
+                        lock(&sem2).await;
+                    }
+                    .boxed();
+
+                    let lock_future2 = async {
+                        lock(&sem2).await;
+                    }
+                    .boxed();
+
+                    let empty_future = async {}.boxed();
+
+                    futunord.push(lock_future1);
+                    futunord.push(lock_future2);
+                    futunord.push(empty_future);
+
+                    // Wait for any future to complete
+                    futunord.next().await.unwrap();
+                });
+
+                let guard = lock(&sem).await;
+
+                handle.await.unwrap();
+
+                drop(guard);
+
+                lock(&sem).await;
+            });
+        },
+        None,
+    )
+}
+
+// This test exercises the following scenario where SEM is a BatchSemaphore with N permits.
+// 1. Initially the semaphore has 0 permits
+// 2. Task T1 tries to acquire 1 permit, gets added as the first Waiter
+// 3. Task T2 tries to acquire 1 permit, gets added as the second Waiter
+// 4. Task T0 releases 1 permit
+// 5. Task T1 drops its Acquire handle without calling poll()
+//
+// At this point, T2 should be woken up and should get the permit.
+// Unfortunately, in an earlier version of BatchSemaphore, this was not happening because
+// the Drop handler for Acquire was only returning permits to the semaphore, but not
+// waking up the next waiter in the queue.
+//
+// The tests below exercise both the specific scenario above (with 1 permit and two tasks), and more
+// general scenarios involving multiple tasks, of which a random subset drop the Acquire guards early.
+mod early_acquire_drop_test {
+    use super::*;
+    use futures::{
+        future::join_all,
+        task::{Context, Poll, Waker},
+        Future,
+    };
+    use pin_project::pin_project;
+    use proptest::proptest;
+    use shuttle::{
+        check_random,
+        sync::mpsc::{channel, Sender},
+    };
+    use std::pin::Pin;
+    use test_log::test;
+
+    #[pin_project]
+    struct Task {
+        poll_count: usize, // how many times the Future has been polled
+        early_drop: bool,  // whether to drop the Acquire handle after polling it once
+        tx: Sender<Waker>, // channel for informing the main task
+        #[pin]
+        acquire: Acquire<'static>,
+    }
+
+    impl Task {
+        fn new(early_drop: bool, tx: Sender<Waker>, sem: &'static BatchSemaphore) -> Self {
+            Self {
+                poll_count: 0,
+                early_drop,
+                tx,
+                acquire: sem.acquire(1),
+            }
+        }
+    }
+
+    impl Future for Task {
+        type Output = usize;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+            let mut this = self.project();
+            if *this.poll_count == 0 {
+                // The first time we are polled, also poll the inner Acquire handle
+                // so this task gets added as a Waiter
+                let s: Poll<Result<(), AcquireError>> = this.acquire.as_mut().poll(cx);
+                assert!(s.is_pending());
+                this.tx.send(cx.waker().clone()).unwrap(); // Notify main task
+                *this.poll_count += 1;
+                Poll::Pending
+            } else if *this.early_drop {
+                // Since this is an early drop, we got 0 permits
+                Poll::Ready(0)
+            } else {
+                // If not early dropping, wait until the inner Acquire handle successfully gets
+                // a permit.  When successful, return 1 permit.
+                this.acquire.as_mut().poll(cx).map(|_| 1)
+            }
+        }
+    }
+
+    // High-level sketch of the test:
+    // S1. Initialize the semaphore with no permits
+    // S2. Spawn a set of tasks, each randomly decides whether or not to drop early
+    //     Each task creates an Acquire handle and polls it once (to get into the waiter queue)
+    //     The task then notifies the main task (by sending a message on an mpsc channel)
+    // S3. The main task waits for messages from all the spawned tasks (so it knows each is a waiter)
+    // S4. The main task releases N permits on the BatchSemaphore, and wakes up all the tasks
+    // S5. At this point, each task either drops its Acquire handle, or tries to acquire the BatchSemaphore
+    //     by polling it until it acquires a permit.
+    fn dropped_acquire_must_release(num_permits: usize, early_drop: Vec<bool>) {
+        shuttle::lazy_static! {
+            // S1. Initialize the semaphore with no permits
+            static ref SEM: BatchSemaphore = BatchSemaphore::new(0);
+        }
+
+        future::block_on(async move {
+            let mut wakers = vec![];
+            let mut handles = vec![];
+
+            // S2. Main task spawns a set of tasks; the `early_drop` vector of booleans determines
+            // which tasks will drop the `Acquire` after polling it exactly once
+            for early_drop in early_drop {
+                let (tx, rx) = channel();
+                let task: Task = Task::new(early_drop, tx, &SEM);
+                handles.push(future::spawn(async move {
+                    let p = task.await;
+                    // Note: tasks doing an early drop will return p=0, and release(0) is a no-op
+                    SEM.release(p);
+                }));
+                // S3. Main task waits for message from spawned task indicating it has polled once
+                wakers.push(rx.recv().unwrap());
+            }
+
+            // S4. Main task releases N permits and wakes up all tasks
+            SEM.release(num_permits);
+            for w in wakers.into_iter() {
+                w.wake();
+            }
+
+            join_all(handles).await;
+        });
+    }
+
+    // The minimal test case (generated by the proptest below) is with 1 permit and 2 tasks, where Task1 does
+    // an early drop, and Task2 does not early drop.  This test checks that scenario exhaustively using check_dfs.
+    #[test]
+    fn dropped_acquire_must_release_exhaustive() {
+        check_dfs(|| dropped_acquire_must_release(1, vec![true, false]), None);
+    }
+
+    // This test checks scenarios where the main task releases multiple permits and there are several tasks, any
+    // subset of which may do an early drop of their Acquire handle.
+
+    const MAX_PERMITS: usize = 8;
+    const MAX_TASKS: usize = 7;
+
+    proptest! {
+        #[test]
+        fn dropped_acquire_must_release_random(num_permits in 1..MAX_PERMITS, early_drop in proptest::collection::vec(proptest::arbitrary::any::<bool>(), 1..MAX_TASKS)) {
+            check_random(
+                move || dropped_acquire_must_release(num_permits, early_drop.clone()),
+                10_000,
+            );
+        }
+    }
+}

--- a/tests/future/mod.rs
+++ b/tests/future/mod.rs
@@ -1,4 +1,5 @@
 mod basic;
+mod batch_semaphore;
 mod channel;
 mod countdown_timer;
 mod pct;


### PR DESCRIPTION
This adds batch semaphores into Shuttle (not originally implemented by me) as the core primitive to be used for other synchronisation primitives. Vector clocks were added to the batch semaphore to track causality across `acquire`, `release`, and `try_acquire` calls. 

Implementing other primitives using the batch semaphore will thus also cause causality to be tracked. The eventual goal is for primitives to only rely on the API of batch semaphore, without calls to e.g. `ExecutionState`. As a result, batch semaphore and the runtime internals can be pulled out of Shuttle into a separate `shuttle-core` crate, while both the stdlib and tokio primitives can be placed into new sibling crates, `shuttle-stdlib` and `shuttle-tokio`, respectively.

An open question is how to proceed with the crate restructuring. One option is for the crate called `shuttle` now to "become" `shuttle-stdlib`, as it will contain the same primitives, but this would require various re-exports. We could also publish a wrapper crate called `shuttle` (intended to be deprecated?) which will re-export items from both `shuttle-core` and `shuttle-stdlib`.

Planned for this PR still:

- [x] Test cases.
  - [x] Test case to show where causality tracking is *not* precise.
- [x] Option for the semaphore to not be strictly fair, by waking all feasible waiters at once, then letting the scheduler resolve the race.
