### PR TITLE
Reporting & replaying failing random seeds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,13 +322,45 @@ where
 
 /// Run the given function under a randomized concurrency scheduler for some number of iterations.
 /// Each iteration will run a (potentially) different randomized schedule.
+/// When the environment variable SHUTTLE_RANDOM_SEED is set to a u64, this number will be used
+/// as the seed to initialize the random scheduler.
 pub fn check_random<F>(f: F, iterations: usize)
 where
     F: Fn() + Send + Sync + 'static,
 {
     use crate::scheduler::RandomScheduler;
+    use tracing::info;
 
-    let scheduler = RandomScheduler::new(iterations);
+    let seed_env = std::env::var("SHUTTLE_RANDOM_SEED");
+    let runner = match seed_env {
+        Ok(s) => match s.as_str().parse::<u64>() {
+            Ok(seed) => {
+                info!(
+                    "Initializing RandomScheduler with the seed provided by SHUTTLE_RANDOM_SEED: {}",
+                    seed
+                );
+                Runner::new(RandomScheduler::new_from_seed(seed, iterations), Default::default())
+            }
+            Err(err) => panic!("The seed provided by SHUTTLE_RANDOM_SEED is not a valid u64: {}", err),
+        },
+        Err(_) => Runner::new(RandomScheduler::new(iterations), Default::default()),
+    };
+
+    runner.run(f);
+}
+
+/// Run function `f` using `RandomScheduler` initialized with the provided `seed` for the given
+/// `iterations`.
+/// This makes generating the random seed for each execution independent from `RandomScheduler`.
+/// Therefore, this can be used with a library (like proptest) that takes care of generating the
+/// random seeds.
+pub fn check_random_with_seed<F>(f: F, seed: u64, iterations: usize)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    use crate::scheduler::RandomScheduler;
+
+    let scheduler = RandomScheduler::new_from_seed(seed, iterations);
     let runner = Runner::new(scheduler, Default::default());
     runner.run(f);
 }

--- a/tests/data/random.rs
+++ b/tests/data/random.rs
@@ -1,4 +1,4 @@
-use crate::check_replay_roundtrip;
+use crate::{check_replay_from_seed_match_schedule, check_replay_roundtrip};
 use shuttle::rand::{thread_rng, Rng};
 use shuttle::scheduler::RandomScheduler;
 use shuttle::sync::Mutex;
@@ -170,6 +170,42 @@ fn dfs_threads_decorrelated_enabled() {
     let scheduler = DfsScheduler::new(None, true);
     let runner = Runner::new(scheduler, Default::default());
     runner.run(thread_rng_decorrelated);
+}
+
+#[test]
+fn replay_from_seed_match_schedule0() {
+    check_replay_from_seed_match_schedule(
+        broken_atomic_counter_stress,
+        15603830570056246250,
+        "91022ceac7d5bcb1a7fcc5d801a8050ea528954032492693491200000000",
+    );
+}
+
+#[test]
+fn replay_from_seed_match_schedule1() {
+    check_replay_from_seed_match_schedule(
+        broken_atomic_counter_stress,
+        2185777353610950419,
+        "91023c93eecb80c29ddcaa1ef81a1c5251494a2c92928a2a954a25a904000000000000",
+    );
+}
+
+#[test]
+fn replay_from_seed_match_schedule2() {
+    check_replay_from_seed_match_schedule(
+        broken_atomic_counter_stress,
+        14231716651102207764,
+        "91024b94fed5e7c2dccdc0c501185a9c0a889e169b64ca455b2d954a52492a49a59204000000\n00000000",
+    );
+}
+
+#[test]
+fn replay_from_seed_match_schedule3() {
+    check_replay_from_seed_match_schedule(
+        broken_atomic_counter_stress,
+        14271799263003420363,
+        "910278cbcd808888bae787c601081eda4f904cb34937e96cb72db9da965c65d2969b29956dab\ne81625a54432c83469d24c020000000000000000",
+    );
 }
 
 // The DFS scheduler uses the same stream of randomness on each execution to ensure determinism


### PR DESCRIPTION
- When a failing case is found by `RandomScheduler`, shuttle now reports the random seed being used in addition to the failing schedule.
    - This requires a minor change in the implementation of `RandomScheduler`. Now, on a new execution, `RandomScheduler.rng` will be reinitialized with the new seed generated from `data_source`. 
       This is necessary because the two RNGs used in `RandomScheduler` (i.e., `rng` and `data_source`), though initialized using the same seed, advances at different paces. Therefore, the two RNGs will most likely be out of sync after the first iteration, and we cannot replay a failure case with just one seed from then. This change synchronizes the two RNGs at each iteration.
       This change does not seem to affect the performance of `RnadomScheduler`.
- Support replaying the failure with just random seeds.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.