### PR TITLE
`std::sync::Mutex` using batch semaphore

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -183,8 +183,6 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     let waker = ExecutionState::with(|state| state.current_mut().waker());
     let cx = &mut Context::from_waker(&waker);
 
-    thread::switch();
-
     loop {
         match future.as_mut().poll(cx) {
             Poll::Ready(result) => break result,

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -1,7 +1,6 @@
-use crate::runtime::execution::ExecutionState;
-use crate::runtime::task::clock::VectorClock;
-use crate::runtime::task::{TaskId, TaskSet};
-use crate::runtime::thread;
+use crate::future::batch_semaphore::{BatchSemaphore, Fairness, TryAcquireError};
+use crate::runtime::task::TaskId;
+use crate::current;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::ops::{Deref, DerefMut};
@@ -12,6 +11,7 @@ use tracing::trace;
 /// A mutex, the same as [`std::sync::Mutex`].
 pub struct Mutex<T: ?Sized> {
     state: RefCell<MutexState>,
+    semaphore: BatchSemaphore,
     inner: std::sync::Mutex<T>,
 }
 
@@ -24,8 +24,6 @@ pub struct MutexGuard<'a, T: ?Sized> {
 #[derive(Debug)]
 struct MutexState {
     holder: Option<TaskId>,
-    waiters: TaskSet,
-    clock: VectorClock,
 }
 
 impl<T> Mutex<T> {
@@ -33,13 +31,11 @@ impl<T> Mutex<T> {
     pub const fn new(value: T) -> Self {
         let state = MutexState {
             holder: None,
-            waiters: TaskSet::new(),
-            clock: VectorClock::new(),
         };
-
         Self {
-            inner: std::sync::Mutex::new(value),
             state: RefCell::new(state),
+            semaphore: BatchSemaphore::const_new(1, Fairness::Unfair),
+            inner: std::sync::Mutex::new(value),
         }
     }
 }
@@ -47,54 +43,41 @@ impl<T> Mutex<T> {
 impl<T: ?Sized> Mutex<T> {
     /// Acquires a mutex, blocking the current thread until it is able to do so.
     pub fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
-        let me = ExecutionState::me();
+        let me = current::me();
 
         let mut state = self.state.borrow_mut();
-        trace!(holder=?state.holder, waiters=?state.waiters, "waiting to acquire mutex {:p}", self);
+        trace!(holder=?state.holder, semaphore=?self.semaphore, "waiting to acquire mutex {:p}", self);
+        drop(state);
 
-        // If the lock is already held, then we are blocked
-        if let Some(holder) = state.holder {
-            if holder == me {
-                panic!("deadlock! task {:?} tried to acquire a Mutex it already holds", me);
+        // Try to acquire without blocking first. If we succeed, we are done
+        // and can move on to acquiring the inner mutex. This is a yield point.
+        match self.semaphore.try_acquire(1) {
+            Ok(()) => (),
+            Err(TryAcquireError::Closed) => unreachable!(),
+            Err(_) => {
+                // If the lock is already held, then we are blocked. This can
+                // happen either because the lock is held by another thread,
+                // or because the lock is held by the current thread. For the
+                // latter case, we check the state to report a more precise
+                // error message.
+                state = self.state.borrow_mut();
+                if let Some(holder) = state.holder {
+                    if holder == me {
+                        panic!("deadlock! task {:?} tried to acquire a Mutex it already holds", me);
+                    }
+                }
+                drop(state);
+
+                self.semaphore.acquire_blocking(1).unwrap();
             }
-
-            state.waiters.insert(me);
-            drop(state);
-
-            // Note that we only need a context switch when we are blocked, but not if the lock is
-            // available. Consider that there is another thread `t` that also wants to acquire the
-            // lock. At the last context switch (where we were chosen), `t` must have been already
-            // runnable and could have been chosen by the scheduler instead. Also, if we want to
-            // re-acquire the lock immediately after releasing it, we know that the release had a
-            // context switch that allowed other threads to acquire in between.
-            ExecutionState::with(|s| s.current_mut().block(false));
-            thread::switch();
-            state = self.state.borrow_mut();
-
-            // Once the scheduler has resumed this thread, we are clear to become its holder.
-            assert!(state.waiters.remove(me));
         }
 
+        state = self.state.borrow_mut();
         assert!(state.holder.is_none());
         state.holder = Some(me);
-
-        trace!(waiters=?state.waiters, "acquired mutex {:p}", self);
-
-        ExecutionState::with(|s| {
-            // Re-block all other waiting threads, since we won the race to take this lock
-            for tid in state.waiters.iter() {
-                s.get_mut(tid).block(false);
-            }
-
-            // Update acquiring thread's clock with the clock stored in the Mutex
-            s.update_clock(&state.clock);
-
-            // Update the vector clock stored in the Mutex with this threads clock.
-            // Future threads that fail a `try_lock` have a causal dependency on this thread's acquire.
-            state.clock.update(s.get_clock(me));
-        });
-
         drop(state);
+
+        trace!(semaphore=?self.semaphore, "acquired mutex {:p}", self);
 
         // Grab a `MutexGuard` from the inner lock, which we must be able to acquire here
         let result = match self.inner.try_lock() {
@@ -109,12 +92,6 @@ impl<T: ?Sized> Mutex<T> {
             Err(TryLockError::WouldBlock) => panic!("mutex state out of sync"),
         };
 
-        // We need to let other threads in here so they may fail a `try_lock`. This is the case
-        // because the current thread holding the lock might not have any further context switches
-        // until after releasing the lock. The `concurrent_lock_try_lock` test illustrates this
-        // scenario and would fail if this context switch is not here.
-        thread::switch();
-
         result
     }
 
@@ -123,71 +100,36 @@ impl<T: ?Sized> Mutex<T> {
     /// If the lock could not be acquired at this time, then Err is returned. This function does not
     /// block.
     pub fn try_lock(&self) -> TryLockResult<MutexGuard<T>> {
-        let me = ExecutionState::me();
+        let me = current::me();
 
         let mut state = self.state.borrow_mut();
-        trace!(holder=?state.holder, waiters=?state.waiters, "trying to acquire mutex {:p}", self);
-
-        // We don't need a context switch here. There are two cases to analyze.
-        // * Consider that `state.holder == None` so that we manage to acquire the lock, but that
-        //   there is another thread `t` that also wants to acquire. At the last context switch
-        //   (where we were chosen), `t` must have been already runnable and could have been chosen
-        //   by the scheduler instead. Then `t`'s acquire has a context switch that allows us to
-        //   run into the `WouldBlock` case.
-        // * Consider that `state.holder == Some(t)` so that we run into the `WouldBlock` case,
-        //   but that `t` wants to release. At the last context switch (where we were chosen), `t`
-        //   must have been already runnable and could have been chosen by the scheduler instead.
-        //   Then `t`'s release has a context switch that allows us to acquire the lock.
-
-        let result = if let Some(holder) = state.holder {
-            trace!("try_lock failed for mutex {:p} held by {:?}", self, holder);
-            Err(TryLockError::WouldBlock)
-        } else {
-            state.holder = Some(me);
-
-            trace!("try_lock acquired mutex {:p}", self);
-
-            // Re-block all other waiting threads, since we won the race to take this lock
-            ExecutionState::with(|s| {
-                for tid in state.waiters.iter() {
-                    s.get_mut(tid).block(false);
-                }
-            });
-
-            // Grab a `MutexGuard` from the inner lock, which we must be able to acquire here
-            match self.inner.try_lock() {
-                Ok(guard) => Ok(MutexGuard {
-                    inner: Some(guard),
-                    mutex: self,
-                }),
-                Err(TryLockError::Poisoned(guard)) => Err(TryLockError::Poisoned(PoisonError::new(MutexGuard {
-                    inner: Some(guard.into_inner()),
-                    mutex: self,
-                }))),
-                Err(TryLockError::WouldBlock) => panic!("mutex state out of sync"),
-            }
-        };
-
-        ExecutionState::with(|s| {
-            // Update the vector clock stored in the Mutex with this threads clock.
-            // Future threads that manage to acquire have a causal dependency on this thread's failed `try_lock`.
-            // Future threads that fail a `try_lock` have a causal dependency on this thread's successful `try_lock`.
-            state.clock.update(s.get_clock(me));
-
-            // Update this thread's clock with the clock stored in the Mutex.
-            // We need to do the vector clock update even in the failing case, because there's a causal
-            // dependency: if the `try_lock` fails, the current thread `t1` knows that the thread `t2`
-            // that owns the lock is in its critical section, and therefore `t1` has a causal dependency
-            // on everything that happened before in `t2` (which is recorded in the Mutex's clock).
-            s.update_clock(&state.clock);
-        });
-
+        trace!(holder=?state.holder, semaphore=?self.semaphore, "trying to acquire mutex {:p}", self);
         drop(state);
 
-        // We need to let other threads in here so they
+        // `try_acquire` is a yield point. We need to let other threads in here so they
         // (a) may fail a `try_lock` (in case we acquired), or
         // (b) may release the lock (in case we failed to acquire) so we can succeed in a subsequent `try_lock`.
-        thread::switch();
+        self.semaphore.try_acquire(1)
+            .map_err(|_| TryLockError::WouldBlock)?;
+
+        state = self.state.borrow_mut();
+        state.holder = Some(me);
+        drop(state);
+
+        trace!(semaphore=?self.semaphore, "acquired mutex {:p}", self);
+
+        // Grab a `MutexGuard` from the inner lock, which we must be able to acquire here
+        let result = match self.inner.try_lock() {
+            Ok(guard) => Ok(MutexGuard {
+                inner: Some(guard),
+                mutex: self,
+            }),
+            Err(TryLockError::Poisoned(guard)) => Err(TryLockError::Poisoned(PoisonError::new(MutexGuard {
+                inner: Some(guard.into_inner()),
+                mutex: self,
+            }))),
+            Err(TryLockError::WouldBlock) => panic!("mutex state out of sync"),
+        };
 
         result
     }
@@ -208,11 +150,10 @@ impl<T: ?Sized> Mutex<T> {
     {
         let state = self.state.borrow();
         assert!(state.holder.is_none());
-        assert!(state.waiters.is_empty());
+
         // Update the receiver's clock with the Mutex clock
-        ExecutionState::with(|s| {
-            s.update_clock(&state.clock);
-        });
+        self.semaphore.try_acquire(1).unwrap();
+
         self.inner.into_inner()
     }
 }
@@ -249,46 +190,16 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
 
 impl<'a, T: ?Sized> Drop for MutexGuard<'a, T> {
     fn drop(&mut self) {
-        // We don't need a context switch here *before* releasing the lock. There are two cases to analyze.
-        // * Other threads that want to `lock` are still blocked at this point.
-        // * Other threads that want to `try_lock` and would fail at this point (but not after we release)
-        //   were already runnable at the last context switch (which could have been right after we acquired)
-        //   and could have been scheduled then to fail the `try_lock`.
-
+        // Release the inner mutex
         self.inner = None;
 
         let mut state = self.mutex.state.borrow_mut();
-        trace!(waiters=?state.waiters, "releasing mutex {:p}", self.mutex);
+        trace!(semaphore=?self.mutex.semaphore, "releasing mutex {:p}", self.mutex);
         state.holder = None;
-
-        // Bail out early if we're panicking so we don't try to touch `ExecutionState`
-        if ExecutionState::should_stop() {
-            return;
-        }
-
-        // Unblock every thread waiting on this lock. The scheduler will choose one of them to win
-        // the race to this lock, and that thread will re-block all the losers.
-        let me = ExecutionState::me();
-        state.holder = None;
-        for tid in state.waiters.iter() {
-            debug_assert_ne!(tid, me);
-            ExecutionState::with(|s| {
-                let t = s.get_mut(tid);
-                debug_assert!(t.blocked());
-                t.unblock();
-            });
-        }
-
-        // Update the Mutex clock with the releasing thread's clock
-        ExecutionState::with(|s| {
-            let clock = s.increment_clock();
-            state.clock.update(clock);
-        });
-
         drop(state);
 
-        // Releasing a lock is a yield point
-        thread::switch();
+        // Release a permit (this is a yield point)
+        self.mutex.semaphore.release(1);
     }
 }
 

--- a/tests/demo/async_match_deadlock.rs
+++ b/tests/demo/async_match_deadlock.rs
@@ -74,5 +74,5 @@ fn async_match_deadlock() {
 fn async_match_deadlock_replay() {
     // Deterministically replay a deadlocking execution so we can, for example, single-step through
     // it in a debugger.
-    shuttle::replay(|| tokio::block_on(main()), "91010cbbc0daf8c5a5a9b162a08a08")
+    shuttle::replay(|| tokio::block_on(main()), "91010ab393f492d4dabde32f202200")
 }


### PR DESCRIPTION
Reimplements `std::sync::Mutex` using batch semaphore. The tests already include cases to check causal dependencies and the number of context switches, so these have not changed.

This PR changes `block_on` to not yield before the future is polled for the first time. This caused one replay test to fail. I'm not sure if we should bump versions for this, since it is technically a breaking change for schedules?

We can delay this PR until after we start the crate reorganisation, but this is ready for reviews in any case.

---

While trying to make sure the new semaphore implementation is equivalent to the old one in terms of context switches, I found it useful to write out how the methods work at a high-level, including their yield points. Including this here in case it's useful:

- `Mutex::lock` when blocked
  - check `available_permits` (0 available)
  - (re-entrant deadlock check)
  - `BatchSemaphore::acquire_blocking(1)` blocked
    - check state (-> not enough permits)
    - enqueue waiter
    - **YIELD** (`block_on` poll yield; wait until woken)
    - check and update state (-> permits now available)
    - remove waiter
    - block other failed waiters
    - **YIELD** (let other threads fail a `try_acquire`)
  - (`acquire_blocking` returns)
  - update state
  - acquire inner mutex
- `Mutex::lock` when not blocked
  - check `available_permits` (1)
  - `BatchSemaphore::acquire_blocking(1)` not blocked
    - check state (-> sufficient permits)
    - update state
    - block other failed waiters
    - **YIELD** (let other threads fail a `try_acquire`)
  - (`acquire_blocking` returns)
  - update state
  - acquire inner mutex
- `Mutex::try_lock` failed
  - `BatchSemaphore::try_acquire(1)` failed
    - **YIELD** (so another `try_acquire` in this thread may succeed)
  - (`try_acquire` returns)
- `Mutex::try_lock` successful
  - `BatchSemaphore::try_acquire(1)` successful
    - update state
    - block other failed waiters
    - **YIELD** (let other threads fail a `try_acquire`)
  - (`try_acquire` returns)
  - update state
  - acquire inner mutex
- `Mutex::drop`
  - release inner mutex
  - update state
  - `BatchSemaphore::release(1)`
    - update state
    - unblock all feasible waiters
    - **YIELD** (allow waiters to race and wake)
  - (`release` returns)
- `Mutex::drop` when panicking
  - release inner mutex
  - update state
  - `BatchSemaphore::release(1)`
    - update state
    - forget waiters
    - close semaphore
  - (`release` returns)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.