### PR TITLE
Omit vector clock from debug outuput of Waiter

### DIFF
--- a/src/future/batch_semaphore.rs
+++ b/src/future/batch_semaphore.rs
@@ -54,7 +54,6 @@ impl Waiter {
 /// farther back correspond to later `release` calls. Each batch is a tuple
 /// of the permits remaining in that batch and the clock of the event whence
 /// the permits originate.
-#[derive(Debug)]
 struct PermitsAvailable {
     // Invariant: the number of permits available is equal to the sum of the
     // batch sizes in the queue.
@@ -68,6 +67,15 @@ struct PermitsAvailable {
     /// The clock of the last successful acquire event. Used for causal
     /// dependence in `try_acquire` failures.
     last_acquire: VectorClock,
+}
+
+// Implement debug in order to not output the `VectorClock`s
+impl Debug for PermitsAvailable {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        fmt.debug_struct("PermitsAvailable")
+            .field("num_available", &self.num_available)
+            .finish()
+    }
 }
 
 impl PermitsAvailable {

--- a/src/future/batch_semaphore.rs
+++ b/src/future/batch_semaphore.rs
@@ -14,7 +14,6 @@ use std::sync::Mutex;
 use std::task::{Context, Poll, Waker};
 use tracing::trace;
 
-#[derive(Debug)]
 struct Waiter {
     task_id: TaskId,
     num_permits: usize,
@@ -22,6 +21,19 @@ struct Waiter {
     has_permits: AtomicBool,
     clock: VectorClock,
     waker: Mutex<Option<Waker>>,
+}
+
+// Implement debug in order to not output the `VectorClock`
+impl Debug for Waiter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        fmt.debug_struct("Waiter")
+            .field("task_id", &self.task_id)
+            .field("num_permits", &self.num_permits)
+            .field("is_queued", &self.is_queued)
+            .field("has_permits", &self.has_permits)
+            .field("waker", &self.waker)
+            .finish()
+    }
 }
 
 impl Waiter {

--- a/src/future/batch_semaphore.rs
+++ b/src/future/batch_semaphore.rs
@@ -24,9 +24,9 @@ struct Waiter {
 }
 
 // Implement debug in order to not output the `VectorClock`
-impl Debug for Waiter {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        fmt.debug_struct("Waiter")
+impl fmt::Debug for Waiter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Waiter")
             .field("task_id", &self.task_id)
             .field("num_permits", &self.num_permits)
             .field("is_queued", &self.is_queued)
@@ -70,9 +70,9 @@ struct PermitsAvailable {
 }
 
 // Implement debug in order to not output the `VectorClock`s
-impl Debug for PermitsAvailable {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        fmt.debug_struct("PermitsAvailable")
+impl fmt::Debug for PermitsAvailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PermitsAvailable")
             .field("num_available", &self.num_available)
             .finish()
     }

--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -4,6 +4,7 @@ use crate::runtime::task::TaskId;
 use crate::runtime::thread;
 use std::cell::RefCell;
 use std::collections::HashSet;
+use std::fmt;
 use std::rc::Rc;
 use tracing::trace;
 
@@ -37,7 +38,6 @@ impl BarrierWaitResult {
 /// threads is released by `wait`. When that happens, we make a "leader token_" available for that
 /// batch. The first thread of a batch to get scheduled after becoming unblocked takes the leader
 /// token (without affecting any threads that are part of a different batch).
-#[derive(Debug)]
 struct BarrierState {
     /// The number of tasks that must call `wait` before they all get unblocked (and one gets
     /// chosen as the leader).
@@ -53,6 +53,18 @@ struct BarrierState {
     /// will take the token (by removing the epoch from the set) and become the leader.
     leader_tokens: HashSet<u64>,
     clock: VectorClock,
+}
+
+// Implement debug in order to not output the `VectorClock`
+impl fmt::Debug for BarrierState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BarrierState")
+            .field("bound", &self.bound)
+            .field("epoch", &self.epoch)
+            .field("waiters", &self.waiters)
+            .field("leader_tokens", &self.leader_tokens)
+            .finish()
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Outputting the `VectorClock` in the debug output just adds noise. Kept it in `Task`, maybe that will want to change as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.