### PR TITLE
Shuttle Explorer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["asynchronous", "concurrency", "development-tools::testing"]
 [dependencies]
 assoc = "0.1.3"
 bitvec = "1.0.1"
+cfg-if = "1.0"
 generator = "0.8.1"
 hex = "0.4.2"
 owo-colors = "3.5.0"
@@ -20,6 +21,11 @@ rand_pcg = "0.3.1"
 scoped-tls = "1.0.0"
 smallvec = { version = "1.11.2", features = ["const_new"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
+
+# for annotation only
+regex = { version = "1.10.6", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
@@ -33,6 +39,10 @@ pin-project = "1.1.3"
 
 [lib]
 bench = false
+
+[features]
+default = []
+annotation = ["dep:serde", "dep:serde_json", "dep:regex"]
 
 [[bench]]
 name = "lock"

--- a/shuttle-explorer/.eslintrc.json
+++ b/shuttle-explorer/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+    "root": true,
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "@typescript-eslint"
+    ],
+    "rules": {
+        "@typescript-eslint/naming-convention": [
+            "warn",
+            {
+                "selector": "import",
+                "format": [ "camelCase", "PascalCase" ]
+            }
+        ],
+        "@typescript-eslint/semi": "warn",
+        "curly": "warn",
+        "eqeqeq": "warn",
+        "no-throw-literal": "warn",
+        "semi": "off"
+    },
+    "ignorePatterns": [
+        "out",
+        "dist",
+        "**/*.d.ts"
+    ]
+}

--- a/shuttle-explorer/.gitignore
+++ b/shuttle-explorer/.gitignore
@@ -1,0 +1,5 @@
+out
+dist
+node_modules
+.vscode-test/
+*.vsix

--- a/shuttle-explorer/.vscode/extensions.json
+++ b/shuttle-explorer/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["dbaeumer.vscode-eslint", "connor4312.esbuild-problem-matchers", "ms-vscode.extension-test-runner"]
+}

--- a/shuttle-explorer/.vscode/launch.json
+++ b/shuttle-explorer/.vscode/launch.json
@@ -1,0 +1,21 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/dist/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		}
+	]
+}

--- a/shuttle-explorer/.vscode/settings.json
+++ b/shuttle-explorer/.vscode/settings.json
@@ -1,0 +1,13 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false, // set this to true to hide the "out" folder with the compiled JS files
+        "dist": false // set this to true to hide the "dist" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true, // set this to false to include "out" folder in search results
+        "dist": true // set this to false to include "dist" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
+}

--- a/shuttle-explorer/.vscode/tasks.json
+++ b/shuttle-explorer/.vscode/tasks.json
@@ -1,0 +1,64 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+            "label": "watch",
+            "dependsOn": [
+                "npm: watch:tsc",
+                "npm: watch:esbuild"
+            ],
+            "presentation": {
+                "reveal": "never"
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "npm",
+            "script": "watch:esbuild",
+            "group": "build",
+            "problemMatcher": "$esbuild-watch",
+            "isBackground": true,
+            "label": "npm: watch:esbuild",
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            }
+        },
+		{
+            "type": "npm",
+            "script": "watch:tsc",
+            "group": "build",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "label": "npm: watch:tsc",
+            "presentation": {
+                "group": "watch",
+                "reveal": "never"
+            }
+        },
+		{
+			"type": "npm",
+			"script": "watch-tests",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never",
+				"group": "watchers"
+			},
+			"group": "build"
+		},
+		{
+			"label": "tasks: watch-tests",
+			"dependsOn": [
+				"npm: watch",
+				"npm: watch-tests"
+			],
+			"problemMatcher": []
+		}
+	]
+}

--- a/shuttle-explorer/.vscodeignore
+++ b/shuttle-explorer/.vscodeignore
@@ -1,0 +1,14 @@
+.vscode/**
+.vscode-test/**
+out/**
+node_modules/**
+src/**
+.gitignore
+.yarnrc
+esbuild.js
+vsc-extension-quickstart.md
+**/tsconfig.json
+**/.eslintrc.json
+**/*.map
+**/*.ts
+**/.vscode-test.*

--- a/shuttle-explorer/README.md
+++ b/shuttle-explorer/README.md
@@ -1,0 +1,34 @@
+# Shuttle Explorer
+
+Timeline visualiser for [Shuttle](https://github.com/awslabs/shuttle).
+
+## Building
+
+To use the extension, it is currently required to build it from source. Pre-requisites include:
+
+- VS Code 1.92.0 or later
+- `node` 18.20 and `npm` 10.5 (other versions are probably fine too)
+- [esbuild Problem Matcher extension](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers), installed either globally or in the Shuttle Explorer workspace. **Without this extension the builds will fail silently!**
+
+Steps:
+
+1. Clone this repository.
+2. Navigate to the Shuttle Explorer directory in a terminal, run `npm install`.
+3. Open the Shuttle Explorer directory in VS Code.
+4. Press F5 or find "Run > Start Debugging" in the menu. Accept a debug configuration if prompted.
+  - In the background, two tasks should spawn: a TypeScript watcher, and an esbuild watcher. You should be able to see both in the "terminal" window, and neither should be reporting an error. If the esbuild watcher is marked as "pending", you need the esbuild Problem Matcher extension.
+  - The TypeScript sources in `src` should be compiled down to JavaScript, output into the `dist` folder.
+5. A new VS Code window (the "extension host") should open.
+6. (Optionally,) open a workspace in the new window, to see the code cursors.
+7. From the command palette (cmd + shift + P), find "Shuttle Explorer: Focus on Home View" to reveal the extension.
+8. Press the "file" button in the top-left corner of the extension panel, or use "View annotated schedule" in the command palette to pick a JSON file to visualise.
+
+Notes:
+
+- Things may go wrong before the extension host window is open. Look at the problems panel, see if there are any problems. Look at the terminal window, to see if the background tasks are running and not reporting any errors.
+- Things may go wrong after the extension host window is open. In that window, look at the console (command palette: "Developer: Open Webview Developer Tools") to look for any errors.
+- After closing the Shuttle Explorer panel, re-opening it will probably not work. Reload the window (cmd + R or command palette: "Developer: Reload Window") to start again.
+
+During development:
+
+- While the extension is running, changing TypeScript files in `src` should trigger an automatic re-compilation. Simply reload the window (cmd + R or command palette: "Developer: Reload Window") with the extension to see the new changes. (Sometimes, the window spontaneously closes after reloading it. Re-start with F5 if this happens.)

--- a/shuttle-explorer/esbuild.js
+++ b/shuttle-explorer/esbuild.js
@@ -1,0 +1,83 @@
+const esbuild = require("esbuild");
+
+const production = process.argv.includes("--production");
+const watch = process.argv.includes("--watch");
+
+/**
+ * @type {import("esbuild").Plugin}
+ */
+// note: the [watch] prefix here is important, see
+// https://github.com/connor4312/esbuild-problem-matchers/blob/51e17a9f4464dd008bfc07871482b94dc87901ce/package.json#L97
+const esbuildProblemMatcherPlugin = {
+  name: "esbuild-problem-matcher",
+
+  setup(build) {
+    build.onStart(() => {
+      console.log("[watch] build started");
+    });
+    build.onEnd((result) => {
+      result.errors.forEach(({ text, location }) => {
+        console.error(`✘ [ERROR] ${text}`);
+        console.error(`    ${location.file}:${location.line}:${location.column}:`);
+      });
+      console.log("[watch] build finished");
+    });
+  },
+};
+
+async function mainBackend() {
+  const ctx = await esbuild.context({
+    entryPoints: [
+      "src/backend/main.mts"
+    ],
+    bundle: true,
+    format: "cjs",
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: "node",
+    outfile: "dist/backend/main.js",
+    external: ["vscode"],
+    logLevel: "silent",
+    plugins: [
+      esbuildProblemMatcherPlugin,
+    ],
+  });
+  if (watch) {
+    await ctx.watch();
+  } else {
+    await ctx.rebuild();
+    await ctx.dispose();
+  }
+}
+
+async function mainFrontend() {
+  const ctx = await esbuild.context({
+    entryPoints: [
+      "src/frontend/main.mts" 
+    ],
+    bundle: true,
+    format: "esm",
+    minify: production,
+    sourcemap: !production,
+    sourcesContent: false,
+    platform: "browser",
+    outfile: "dist/frontend/main.js",
+    external: [],
+    logLevel: "silent",
+    plugins: [
+      esbuildProblemMatcherPlugin,
+    ],
+  });
+  if (watch) {
+    await ctx.watch();
+  } else {
+    await ctx.rebuild();
+    await ctx.dispose();
+  }
+}
+
+Promise.any([mainBackend(), mainFrontend()]).catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/shuttle-explorer/media/main.css
+++ b/shuttle-explorer/media/main.css
@@ -1,0 +1,172 @@
+body {
+    padding: 0;
+}
+
+main {
+    display: grid;
+    gap: 0;
+    grid-template-areas:
+        "tl t s"
+        "m m s";
+    grid-template-columns: 100px 1fr 300px;
+    grid-template-rows: 20px 1fr;
+    height: 100vh;
+    max-height: 100%;
+    margin: 0;
+}
+
+vscode-checkbox .codicon {
+    transform: translate(0, 3px);
+}
+
+.panel-topleft {
+    grid-area: tl;
+    padding: 2px 5px;
+}
+
+.panel-topleft a {
+    cursor: pointer;
+    display: inline-block;
+    padding: 1px 3px 1px 1px;
+}
+.panel-topleft a.selected {
+    background: var(--vscode-inputOption-activeBorder);
+}
+
+.panel-top {
+    grid-area: t;
+}
+
+.panel-sidebar {
+    grid-area: s;
+    overflow-y: scroll;
+}
+
+.panel-sidebar vscode-panel-view {
+    flex-direction: column;
+}
+
+.panel-sidebar #sidebar-view-1.show-event .placeholder,
+.panel-sidebar #sidebar-view-1.show-task .placeholder,
+.panel-sidebar #sidebar-view-1.show-object .placeholder {
+    display: none;
+}
+
+.panel-sidebar #sidebar-view-1 .event-info,
+.panel-sidebar #sidebar-view-1 .task-info,
+.panel-sidebar #sidebar-view-1 .object-info {
+    display: none;
+}
+
+.panel-sidebar #sidebar-view-1.show-event .event-info,
+.panel-sidebar #sidebar-view-1.show-task .task-info,
+.panel-sidebar #sidebar-view-1.show-object .object-info {
+    display: block;
+}
+
+.event-info-backtrace-holder {
+    display: none;
+}
+.event-info-backtrace-holder.show {
+    display: block;
+}
+
+.panel-main {
+    display: grid;
+    gap: 0;
+    grid-template-areas: "l r";
+    grid-template-columns: 100px 1fr;
+    grid-template-rows: 1fr;
+    grid-area: m;
+    overflow-x: hidden;
+    overflow-y: scroll;
+}
+
+.panel-main-left {
+    grid-area: l;
+}
+
+.panel-main-right {
+    grid-area: r;
+}
+
+svg rect.task {
+    cursor: pointer;
+    fill: #ddd;
+    stroke: #999;
+    stroke-width: 1px;
+}
+
+svg rect.task.selected {
+    fill: #bbb;
+    stroke: #333;
+    stroke-width: 1px;
+}
+
+svg rect.blocked {
+    fill: #a00;
+}
+
+svg rect.object {
+    cursor: pointer;
+    fill: #add;
+    stroke: #799;
+    stroke-width: 1px;
+}
+
+svg rect.object.selected {
+    fill: #9bb;
+    stroke: #366;
+    stroke-width: 1px;
+}
+
+svg rect.event {
+    cursor: pointer;
+    fill: #0a0;
+    stroke: #070;
+    stroke-width: 1px;
+}
+svg rect.event.summary {
+    fill: #8a8;
+}
+
+svg rect.event.before {
+    fill: #ca0;
+}
+svg rect.event.after {
+    fill: #0ac;
+}
+svg rect.event.before.summary {
+    fill: #ca8;
+}
+svg rect.event.after.summary {
+    fill: #8ac;
+}
+
+svg rect.event.selected {
+    fill: #0f0;
+}
+
+svg rect.event:hover {
+    fill: #0d0;
+}
+svg rect.event.before:hover {
+    fill: #cd0;
+}
+svg rect.event.after:hover {
+    fill: #0dc;
+}
+
+svg path.link {
+    fill: none;
+    stroke: #000;
+    marker-end: url(#arrow);
+}
+
+.panel-main-left .pm, .panel-main-left circle {
+    cursor: pointer;
+}
+
+.panel-main-left .entry {
+    cursor: pointer;
+}

--- a/shuttle-explorer/media/reset.css
+++ b/shuttle-explorer/media/reset.css
@@ -1,0 +1,30 @@
+html {
+	box-sizing: border-box;
+	font-size: 13px;
+}
+
+*,
+*:before,
+*:after {
+	box-sizing: inherit;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ol,
+ul {
+	margin: 0;
+	padding: 0;
+	font-weight: normal;
+}
+
+img {
+	max-width: 100%;
+	height: auto;
+}

--- a/shuttle-explorer/media/vscode.css
+++ b/shuttle-explorer/media/vscode.css
@@ -1,0 +1,91 @@
+:root {
+	--container-paddding: 20px;
+	--input-padding-vertical: 6px;
+	--input-padding-horizontal: 4px;
+	--input-margin-vertical: 4px;
+	--input-margin-horizontal: 0;
+}
+
+body {
+	padding: 0 var(--container-paddding);
+	color: var(--vscode-foreground);
+	font-size: var(--vscode-font-size);
+	font-weight: var(--vscode-font-weight);
+	font-family: var(--vscode-font-family);
+	background-color: var(--vscode-editor-background);
+}
+
+ol,
+ul {
+	padding-left: var(--container-paddding);
+}
+
+body > *,
+form > * {
+	margin-block-start: var(--input-margin-vertical);
+	margin-block-end: var(--input-margin-vertical);
+}
+
+*:focus {
+	outline-color: var(--vscode-focusBorder) !important;
+}
+
+a {
+	color: var(--vscode-textLink-foreground);
+}
+
+a:hover,
+a:active {
+	color: var(--vscode-textLink-activeForeground);
+}
+
+code {
+	font-size: var(--vscode-editor-font-size);
+	font-family: var(--vscode-editor-font-family);
+}
+
+button {
+	border: none;
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	width: 100%;
+	text-align: center;
+	outline: 1px solid transparent;
+	outline-offset: 2px !important;
+	color: var(--vscode-button-foreground);
+	background: var(--vscode-button-background);
+}
+
+button:hover {
+	cursor: pointer;
+	background: var(--vscode-button-hoverBackground);
+}
+
+button:focus {
+	outline-color: var(--vscode-focusBorder);
+}
+
+button.secondary {
+	color: var(--vscode-button-secondaryForeground);
+	background: var(--vscode-button-secondaryBackground);
+}
+
+button.secondary:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+input:not([type='checkbox']),
+textarea {
+	display: block;
+	width: 100%;
+	border: none;
+	font-family: var(--vscode-font-family);
+	padding: var(--input-padding-vertical) var(--input-padding-horizontal);
+	color: var(--vscode-input-foreground);
+	outline-color: var(--vscode-input-border);
+	background-color: var(--vscode-input-background);
+}
+
+input::placeholder,
+textarea::placeholder {
+	color: var(--vscode-input-placeholderForeground);
+}

--- a/shuttle-explorer/package-lock.json
+++ b/shuttle-explorer/package-lock.json
@@ -1,0 +1,5913 @@
+{
+  "name": "shuttle-explorer",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shuttle-explorer",
+      "version": "0.0.1",
+      "dependencies": {
+        "@types/d3": "^7.4.3",
+        "@vscode/codicons": "^0.0.36",
+        "@vscode/webview-ui-toolkit": "^1.4.0",
+        "d3": "^7.9.0",
+        "jsonlint-pos": "^2.1.2"
+      },
+      "devDependencies": {
+        "@types/mocha": "^10.0.7",
+        "@types/node": "20.x",
+        "@types/vscode": "^1.92.0",
+        "@typescript-eslint/eslint-plugin": "^7.14.1",
+        "@typescript-eslint/parser": "^7.11.0",
+        "@vscode/test-cli": "^0.0.9",
+        "@vscode/test-electron": "^2.4.0",
+        "esbuild": "^0.21.5",
+        "eslint": "^8.57.0",
+        "npm-run-all": "^4.1.5",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "vscode": "^1.92.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/fast-element": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.13.0.tgz",
+      "integrity": "sha512-iFhzKbbD0cFRo9cEzLS3Tdo9BYuatdxmCEKCpZs1Cro/93zNMpZ/Y9/Z7SknmW6fhDZbpBvtO8lLh9TFEcNVAQ=="
+    },
+    "node_modules/@microsoft/fast-foundation": {
+      "version": "2.49.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.6.tgz",
+      "integrity": "sha512-DZVr+J/NIoskFC1Y6xnAowrMkdbf2d5o7UyWK6gW5AiQ6S386Ql8dw4KcC4kHaeE1yL2CKvweE79cj6ZhJhTvA==",
+      "dependencies": {
+        "@microsoft/fast-element": "^1.13.0",
+        "@microsoft/fast-web-utilities": "^5.4.1",
+        "tabbable": "^5.2.0",
+        "tslib": "^1.13.0"
+      }
+    },
+    "node_modules/@microsoft/fast-foundation/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@microsoft/fast-react-wrapper": {
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.24.tgz",
+      "integrity": "sha512-sRnSBIKaO42p4mYoYR60spWVkg89wFxFAgQETIMazAm2TxtlsnsGszJnTwVhXq2Uz+XNiD8eKBkfzK5c/i6/Kw==",
+      "dependencies": {
+        "@microsoft/fast-element": "^1.13.0",
+        "@microsoft/fast-foundation": "^2.49.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@microsoft/fast-web-utilities": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
+      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
+      "dependencies": {
+        "exenv-es6": "^1.1.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.6.tgz",
+      "integrity": "sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ=="
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.3.tgz",
+      "integrity": "sha512-laXM4+1o5ImZv3RpFAsTRn3TEkzqkytiOY0Dz0sq5cnd1dtNlk6sHLon4OvqaiJb28T0S/TdsBI3Sjsy+keJrw=="
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.10.tgz",
+      "integrity": "sha512-cuHoUgS/V3hLdjJOLTT691+G2QoqAjCVLmr4kJXR4ha56w1Zdu8UUQ5TxLRqudgNjwXeQxKMq4j+lyf9sWuslg=="
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.8.tgz",
+      "integrity": "sha512-ew63aJfQ/ms7QQ4X7pk5NxQ9fZH/z+i24ZfJ6tJSfqxJMrYLiK01EAs2/Rtw/JreGUsS3pLPNV644qXFGnoZNQ==",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
+      "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.4.tgz",
+      "integrity": "sha512-ioyQ1zK9aGEomJ45zz8S8IdzElyxhvP1RVWnPrXDf6wFaUb+kk1tEcVVJkF7RPGM0VWI7cp5U57oCPIn5iN1qg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.92.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.92.0.tgz",
+      "integrity": "sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
+      "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ=="
+    },
+    "node_modules/@vscode/test-cli": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.9.tgz",
+      "integrity": "sha512-vsl5/ueE3Jf0f6XzB0ECHHMsd5A0Yu6StElb8a+XsubZW7kHNAOw4Y3TSSuDzKEpLnJ92nbMy1Zl+KLGCE6NaA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mocha": "^10.0.2",
+        "c8": "^9.1.0",
+        "chokidar": "^3.5.3",
+        "enhanced-resolve": "^5.15.0",
+        "glob": "^10.3.10",
+        "minimatch": "^9.0.3",
+        "mocha": "^10.2.0",
+        "supports-color": "^9.4.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "vscode-test": "out/bin.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
+      "integrity": "sha512-Gc6EdaLANdktQ1t+zozoBVRynfIsMKMc94Svu1QreOBC8y76x4tvaK32TljrLi1LI2+PK58sDVbL7ALdqf3VRQ==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^7.0.1",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@vscode/webview-ui-toolkit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
+      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
+      "dependencies": {
+        "@microsoft/fast-element": "^1.12.0",
+        "@microsoft/fast-foundation": "^2.49.4",
+        "@microsoft/fast-react-wrapper": "^0.3.22",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+      "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.22.3",
+        "es-errors": "^1.2.1",
+        "get-intrinsic": "^1.2.3",
+        "is-array-buffer": "^3.0.4",
+        "is-shared-array-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/c8": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-9.1.0.tgz",
+      "integrity": "sha512-mBWcT5iqNir1zIkzSPyI3NCR9EZCVI3WUD+AVO17MVWTSFNyUueXE82qTeampNtTr+ilN/5Ua3j24LgbCKjDVg==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": ">=14.14.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+      "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+      "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+      "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+      "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+      "integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "arraybuffer.prototype.slice": "^1.0.3",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "data-view-buffer": "^1.0.1",
+        "data-view-byte-length": "^1.0.1",
+        "data-view-byte-offset": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-set-tostringtag": "^2.0.3",
+        "es-to-primitive": "^1.2.1",
+        "function.prototype.name": "^1.1.6",
+        "get-intrinsic": "^1.2.4",
+        "get-symbol-description": "^1.0.2",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.0.3",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.0.7",
+        "is-array-buffer": "^3.0.4",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.1",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.3",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.13",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.13.1",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.5",
+        "regexp.prototype.flags": "^1.5.2",
+        "safe-array-concat": "^1.1.2",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.trim": "^1.2.9",
+        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-length": "^1.0.1",
+        "typed-array-byte-offset": "^1.0.2",
+        "typed-array-length": "^1.0.6",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/exenv-es6": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
+      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "functions-have-names": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+      "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+      "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.0",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+      "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+      "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+      "dev": true,
+      "dependencies": {
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "peer": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/jsonlint-pos": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/jsonlint-pos/-/jsonlint-pos-2.1.2.tgz",
+      "integrity": "sha512-Y/ZCWF8/HomJmNb0amUZG7bms9SoMQDzYg30WtMSgn0Rt+u1T0EUBQK++po80+LIh7z4bASSWGhVGpY9GyQR5A==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "JSV": ">= 4.0.x",
+        "lodash": "^4.17.21"
+      },
+      "bin": {
+        "jsonlint": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha512-ZJ6wx9xaKJ3yFUhq5/sk82PJMuUyLk277I8mQeyDgCTjGdjWJIvPfaU5LIXaMuaN2UO1X3kZH4+lgphublZUHw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "define-properties": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
+      "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.9.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.3.0",
+        "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
+        "string-width": "^6.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "dev": true
+    },
+    "node_modules/ora/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
+      "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^10.2.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+      "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "set-function-name": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+      "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "get-intrinsic": "^1.2.4",
+        "has-symbols": "^1.0.3",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+      "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.6",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "dev": true
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
+      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+      "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+      "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
+      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+      "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+      "integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+      "integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-proto": "^1.0.3",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/shuttle-explorer/package.json
+++ b/shuttle-explorer/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "shuttle-explorer",
+  "displayName": "Shuttle Explorer",
+  "description": "",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.92.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [],
+  "main": "./dist/backend/main.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "shuttle-explorer.view",
+        "title": "View annotated schedule"
+      }
+    ],
+    "viewsContainers": {
+      "panel": [
+        {
+          "id": "shuttleExplorerPanel",
+          "title": "Shuttle Explorer",
+          "icon": "$(rocket)"
+        }
+      ]
+    },
+    "views": {
+      "shuttleExplorerPanel": [
+        {
+          "type": "webview",
+          "id": "shuttleExplorerPanel.views.home",
+          "name": "Home",
+          "contextualTitle": "Shuttle Explorer",
+          "initialSize": 6,
+          "visibility": "visible"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run package",
+    "compile": "npm run check-types && npm run lint && node esbuild.js",
+    "watch": "npm-run-all -p watch:*",
+    "watch:esbuild": "node esbuild.js --watch",
+    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+    "package": "npm run check-types && npm run lint && node esbuild.js --production",
+    "compile-tests": "tsc -p . --outDir out",
+    "watch-tests": "tsc -p . -w --outDir out",
+    "pretest": "npm run compile-tests && npm run compile && npm run lint",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint src --ext mts",
+    "test": "vscode-test"
+  },
+  "devDependencies": {
+    "@types/mocha": "^10.0.7",
+    "@types/node": "20.x",
+    "@types/vscode": "^1.92.0",
+    "@typescript-eslint/eslint-plugin": "^7.14.1",
+    "@typescript-eslint/parser": "^7.11.0",
+    "@vscode/test-cli": "^0.0.9",
+    "@vscode/test-electron": "^2.4.0",
+    "esbuild": "^0.21.5",
+    "eslint": "^8.57.0",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "@types/d3": "^7.4.3",
+    "@vscode/codicons": "^0.0.36",
+    "@vscode/webview-ui-toolkit": "^1.4.0",
+    "d3": "^7.9.0",
+    "jsonlint-pos": "^2.1.2"
+  }
+}

--- a/shuttle-explorer/src/backend/main.mts
+++ b/shuttle-explorer/src/backend/main.mts
@@ -1,0 +1,590 @@
+import * as vscode from "vscode";
+import * as jsonlint from "jsonlint-pos";
+
+// to decorate the JSON itself
+const decorationSchedule = vscode.window.createTextEditorDecorationType({
+    backgroundColor: "#4d0",
+});
+
+// to place cursors in the code corresponding to tasks
+const decorationCode = vscode.window.createTextEditorDecorationType({
+    after: {
+        backgroundColor: "#4d0",
+        color: "#090",
+        height: "1.1em",
+        margin: "1px",
+    },
+});
+
+import { Schedule, ScheduleEvent, ProcessedSchedule, ScheduleV0 } from "../common/schedule.mjs";
+import { MessageBackToFront, MessageFrontToBack } from "../common/messages.mts";
+
+export function activate(context: vscode.ExtensionContext) {
+    // TODO: the panel does not show again after closing, the entire window has to be reloaded
+    console.log("Shuttle Explorer activated");
+    const explorer = new Explorer(context.extensionUri);
+    vscode.window.onDidChangeActiveTextEditor((editor) => explorer.decorateEditor(editor));
+    context.subscriptions.push(vscode.window.registerWebviewViewProvider(Explorer.viewType, explorer));
+    context.subscriptions.push(vscode.commands.registerCommand("shuttle-explorer.view", () => explorer.askForSchedule()));
+}
+
+export function deactivate() {}
+
+type CustomFilter = {
+    path: vscode.Uri,
+    watcher: vscode.FileSystemWatcher,
+};
+
+class Explorer implements vscode.WebviewViewProvider {
+    // matches the view ID in package.json
+    public static readonly viewType = "shuttleExplorerPanel.views.home";
+    private _view?: vscode.WebviewView;
+
+    // schedule
+    private _schedulePath: vscode.Uri | null = null;
+    private _scheduleString: string | null = null;
+    private _annotatedSchedule?: ScheduleV0;
+    private _annotatedScheduleWithPos: any | null = null;
+
+    // code cursors
+    private _activeEditor?: vscode.TextEditor;
+    private _previewEvent?: [number, ScheduleEvent] | null;
+    private _selectedEvent?: [number, ScheduleEvent];
+    private _processedSchedule?: ProcessedSchedule;
+
+    // custom filters
+    private _customFilters: CustomFilter[] = [];
+
+    constructor(
+        private readonly _extensionUri: vscode.Uri,
+    ) {}
+
+    private _processSchedule(
+        schedule: ScheduleV0,
+    ) {
+        // process the schedule so that we know, for each event, which other
+        // tasks are concurrently executing and thus which code cursors should
+        // be shown
+        let tasksRunning: number[] = [];
+        let lastEventByTask: Map<number, number> = new Map();
+        let eventId = 0;
+        let previousEvents: ScheduleEvent[][] = [];
+        for (const [taskId, _info, kind] of schedule.events) {
+            if (typeof kind === "string" || kind instanceof String) {
+                if (kind === "TaskTerminated") {
+                    tasksRunning.splice(tasksRunning.indexOf(taskId), 1);
+                }
+            } else {
+                if ("TaskCreated" in kind) {
+                    tasksRunning.push(kind["TaskCreated"][0]);
+                }
+            }
+            lastEventByTask.set(taskId, eventId);
+            const previous = tasksRunning.sort()
+                .filter(otherId => taskId !== otherId)
+                .filter(otherId => lastEventByTask.has(otherId))
+                .map(otherId => schedule.events[lastEventByTask.get(otherId)!]);
+            previousEvents.push(previous);
+            eventId++;
+        }
+        this._processedSchedule = {
+            previousEvents,
+        };
+    }
+
+    public async askForSchedule() {
+        // ask for schedule
+        const schedule = await vscode.window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: {
+                "Schedule": ["json"],
+            },
+        });
+        if (schedule) {
+            this.setSchedulePath(schedule[0]);
+        }
+    }
+
+    public setSchedulePath(
+        path: vscode.Uri,
+    ) {
+        this._schedulePath = path;
+        this._loadSchedule();
+    }
+
+    private _loadSchedule() {
+        if (this._schedulePath === null) { return; }
+        vscode.workspace.fs.readFile(this._schedulePath).then((scheduleRaw: Uint8Array) => {
+            this._scheduleString = new TextDecoder("utf-8").decode(scheduleRaw);
+            const schedule: Schedule = JSON.parse(this._scheduleString);
+            switch (schedule.version) {
+                case 0:
+                    this.setAnnotatedSchedule(schedule as ScheduleV0);
+                    this.decorateEditor(vscode.window.activeTextEditor);
+                    break;
+                default:
+                    vscode.window.showErrorMessage(`Schedule version ${schedule.version} not supported.`);
+            }
+        }, (reason) => {
+            console.error(reason);
+            vscode.window.showErrorMessage("Could not load schedule.");
+        });
+    }
+
+    public setAnnotatedSchedule(
+        schedule: ScheduleV0,
+    ) {
+        this._annotatedSchedule = schedule;
+        this._annotatedScheduleWithPos = null;
+        this._previewEvent = null;
+        this._selectedEvent = [0, schedule.events[0]];
+        this._sendMessage({
+            type: "createTimeline",
+            data: schedule,
+        });
+        this._processSchedule(schedule);
+    }
+
+    public decorateEditor(
+        editor?: vscode.TextEditor,
+    ) {
+        this._activeEditor = editor;
+        this._updateDecorations();
+    }
+
+    private _sendMessage(message: MessageBackToFront) {
+        if (this._view) {
+            this._view.webview.postMessage(message);
+        }
+    }
+
+    public resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        _context: vscode.WebviewViewResolveContext,
+        _token: vscode.CancellationToken,
+    ) {
+        this._view = webviewView;
+        webviewView.webview.options = {
+            // allow scripts in the webview
+            enableScripts: true,
+            localResourceRoots: [
+                this._extensionUri,
+            ],
+        };
+        webviewView.webview.html = this._getHtmlForWebview(webviewView.webview);
+        webviewView.webview.onDidReceiveMessage((msg: MessageFrontToBack) => { switch (msg.type) {
+            case "backtraceClick": this._onBacktraceClick(msg.data[0], msg.data[1]); break;
+            case "createCustomFilter":
+                vscode.window.showOpenDialog({
+                    canSelectFiles: true,
+                    canSelectFolders: false,
+                    canSelectMany: false,
+                    filters: {
+                        "Filter": ["js"],
+                    },
+                }).then((path) => {
+                    if (!path || path.length !== 1) { return; }
+                    const filterPath = path[0];
+                    const watcher = vscode.workspace.createFileSystemWatcher(
+                        filterPath.fsPath, // TODO: is this right? it's not really a glob pattern ...
+                    );
+                    const filter: CustomFilter = {
+                        path: filterPath,
+                        watcher,
+                    };
+                    const cleanup = () => {
+                        this._customFilters.splice(this._customFilters.indexOf(filter), 1);
+                        watcher.dispose();
+                    }
+                    const update = () => vscode.workspace.fs.readFile(filterPath).then((sourceRaw: Uint8Array) => {
+                        const source = new TextDecoder("utf-8").decode(sourceRaw);
+                        this._sendMessage({
+                            type: "updateCustomFilter",
+                            data: {
+                                name: filterPath.fsPath,
+                                source,
+                            },
+                        });
+                    }, (reason) => {
+                        console.error(reason);
+                        vscode.window.showErrorMessage("Could not load custom filter.");
+                        cleanup();
+                    });
+                    watcher.onDidChange(() => update());
+                    watcher.onDidDelete(() => cleanup());
+                    this._customFilters.push(filter);
+                    update();
+                });
+                break;
+            case "createEventFilterStart":
+                // "Create filter" pressed in event panel, ask user what they want
+                vscode.window.showQuickPick([
+                    {
+                        filterKind: "before",
+                        label: "causally before",
+                        description: "Filter will show only events that causally precede (happen-before) the selected event.",
+                    }, {
+                        filterKind: "after",
+                        label: "causally after",
+                        description: "Filter will show only events that causally succeed (happen-after) the selected event.",
+                    }, {
+                        filterKind: "concurrent",
+                        label: "concurrent",
+                        description: "Filter will show only events that are concurrent with the selected event, i.e., are not causally related.",
+                    },
+                ], {
+                    title: "Which type of filter should be created?",
+                }).then((chosen) => {
+                    if (!chosen) return;
+                    this._sendMessage({
+                        type: "createEventFilter",
+                        data: {
+                            eventId: msg.data,
+                            kind: chosen.filterKind as ("before" | "after" | "concurrent"),
+                        },
+                    });
+                });
+                break;
+            case "createObjectFilterStart":
+                // "Create filter" pressed in object panel, ask user what they want
+                vscode.window.showQuickPick([
+                    {
+                        keepObject: true,
+                        label: "with object",
+                        description: "Filter will show only events that relate to the object.",
+                    }, {
+                        keepObject: false,
+                        label: "without object",
+                        description: "Filter will hide events that relate to the object.",
+                    },
+                ], {
+                    title: "Which type of filter should be created?",
+                }).then((chosen) => {
+                    if (!chosen) return;
+                    this._sendMessage({
+                        type: "createObjectFilter",
+                        data: {
+                            objectId: msg.data,
+                            keepObject: chosen.keepObject,
+                        },
+                    });
+                });
+                break;
+            case "eventHover": this._onEventHover(msg.data); break;
+            case "eventHoverOff": this._onEventHoverOff(msg.data); break;
+            case "eventClick":
+                this._ensureFocus();
+                this._onEventClick(msg.data);
+                break;
+            case "objectClick": this._ensureFocus(); break;
+            case "reloadSchedule":
+                if (this._schedulePath) {
+                    this._loadSchedule();
+                } else {
+                    this.askForSchedule();
+                }
+                break;
+            case "taskClick": this._ensureFocus(); break;
+        } });
+    }
+
+    private _ensureFocus() {
+        if (!this._view) { return; }
+        this._view.show();
+    }
+
+    private _onEventHover(
+        event_id: number,
+    ) {
+        if (!this._annotatedSchedule
+            || !this._annotatedSchedule.events[event_id]
+            || !this._selectedEvent) { return; }
+        if (this._selectedEvent[0] === event_id) {
+            this._previewEvent = null;
+            return;
+        }
+        this._previewEvent = [event_id, this._annotatedSchedule.events[event_id]];
+        this._updateDecorations();
+    }
+
+    private _onEventHoverOff(
+        eventId: number,
+    ) {
+        if (!this._annotatedSchedule
+            || !this._annotatedSchedule.events[eventId]
+            || !this._previewEvent) { return; }
+        if (this._previewEvent[0] === eventId) {
+            this._previewEvent = null;
+            this._updateDecorations();
+        }
+    }
+
+    private _onEventClick(
+        eventId: number,
+    ) {
+        if (!this._annotatedSchedule
+            || !this._annotatedSchedule.events[eventId]) { return; }
+        this._selectedEvent = [eventId, this._annotatedSchedule.events[eventId]];
+        if (this._previewEvent && this._selectedEvent[0] === this._previewEvent[0]) {
+            this._previewEvent = null;
+        }
+        this._updateDecorations();
+    }
+
+    private _onBacktraceClick(
+        eventId: number,
+        btId: number,
+    ) {
+        if (!this._activeEditor
+            || !this._annotatedSchedule
+            || !this._annotatedSchedule.events[eventId]
+            || !this._annotatedSchedule.events[eventId][1]) { return; }
+        const [pathId, _functionId, line, col] = this._annotatedSchedule.events[eventId][1][btId];
+        const path = vscode.Uri.joinPath(
+            vscode.workspace.workspaceFolders![0].uri,
+            this._annotatedSchedule.files[pathId].path,
+        );
+        vscode.window.showTextDocument(path, {
+            preview: true,
+            selection: new vscode.Selection(
+                line - 1, col - 1,
+                line - 1, col - 1,
+            ),
+        });
+    }
+
+    private _updateDecorations() {
+        if (!this._activeEditor
+            || !this._annotatedSchedule) { return; }
+        const activePath = this._activeEditor.document.uri;
+
+        const decorations: vscode.DecorationOptions[] = [];
+        const eventId = this._selectedEvent![0];
+
+        // if we are looking at the schedule JSON, highlight the current event
+        if (activePath.toString() === this._schedulePath?.toString()) {
+            // this is ugly, but it turns out parsing JSON while preserving
+            // the source positions is not such a common task, so we use
+            // a niche library
+            if (this._annotatedScheduleWithPos === null) {
+                jsonlint.parser.setPosEnabled(true);
+                this._annotatedScheduleWithPos = (jsonlint as any).parse(this._scheduleString);
+            }
+
+            const {
+                first_line,
+                last_line,
+                first_column,
+                last_column,
+            } = this._annotatedScheduleWithPos.events._pos[`_${eventId}`];
+            decorations.push({
+                range: new vscode.Range(first_line - 1, first_column, last_line - 1, last_column),
+            });
+
+            this._activeEditor.setDecorations(decorationSchedule, decorations);
+            this._activeEditor.setDecorations(decorationCode, []);
+            return;
+        }
+
+        const eventsToShow = [this._selectedEvent![1]].concat(this._processedSchedule!.previousEvents[eventId]);
+
+        for (const [taskId, info, kind] of eventsToShow) {
+            if (info === null) { continue; }
+            const [pathIdx, _functionIdx, line, col] = info[0];
+
+            const eventPath = vscode.Uri.joinPath(
+                vscode.workspace.workspaceFolders![0].uri,
+                this._annotatedSchedule!.files[pathIdx].path,
+            );
+            if (activePath.toString() !== eventPath.toString()) {
+                continue;
+            }
+
+            decorations.push({
+                range: new vscode.Range(line - 1, col - 1, line - 1, col - 1),
+                renderOptions: {
+                    after: {
+                        contentText: "#" + taskId,
+                    },
+                },
+            });
+        }
+        // if (this._previewEvent) addEvent(this._previewEvent[1]);
+
+        this._activeEditor.setDecorations(decorationSchedule, []);
+        this._activeEditor.setDecorations(decorationCode, decorations);
+    }
+
+    private _getHtmlForWebview(webview: vscode.Webview) {
+        // prepare URIs for local stylesheets
+        const styleResetUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "media", "reset.css"));
+        const styleVSCodeUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "media", "vscode.css"));
+        const styleMainUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "media", "main.css"));
+
+        // package-sourced
+        const styleCodiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "node_modules", "@vscode/codicons", "dist", "codicon.css"));
+        const toolkitUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "node_modules", "@vscode/webview-ui-toolkit", "dist", "toolkit.min.js"));
+        const d3Uri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "node_modules", "d3", "dist", "d3.min.js"));
+
+        // frontend Javascript
+        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, "dist", "frontend", "main.js"));
+
+        const nonce = getNonce();
+        // TODO: move to separate file
+        // TODO: many of the "classes" here should actually be "id"s
+        return /*html*/`<!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <!-- unsafe-eval is a bit sketchy, it's only here for custom filters... -->
+                <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; font-src ${webview.cspSource}; script-src 'nonce-${nonce}' 'unsafe-eval'">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <link href="${styleResetUri}" rel="stylesheet">
+                <link href="${styleVSCodeUri}" rel="stylesheet">
+                <link href="${styleCodiconsUri}" rel="stylesheet">
+                <link href="${styleMainUri}" rel="stylesheet">
+                <title>Shuttle Explorer</title>
+                <script nonce="${nonce}" type="text/javascript" src="${d3Uri}"></script>
+                <script nonce="${nonce}" type="module" src="${toolkitUri}"></script>
+                <script nonce="${nonce}" type="module" src="${scriptUri}"></script>
+            </head>
+            <body>
+                <main>
+                    <div class="panel-topleft">
+                        <a id="reload-schedule" title="Load or reload schedule file">
+                            <i class="codicon codicon-file"></i>
+                        </a><a id="toggle-cdag" title="Show causal graph">
+                            <i class="codicon codicon-repo-forked"></i>
+                        </a><a id="toggle-objects" class="selected" title="Show objects">
+                            <i class="codicon codicon-symbol-field"></i>
+                        </a><a id="reveal-selected" title="Scroll to selected task/event/object">
+                            <i class="codicon codicon-eye"></i>
+                        </a>
+                    </div>
+                    <svg class="panel-top"></svg>
+                    <div class="panel-sidebar">
+                        <vscode-panels activeid="sidebar-tab-1">
+                            <vscode-panel-tab id="sidebar-tab-1">SELECTION</vscode-panel-tab>
+                            <vscode-panel-tab id="sidebar-tab-2">FILTERS</vscode-panel-tab>
+                            <vscode-panel-view id="sidebar-view-1">
+                                <p class="placeholder">Select an event, task, or object.</p>
+                                <div class="event-info">
+                                    <vscode-data-grid grid-template-columns="2fr 3fr">
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Kind</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="event-info-kind">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Time</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="event-info-time">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Task</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="event-info-task">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Extra data</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="event-info-extra">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                    </vscode-data-grid>
+                                    <div class="event-info-backtrace-holder">
+                                        <vscode-divider></vscode-divider>
+                                        <vscode-data-grid class="event-info-backtrace" grid-template-columns="2fr 3fr">
+                                            <vscode-data-grid-row row-type="header">
+                                                <vscode-data-grid-cell grid-column="1" cell-type="columnheader">Function</vscode-data-grid-cell>
+                                                <vscode-data-grid-cell grid-column="2" cell-type="columnheader">Path</vscode-data-grid-cell>
+                                            </vscode-data-grid-row>
+                                        </vscode-data-grid>
+                                    </div>
+                                    <vscode-button class="event-create-filter">Create filter</vscode-button>
+                                </div>
+                                <div class="task-info">
+                                    <vscode-data-grid grid-template-columns="2fr 3fr">
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Kind</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="task-info-kind">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Name</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="task-info-name">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">ID</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="task-info-id">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Created by</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="task-info-created">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">First step</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="task-info-first">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Last step</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="task-info-last">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                    </vscode-data-grid>
+                                </div>
+                                <div class="object-info">
+                                    <vscode-data-grid grid-template-columns="2fr 3fr">
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Kind</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-kind">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Name</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-name">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">ID</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-id">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Created by</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-created">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Seen by</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-seen">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">First step</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-first">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                        <vscode-data-grid-row>
+                                            <vscode-data-grid-cell grid-column="1">Last step</vscode-data-grid-cell>
+                                            <vscode-data-grid-cell grid-column="2" class="object-info-last">-</vscode-data-grid-cell>
+                                        </vscode-data-grid-row>
+                                    </vscode-data-grid>
+                                    <vscode-button class="object-create-filter">Create filter</vscode-button>
+                                </div>
+                            </vscode-panel-view>
+                            <vscode-panel-view id="sidebar-view-2">
+                                <vscode-checkbox id="filters-tick">Tick events <vscode-badge>0</vscode-badge></vscode-checkbox>
+                                <vscode-checkbox id="filters-semaphore" checked>Semaphore events <vscode-badge>0</vscode-badge></vscode-checkbox>
+                                <vscode-checkbox id="filters-task" checked>Task events <vscode-badge>0</vscode-badge></vscode-checkbox>
+                                <vscode-checkbox id="filters-random" checked>Random events <vscode-badge>0</vscode-badge></vscode-checkbox>
+                                <vscode-button id="filters-add">Add custom filter</vscode-button>
+                                <vscode-divider></vscode-divider>
+                                <div id="filters-user"></div>
+                            </vscode-panel-view>
+                        </vscode-panels>
+                    </div>
+                    <div class="panel-main"></div>
+                </main>
+            </body>
+            </html>`;
+    }
+}
+
+function getNonce() {
+    let text = "";
+    const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/shuttle-explorer/src/common/clocks.mts
+++ b/shuttle-explorer/src/common/clocks.mts
@@ -1,0 +1,43 @@
+import { Event } from "./events.mts";
+
+export enum Ordering {
+    Less = -1,
+    Equal,
+    Greater,
+}
+
+function unifyOrdering(a: Ordering, b: Ordering): Ordering | null {
+    if (a === Ordering.Equal && b === Ordering.Equal) {
+        return Ordering.Equal;
+    } else if ((a === Ordering.Less && b === Ordering.Greater)
+        || (a === Ordering.Greater && b === Ordering.Less)) {
+        return null;
+    } else if (a === Ordering.Less || b === Ordering.Less) {
+        return Ordering.Less;
+    } else if (a === Ordering.Greater || b === Ordering.Greater) {
+        return Ordering.Greater;
+    } else {
+        // unreachable!
+        return null;
+    }
+}
+
+function numCmp(a: number, b: number): Ordering {
+    return a < b ? Ordering.Less : (a > b ? Ordering.Greater : Ordering.Equal);
+}
+
+export function clockCmp({clock: clockA}: Event, {clock: clockB}: Event): Ordering | null {
+    if (clockA === null || clockB === null) {
+        return null;
+    }
+    const entriesA = clockA.length;
+    const entriesB = clockB.length;
+    let ord: Ordering | null = numCmp(entriesA, entriesB);
+    for (let i = 0; i < Math.min(entriesA, entriesB); i++) {
+        ord = unifyOrdering(ord, numCmp(clockA[i], clockB[i]));
+        if (ord === null) {
+            return null;
+        }
+    }
+    return ord;
+}

--- a/shuttle-explorer/src/common/context.mts
+++ b/shuttle-explorer/src/common/context.mts
@@ -1,0 +1,106 @@
+import { Event, eventCategories, EventId, readEvent } from "./events.mts";
+import { Filter, filterByCategory, initFilter } from "./filters.mts";
+import { HierarchyEntry } from "./hierarchy.mts";
+import { Object, ObjectId, readObject } from "./objects.mts";
+import { Schedule, ScheduleV0 } from "./schedule.mts";
+import { Task, TaskId, readTask } from "./tasks.mts";
+
+export type ExtContextData = {
+    source: ScheduleV0,
+    tasks: Task[],
+    objects: Object[],
+    events: Event[],
+};
+
+export type ExtContextHierarchy = {
+    hierarchy: HierarchyEntry[],
+};
+
+export type ExtContextFilters = {
+    chain: Filter<any>[],
+    keptEvents: number,
+};
+
+export function createContextData(schedule: Schedule): ExtContextData {
+    switch (schedule.version) {
+        case 0:
+            const scheduleV0: ScheduleV0 = (schedule as ScheduleV0);
+
+            const ctx: ExtContextData = {
+                source: scheduleV0,
+                tasks: [],
+                objects: [],
+                events: [],
+            };
+
+            // process tasks, objects, then events; the order matters
+            for (let taskId: TaskId = 0; taskId < scheduleV0.tasks.length; taskId++) {
+                ctx.tasks.push(readTask(ctx, taskId));
+            }
+            for (let objectId: ObjectId = 0; objectId < scheduleV0.objects.length; objectId++) {
+                ctx.objects.push(readObject(ctx, objectId));
+            }
+            for (let eventId: EventId = 0; eventId < scheduleV0.events.length; eventId++) {
+                ctx.events.push(readEvent(ctx, eventId));
+            }
+            return ctx;
+        default:
+            throw "schedule version not supported";
+    }
+}
+
+export function createContextHierarchy(ctxData: ExtContextData): ExtContextHierarchy {
+    const ctx: ExtContextHierarchy = {
+        hierarchy: [],
+    };
+
+    // heuristic: find nearest common ancestor for tasks that have seen the object
+    for (const object of ctxData.objects) {
+        const path = ctxData.tasks[object.createdBy].path;
+        let pathLength = path.length;
+        for (let seenById of [...object.seenBy.keys()].sort()) {
+            let otherPath = ctxData.tasks[seenById].path;
+            if (pathLength > otherPath.length) {
+                pathLength = otherPath.length;
+            }
+            while (pathLength > 0 && path[pathLength - 1] !== otherPath[pathLength - 1]) {
+                pathLength--;
+            }
+        }
+
+        // TODO: heuristic: only keep objects that were seen by two or more threads
+        // TODO: hackily only enabled for schedules with a large number of objects!
+        if (ctxData.objects.length < 1000 || object.seenBy.size > 1) {
+            ctxData.tasks[path[pathLength - 1]].children.push(object);
+        }
+    }
+
+    // flatten data for hierarchy display
+    let visibleIndex = -1;
+    function walk(entry: HierarchyEntry, depth: number): void {
+        // keep hierarchy open to a max depth of 3 by default
+        //entry.visible = depth <= 3;
+        //entry.visibleIndex = entry.visible ? ++visibleIndex : visibleIndex;
+        entry.flatIndex = ctx.hierarchy.length;
+        entry.depth = depth;
+        ctx.hierarchy.push(entry);
+        entry.children.forEach((child) => walk(child, depth + 1));
+    }
+    walk(ctxData.tasks[0], 0);
+
+    return ctx;
+}
+
+export function createContextFilters(ctxData: ExtContextData): ExtContextFilters {
+    let filter = initFilter(ctxData, filterByCategory);
+    let keptEvents = 0;
+    for (let category of eventCategories) {
+        if (filter.data.enabledCategories[category]) {
+            keptEvents += filter.data.categoryCounts[category];
+        }
+    }
+    return {
+        chain: [filter],
+        keptEvents,
+    };
+}

--- a/shuttle-explorer/src/common/events.mts
+++ b/shuttle-explorer/src/common/events.mts
@@ -1,0 +1,231 @@
+import { ExtContextData } from "./context.mts";
+import { ObjectId } from "./objects.mts";
+import { ScheduleEvent } from "./schedule.mts";
+import { TaskId } from "./tasks.mts";
+
+export type EventCategory =
+    "tick"
+    | "semaphore"
+    | "task"
+    | "random";
+
+export const eventCategories: EventCategory[] = [
+    "tick",
+    "semaphore",
+    "task",
+    "random",
+];
+
+export type EventBacktraceFrame = {
+    btId: number,
+    path: string,
+    functionName: string,
+    line: number,
+    col: number,
+};
+export type EventBacktrace = EventBacktraceFrame[];
+
+export type EventKind =
+    | "SemaphoreCreated"
+    | "SemaphoreClosed"
+    | "SemaphoreAcquireFast"
+    | "SemaphoreAcquireBlocked"
+    | "SemaphoreAcquireUnblocked"
+    | "SemaphoreTryAcquire"
+    | "SemaphoreRelease"
+    | "TaskCreated"
+    | "TaskTerminated"
+    | "Random"
+    | "Tick";
+
+export type EventId = number;
+
+export type Event = {
+    source: ScheduleEvent,
+    id: EventId,
+    taskId: TaskId,
+    backtrace: EventBacktrace | null,
+    kind: EventKind | null,
+    category: EventCategory | null,
+    data: any,
+    clock: number[] | null,
+    runnable: TaskId[] | null,
+    extra: any,
+};
+
+/**
+ * Reads the given event from the annotated schedule. Tasks and objects should
+ * be initialised in `ctx` by this point.
+ */
+export function readEvent(ctx: ExtContextData, eventId: number): Event {
+    const [taskId, info, kind, clock, runnable, extra] = ctx.source.events[eventId];
+    const event: Event = {
+        source: ctx.source.events[eventId],
+        id: eventId,
+        taskId,
+        backtrace: null,
+        kind: null,
+        category: null,
+        data: null,
+        clock: !!clock ? clock : null,
+        runnable: !!runnable ? runnable : null,
+        extra,
+    };
+    if (info) {
+        event.backtrace = info.map(([pathId, functionId, line, col], btId) => ({
+            btId,
+            path: ctx.source.files[pathId].path,
+            functionName: ctx.source.functions[functionId].name,
+            line,
+            col,
+        }));
+    }
+
+    // parse data into nicer representation
+    if (typeof kind === "string" || kind instanceof String) {
+        event.kind = kind as EventKind;
+    } else {
+        if ("TaskCreated" in kind) {
+            event.kind = "TaskCreated";
+            event.data = {
+                taskId: kind["TaskCreated"][0],
+                isFuture: kind["TaskCreated"][1],
+            };
+        } else if ("SemaphoreCreated" in kind) {
+            event.kind = "SemaphoreCreated";
+            event.data = {
+                objectId: kind["SemaphoreCreated"],
+            };
+        } else if ("SemaphoreClosed" in kind) {
+            event.kind = "SemaphoreClosed";
+            event.data = {
+                objectId: kind["SemaphoreClosed"],
+            };
+        } else if ("SemaphoreAcquireFast" in kind) {
+            event.kind = "SemaphoreAcquireFast";
+            event.data = {
+                objectId: kind["SemaphoreAcquireFast"][0],
+                numPermits: kind["SemaphoreAcquireFast"][1],
+            };
+        } else if ("SemaphoreAcquireBlocked" in kind) {
+            event.kind = "SemaphoreAcquireBlocked";
+            event.data = {
+                objectId: kind["SemaphoreAcquireBlocked"][0],
+                numPermits: kind["SemaphoreAcquireBlocked"][1],
+            };
+        } else if ("SemaphoreAcquireUnblocked" in kind) {
+            event.kind = "SemaphoreAcquireUnblocked";
+            event.data = {
+                objectId: kind["SemaphoreAcquireUnblocked"][0],
+                taskId: kind["SemaphoreAcquireUnblocked"][1],
+                numPermits: kind["SemaphoreAcquireUnblocked"][2],
+            };
+        } else if ("SemaphoreTryAcquire" in kind) {
+            event.kind = "SemaphoreTryAcquire";
+            event.data = {
+                objectId: kind["SemaphoreTryAcquire"][0],
+                numPermits: kind["SemaphoreTryAcquire"][1],
+                successful: kind["SemaphoreTryAcquire"][2],
+            };
+        } else if ("SemaphoreRelease" in kind) {
+            event.kind = "SemaphoreRelease";
+            event.data = {
+                objectId: kind["SemaphoreRelease"][0],
+                numPermits: kind["SemaphoreRelease"][1],
+            };
+        }
+    }
+
+    // identify tasks which have seen an object
+    function seen(objectId: ObjectId, taskId: TaskId) {
+        ctx.objects[objectId].seenBy.set(taskId, true);
+    }
+
+    let category: EventCategory | null = null;
+    switch (event.kind) {
+        case "TaskCreated":
+            category = "task";
+            // update task kind
+            ctx.tasks[event.data.taskId].isFuture = event.data.isFuture;
+            ctx.tasks[event.data.taskId].createEvent = event;
+            ctx.tasks[event.data.taskId].createdAt = eventId;
+            break;
+        case "TaskTerminated":
+            category = "task";
+            // update task closing event
+            ctx.tasks[taskId].lastStep = eventId;
+            break;
+
+        case "SemaphoreCreated":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            ctx.objects[event.data.objectId].createEvent = event;
+            break;
+        case "SemaphoreClosed":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            // update object closing event
+            ctx.objects[event.data.objectId].lastStep = eventId;
+            break;
+        case "SemaphoreAcquireFast":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            break;
+        case "SemaphoreAcquireBlocked":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            break;
+        case "SemaphoreAcquireUnblocked":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            break;
+        case "SemaphoreTryAcquire":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            break;
+        case "SemaphoreRelease":
+            category = "semaphore";
+            seen(event.data.objectId, taskId);
+            break;
+
+        case "Tick":
+            category = "tick";
+            break;
+
+        case "Random":
+            category = "random";
+            break;
+    }
+    event.category = category;
+
+    // record which tasks were blocked
+    if (event.runnable !== null) {
+        for (const {id, firstStep, lastStep, blockedAt} of ctx.tasks) {
+            if (!event.runnable.includes(id)
+                && firstStep <= eventId
+                && eventId <= lastStep) {
+                blockedAt.push(eventId);
+                // blockedRanges.push([lastSchedule, eventId]);
+            }
+        }
+        // TODO: keeping track of blocked *ranges* rather than ticks should
+        //       be more efficient
+        // lastSchedule = eventId;
+    }
+
+    // compute events belonging to each task
+    ctx.tasks[taskId].events.push(event);
+
+    return event;
+}
+
+export function writeEvent(event: Event): ScheduleEvent {
+    return [
+        event.taskId,
+        event.source[1],
+        event.source[2],
+        event.clock,
+        event.runnable,
+        event.extra,
+    ];
+}

--- a/shuttle-explorer/src/common/filters.mts
+++ b/shuttle-explorer/src/common/filters.mts
@@ -1,0 +1,176 @@
+/**
+ * Filters are a system to hide events from the timeline based on various
+ * criteria, such as the kind of event, which object it is related to, whether
+ * it happens-before another event, etc.
+ */
+
+import {
+    Event,
+    EventCategory,
+    eventCategories,
+} from "./events.mts";
+
+import {
+    ExtContextData,
+} from "./context.mts";
+import { clockCmp, Ordering } from "./clocks.mts";
+
+/**
+ * A filter for events.
+ */
+export interface Filter<TData> {
+    /**
+     * Title to show in the filters list. (Not shown for built-in filters.)
+     */
+    title: string,
+
+    /**
+     * Is the filter currently enabled?
+     */
+    enabled: boolean,
+
+    /**
+     * Is the filter built-in and thus always present in the filter chain?
+     */
+    builtin: boolean,
+
+    /**
+     * Any state that the filter makes use of.
+     */
+    data: TData,
+
+    /**
+     * How many events *in total*, i.e., without applying prior filters in the
+     * chain, pass through this filter? Set after initialisation.
+     */
+    totalCount?: number,
+
+    /**
+     * Initialises the filter's state.
+     */
+    init?: (self: TData, events: Event[]) => void,
+
+    /**
+     * Checks whether the given event passes through this filter.
+     * @returns `true` iff the event passes, i.e., it should be shown in the
+     * timeline (assuming other filters don't filter it out).
+     */
+    check: (self: TData, event: Event) => boolean,
+};
+
+/**
+ * A helper type to declare filter types which satisfy the `Filter` interface.
+ */
+type BaseFilter<TData> = {
+    title: string,
+    enabled: boolean,
+    builtin: boolean,
+    data: TData,
+    totalCount?: number,
+    init?: (self: TData, events: Event[]) => void,
+    check: (self: TData, event: Event) => boolean,
+};
+
+type FilterByCategoryData = {
+    /**
+     * Which categories are currently enabled?
+     */
+    enabledCategories: {[key in EventCategory]?: boolean},
+
+    /**
+     * How many events in each category?
+     */
+    categoryCounts: {[key in EventCategory]?: number},
+};
+/**
+ * Categories enabled by default.
+ */
+const categoriesEnabledByDefault: EventCategory[] = [
+    "semaphore",
+    "task",
+    "random",
+];
+export const filterByCategory: BaseFilter<FilterByCategoryData> = {
+    title: "Category filter",
+    enabled: true,
+    builtin: true,
+    data: {
+        enabledCategories: {},
+        categoryCounts: {},
+    },
+    init: (self, events) => {
+        for (const category of eventCategories) {
+            self.enabledCategories[category] = categoriesEnabledByDefault.includes(category);
+            self.categoryCounts[category] = 0;
+        }
+
+        // count number of events per category
+        for (const event of events) {
+            self.categoryCounts[event.category!]!++;
+        }
+    },
+    check: (self, {category}) => self.enabledCategories[category!]!,
+};
+
+/**
+ * Initialises a filter with stats, such as the total number of events that the
+ * filter keeps.
+ * @param filter Filter to initialise.
+ * @returns Initialised filter.
+ */
+export function initFilter(ctx: ExtContextData, filter: Filter<any>): Filter<any> {
+    if (filter.init) {
+        filter.init(filter.data, ctx.events);
+    }
+    filter.totalCount = ctx.events.filter(event => filter.check(filter.data, event)).length;
+    return filter;
+}
+
+/**
+ * Creates a filter that only keeps or hides events related to a specific object.
+ * @param objectId Object ID to keep or hid.
+ * @param keepObject If `true`, related events are kept, otherwise they are filtered.
+ * @returns A filter which keeps events related to the given object.
+ */
+export function filterByObject(ctx: ExtContextData, objectId: number, keepObject: boolean): Filter<{}> {
+    return initFilter(ctx, {
+        title: `Show only events ${keepObject ? "with" : "without"} object ${objectId}`,
+        enabled: true,
+        builtin: false,
+        data: {},
+        check: (_self, {category, data}) => (category === "semaphore" && data.objectId === objectId) == keepObject,
+    });
+}
+
+export function filterByEventBefore(ctx: ExtContextData, eventId: number): Filter<{}> {
+    const refEvent = ctx.events[eventId];
+    return initFilter(ctx, {
+        title: `Show only events causally before event ${eventId}`,
+        enabled: true,
+        builtin: false,
+        data: {},
+        check: (_self, event) => event.id === refEvent.id || clockCmp(event, refEvent) === Ordering.Less,
+    });
+}
+
+export function filterByEventAfter(ctx: ExtContextData, eventId: number): Filter<{}> {
+    const refEvent = ctx.events[eventId];
+    return initFilter(ctx, {
+        title: `Show only events causally after event ${eventId}`,
+        enabled: true,
+        builtin: false,
+        data: {},
+        check: (_self, event) => event.id === refEvent.id || clockCmp(refEvent, event) === Ordering.Less,
+    });
+}
+
+export function filterByEventConcurrent(ctx: ExtContextData, eventId: number): Filter<{}> {
+    const refEvent = ctx.events[eventId];
+    return initFilter(ctx, {
+        title: `Show only events concurrent to (causally unrelated to) event ${eventId}`,
+        enabled: true,
+        builtin: false,
+        data: {},
+        check: (_self, event) => event.id === refEvent.id || clockCmp(refEvent, event) === null,
+    });
+}

--- a/shuttle-explorer/src/common/hierarchy.mts
+++ b/shuttle-explorer/src/common/hierarchy.mts
@@ -1,0 +1,68 @@
+import { Event } from "./events.mts";
+import { TaskId } from "./tasks.mts";
+
+/**
+ * An entry in the hierarchy display (left panel).
+ */
+export interface HierarchyEntry {
+    /**
+     * Display name, shown in the details panel, and in the hierarchy.
+     */
+    name: string | null,
+
+    /**
+     * Is this a task (`true`), or an object (`false`)?
+     */
+    isTask: boolean,
+
+    /**
+     * Index of this entry in the flattened hierarchy (obtained by a
+     * depth-first flattening of the tree).
+     */
+    flatIndex: number,
+
+    /**
+     * How deep in the hierarchy is this entry? `0` for the root task.
+     */
+    depth: number,
+
+    /**
+     * Other entries that are shown as child nodes of this one.
+     */
+    children: HierarchyEntry[],
+
+    /**
+     * Sequence of task IDs, leading from the root to this entry.
+     */
+    path: number[],
+
+    /**
+     * First step that involves this entry.
+     */
+    firstStep: number,
+
+    /**
+     * Last step that involves this entry.
+     */
+    lastStep: number,
+
+    /**
+     * Events involving this entry.
+     */
+    events: Event[],
+
+    /**
+     * Which event created this entry? `null` for the root task.
+     */
+    createEvent: Event | null,
+
+    /**
+     * Which task created this entry?
+     */
+    createdBy: TaskId,
+
+    /**
+     * At what time was this entry created?
+     */
+    createdAt: number,
+};

--- a/shuttle-explorer/src/common/messages.mts
+++ b/shuttle-explorer/src/common/messages.mts
@@ -1,0 +1,65 @@
+import { EventId } from "./events.mts";
+import { ObjectId } from "./objects.mts";
+import { Schedule } from "./schedule.mts";
+import { TaskId } from "./tasks.mts";
+
+/**
+ * Message sent from the backend to the frontend.
+ */
+export type MessageBackToFront =
+    {
+        type: "createTimeline",
+        data: Schedule,
+    } | {
+        type: "createEventFilter",
+        data: {
+            eventId: EventId,
+            kind: "before" | "after" | "concurrent",
+        },
+    } | {
+        type: "createObjectFilter",
+        data: {
+            objectId: ObjectId,
+            keepObject: boolean,
+        },
+    } | {
+        type: "updateCustomFilter",
+        data: {
+            name: string,
+            source: string,
+        },
+    };
+
+/**
+ * Message sent from the frontend to the backend.
+ */
+export type MessageFrontToBack =
+    {
+        type: "backtraceClick",
+        data: [EventId, number],
+    } | {
+        type: "createCustomFilter",
+    } | {
+        type: "createEventFilterStart",
+        data: EventId,
+    } | {
+        type: "createObjectFilterStart",
+        data: ObjectId,
+    } | {
+        type: "eventHover",
+        data: EventId,
+    } | {
+        type: "eventHoverOff",
+        data: EventId,
+    } | {
+        type: "eventClick",
+        data: EventId,
+    } | {
+        type: "objectClick",
+        data: ObjectId,
+    } | {
+        type: "reloadSchedule",
+    } | {
+        type: "taskClick",
+        data: TaskId,
+    };

--- a/shuttle-explorer/src/common/objects.mts
+++ b/shuttle-explorer/src/common/objects.mts
@@ -1,0 +1,48 @@
+import { ExtContextData } from "./context.mts";
+import { HierarchyEntry } from "./hierarchy.mts";
+import { ScheduleObject } from "./schedule.mts";
+
+export type ObjectId = number;
+
+export type Object = HierarchyEntry & {
+    source: ScheduleObject,
+    id: ObjectId,
+    isTask: false,
+    seenBy: Map<number, boolean>,
+    kind: string | null,
+};
+
+/**
+ * Reads the given object from the annotated schedule.
+ */
+export function readObject(ctx: ExtContextData, objectId: number): Object {
+    const {created_by, created_at, name, kind} = ctx.source.objects[objectId];
+    const object: Object = {
+        source: ctx.source.objects[objectId],
+        id: objectId,
+        isTask: false,
+        name,
+        kind,
+        createEvent: null,
+        createdBy: created_by,
+        firstStep: created_at,
+        createdAt: created_at,
+        lastStep: ctx.source.events.length - 1,
+        seenBy: new Map(),
+        children: [],
+        path: [],
+        flatIndex: 0,
+        depth: 0,
+        events: [],
+    };
+    return object;
+}
+
+export function writeObject(object: Object): ScheduleObject {
+    return {
+        created_by: object.createdBy,
+        created_at: object.createdAt,
+        name: object.name,
+        kind: object.kind,
+    };
+}

--- a/shuttle-explorer/src/common/schedule.mts
+++ b/shuttle-explorer/src/common/schedule.mts
@@ -1,0 +1,57 @@
+/**
+ * Type definitions must match the JSON produced by `serde`.
+ */
+
+// TODO: name these types better
+
+export type ScheduleObject = {
+    created_by: number,
+    created_at: number,
+    name: string | null,
+    kind: string | null,
+};
+
+export type ScheduleTask = {
+    created_by: number,
+    first_step: number,
+    last_step: number,
+    name: string | null,
+};
+
+export type ScheduleEventKind =
+    | {"SemaphoreCreated": number}
+    | {"SemaphoreClosed": number}
+    | {"SemaphoreAcquireFast": [number, number]}
+    | {"SemaphoreAcquireBlocked": [number, number]}
+    | {"SemaphoreAcquireUnblocked": [number, number, number]}
+    | {"SemaphoreTryAcquire": [number, number, boolean]}
+    | {"SemaphoreRelease": [number, number]}
+    | {"TaskCreated": [number, boolean]}
+    | "TaskTerminated"
+    | "Random"
+    | "Tick"
+    | {"Schedule": number[]};
+
+export type ScheduleEvent = [
+    number, // task
+    [number, number, number, number][] | null, // backtrace
+    ScheduleEventKind,
+    number[] | null, // vector clock
+    number[] | null, // runnable tasks when scheduling
+    any, // optional extra data
+];
+
+export type Schedule = {version: number};
+
+export type ScheduleV0 = {
+    version: 0,
+    files: {path: string}[],
+    functions: {name: string}[],
+    objects: ScheduleObject[],
+    tasks: ScheduleTask[],
+    events: ScheduleEvent[],
+};
+
+export type ProcessedSchedule = {
+    previousEvents: ScheduleEvent[][],
+};

--- a/shuttle-explorer/src/common/tasks.mts
+++ b/shuttle-explorer/src/common/tasks.mts
@@ -1,0 +1,56 @@
+import { ExtContextData } from "./context.mts";
+import { HierarchyEntry } from "./hierarchy.mts";
+import { ScheduleTask } from "./schedule.mts";
+
+export type TaskId = number;
+
+export type Task = HierarchyEntry & {
+    source: ScheduleTask,
+    id: TaskId,
+    isTask: true,
+    isFuture: boolean,
+    blockedAt: number[], // TODO: blockedRanges: [], ?
+};
+
+/**
+ * Reads the given task from the annotated schedule.
+ */
+export function readTask(ctx: ExtContextData, taskId: number): Task {
+    const {created_by, first_step, name} = ctx.source.tasks[taskId];
+    const task: Task = {
+        source: ctx.source.tasks[taskId],
+        id: taskId,
+        name,
+        isTask: true,
+        isFuture: false,
+        createEvent: null,
+        createdBy: created_by,
+        createdAt: first_step,
+        firstStep: first_step > 10000000 ? 0 : first_step, // DEMO HACK: sometimes -1 is serialised here ...
+        lastStep: ctx.source.events.length - 1, // last_step,
+        children: [],
+        path: [0],
+        flatIndex: 0,
+        depth: 0,
+        events: [],
+        blockedAt: [], // TODO: blockedRanges: [], ?
+    };
+
+    // `created_by === taskId` only for the initial/main thread. Otherwise,
+    // this task was created by another.
+    if (created_by !== taskId) {
+        ctx.tasks[created_by].children.push(task);
+        task.path = ctx.tasks[created_by].path.concat([taskId]);
+    }
+
+    return task;
+}
+
+export function writeTask(task: Task): ScheduleTask {
+    return {
+        created_by: task.createdBy,
+        first_step: task.firstStep,
+        last_step: task.source.last_step,
+        name: task.name,
+    };
+}

--- a/shuttle-explorer/src/deno.json.tmp
+++ b/shuttle-explorer/src/deno.json.tmp
@@ -1,0 +1,3 @@
+{
+    "exclude": ["backend", "frontend"]
+}

--- a/shuttle-explorer/src/frontend/cdag.mts
+++ b/shuttle-explorer/src/frontend/cdag.mts
@@ -1,0 +1,122 @@
+import { clockCmp, Ordering } from "../common/clocks.mts";
+import { TaskId } from "../common/tasks.mts";
+import { EventUI } from "./events.mts";
+import { ExtContextUI } from "./ui.mts";
+
+export function updateCdag(ctx: ExtContextUI) {
+    // TODO: this is still a little bit broken, but it is probably because the
+    // clocks coming from Shuttle are not quite right
+
+    // find position of events in causal graph (CDAG)
+    // TODO: only do once
+
+    // in the CDAG we want to organise events vertically into tasks (same as
+    // for the timeline view), and horizontally according to causality, with
+    // program order represented as the order of events in a lane, and causal
+    // dependence shown as arrows
+
+    // for each task, keep track of highest clock it has seen so far
+    // at each step; there can be a bump to the clock for one of two reasons:
+    // - the task itself has performed an observable step
+    // - another task has performed an observable step, and the current task
+    //   causally depends on that other task
+
+    // for display purposes, the first case is not relevant: the bump by
+    // itself is only observable by the current task?
+
+    const lastEvent: Map<TaskId, EventUI> = new Map();
+    const lastSeenIndex: Map<TaskId, number> = new Map();
+    const lastDependedOn: Map<TaskId, EventUI | null> = new Map();
+    const taskColumn: Map<TaskId, number> = new Map();
+    const columnUsed: Map<number, number> = new Map();
+    for (let eventId = 0; eventId < ctx!.events.length; eventId++) {
+        const event = ctx!.events[eventId];
+        event.causallyDependsOn.length = 0;
+
+        // the first event is in the first column
+        let cdagIdx = 0;
+        if (eventId === 0) {
+            cdagIdx = 0;
+        }
+
+        // in the absence of causal ordering, each task starts in the first column
+        if (!taskColumn.has(event.event.taskId)) {
+            taskColumn.set(event.event.taskId, 0);
+        }
+
+        // look at the events of other tasks that happened since this task's last event
+        if (!lastSeenIndex.has(event.event.taskId)) {
+            lastSeenIndex.set(event.event.taskId, 0);
+            lastDependedOn.set(event.event.taskId, null);
+        }
+
+        //console.log("checking", event.event.id, "of task", event.event.taskId, "range is from/to", lastSeenIndex.get(event.event.taskId), eventId);
+        if (event.event.clock) {
+            const dependingOn: Map<TaskId, EventUI> = new Map();
+            for (let otherEventId = lastSeenIndex.get(event.event.taskId)!; otherEventId < eventId; otherEventId++) {
+                const otherEvent = ctx!.events[otherEventId];
+
+                if (otherEvent.event.taskId === event.event.taskId) {
+                    cdagIdx = Math.max(cdagIdx, otherEvent.cdagIdx + 1);
+                } else if (otherEvent.event.clock) {
+                    // is there a causal ordering?
+                    const order = clockCmp(otherEvent.event, event.event);
+                    if (order === Ordering.Less) { // otherEvent happens-before event
+                        //let transitiveDependency = false;
+
+                        // TODO: remove, this shouldn't happen
+                        // has the previous event in this task already causally dependend on otherEvent?
+                        // if so, we don't want to add another link, it would be redundant
+                        const prevEventOfThisTask = lastEvent.get(event.event.taskId);
+                        if (prevEventOfThisTask && clockCmp(otherEvent.event, prevEventOfThisTask.event) === Ordering.Less) {
+                            // console.log("  this shouldn't happen?", otherEvent.event.id, event.event.id, otherEvent.event.clock, event.event.clock);
+                            continue;
+                        }
+
+                        //console.log("  less", otherEvent.event.id, event.event.id, otherEvent.event.clock, event.event.clock);
+
+                        cdagIdx = Math.max(cdagIdx, otherEvent.cdagIdx + 1);
+                        dependingOn.set(otherEvent.event.taskId, otherEvent);
+                    } else if (order === Ordering.Equal) { // otherEvent === event?
+                        //console.log("  equal???", otherEvent.event.id, event.event.id, otherEvent.event.clock, event.event.clock);
+                    } else if (order === Ordering.Greater) { // this should not happen! we are iterating the orders in timeline order
+                        //console.log("  greater?!", otherEvent.event.id, event.event.id, otherEvent.event.clock, event.event.clock);
+                    } else { // no causal ordering
+                        // pass
+                    }
+                }
+            }
+            for (const [_taskId, otherEvent] of dependingOn) {
+                event.causallyDependsOn.push(otherEvent);
+            }
+            lastEvent.set(event.event.taskId, event);
+            lastSeenIndex.set(event.event.taskId, eventId);
+            //console.log("  result", eventId, cdagIdx, event.event.clock);
+        }
+        event.cdagIdx = cdagIdx;
+        if (!columnUsed.has(cdagIdx)) {
+            columnUsed.set(cdagIdx, 0);
+        }
+        if (!event.filtered) {
+            columnUsed.set(cdagIdx, columnUsed.get(cdagIdx)! + 1);
+        }
+    }
+
+    // sort used columns and give ones which contain more than one non-filtered event increasing indices
+    // see https://stackoverflow.com/a/51242261
+    const sortedColumns = new Map([...columnUsed].sort((a, b) => a[0] - b[0]));
+    let cdagColumns = 0;
+    for (const [column, visibleEvents] of sortedColumns) {
+        columnUsed.set(column, cdagColumns);
+        if (visibleEvents > 0) {
+            cdagColumns++;
+        }
+    }
+    ctx!.timeline.cdagColumns = cdagColumns;
+
+    // renumber based on columns which are not empty
+    for (let eventId = 0; eventId < ctx!.events.length; eventId++) {
+        const event = ctx!.events[eventId];
+        event.cdagKeptIdx = columnUsed.get(event.cdagIdx)!;
+    }
+}

--- a/shuttle-explorer/src/frontend/events.mts
+++ b/shuttle-explorer/src/frontend/events.mts
@@ -1,0 +1,24 @@
+import { Event } from "../common/events.mts";
+
+export type EventUI = {
+    event: Event,
+    // TODO: rename to *Index (for consistency)
+    keptIdx: number,
+    cdagIdx: number,
+    cdagKeptIdx: number,
+    shownIdx: number,
+    filtered: boolean,
+    causallyDependsOn: EventUI[],
+};
+
+export function createEventUI(event: Event): EventUI {
+    return {
+        event,
+        keptIdx: 0,
+        cdagIdx: 0,
+        cdagKeptIdx: 0,
+        shownIdx: 0,
+        filtered: false,
+        causallyDependsOn: [],
+    };
+}

--- a/shuttle-explorer/src/frontend/hierarchy.mts
+++ b/shuttle-explorer/src/frontend/hierarchy.mts
@@ -1,0 +1,56 @@
+import { HierarchyEntry } from "../common/hierarchy.mts";
+import { Object } from "../common/objects.mts";
+import { Task } from "../common/tasks.mts";
+
+export interface HierarchyEntryUI {
+    entry: HierarchyEntry,
+
+    isTask: boolean,
+
+    /**
+     * Is this entry currently visible? An entry may be hidden if its parent
+     * is collapsed.
+     */
+    visible: boolean,
+
+    /**
+     * Index of this entry among the currently visible entries. Collapsed
+     * entries have the same visible index as the last visible entry.
+     */
+    visibleIndex: number,
+
+    /**
+     * Is the entry open (`true`) or collapsed (`false`)?
+     */
+    open: boolean,
+};
+
+export type ObjectUI = HierarchyEntryUI & {
+    isTask: false,
+    entry: Object,
+};
+
+export type TaskUI = HierarchyEntryUI & {
+    isTask: true,
+    entry: Task,
+};
+
+export function createObjectUI(object: Object): ObjectUI {
+    return {
+        entry: object,
+        isTask: false,
+        visible: true,
+        visibleIndex: 0,
+        open: true,
+    };
+}
+
+export function createTaskUI(task: Task): TaskUI {
+    return {
+        entry: task,
+        isTask: true,
+        visible: true,
+        visibleIndex: 0,
+        open: true,
+    };
+}

--- a/shuttle-explorer/src/frontend/main.mts
+++ b/shuttle-explorer/src/frontend/main.mts
@@ -1,0 +1,111 @@
+import * as d3 from "d3";
+
+declare const acquireVsCodeApi: any;
+
+import {
+    provideVSCodeDesignSystem,
+    vsCodeButton,
+    vsCodeCheckbox,
+    vsCodeDataGrid,
+    vsCodeDataGridCell,
+    vsCodeDataGridRow,
+    vsCodeDivider,
+    vsCodeLink,
+    vsCodePanels,
+    vsCodePanelTab,
+    vsCodePanelView,
+} from "@vscode/webview-ui-toolkit";
+
+import { Schedule } from "../common/schedule.mjs";
+import {
+    createContextData,
+    createContextFilters,
+    createContextHierarchy,
+    ExtContextData,
+    ExtContextFilters,
+    ExtContextHierarchy,
+} from "../common/context.mjs";
+import { addCustomFilter, addFilter, createContextUI, ctxData, ExtContextUI } from "./ui.mts";
+import { filterByEventAfter, filterByEventBefore, filterByEventConcurrent, filterByObject } from "../common/filters.mts";
+import { MessageBackToFront, MessageFrontToBack } from "../common/messages.mts";
+
+type ExtContext = {
+    data: ExtContextData,
+    hierarchy: ExtContextHierarchy,
+    filters: ExtContextFilters,
+    ui: ExtContextUI,
+};
+
+export let vscode: any = null;
+
+export function sendMessage(message: MessageFrontToBack) {
+    vscode.postMessage(message);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    vscode = acquireVsCodeApi();
+
+    provideVSCodeDesignSystem().register(
+        vsCodeButton(),
+        vsCodeCheckbox(),
+        vsCodeDataGrid(),
+        vsCodeDataGridCell(),
+        vsCodeDataGridRow(),
+        vsCodeDivider(),
+        vsCodeLink(),
+        vsCodePanels(),
+        vsCodePanelTab(),
+        vsCodePanelView(),
+    );
+
+    function createTimeline(schedule: Schedule) {
+        let ctxPartial: {
+            data?: ExtContextData,
+            hierarchy?: ExtContextHierarchy,
+            filters?: ExtContextFilters,
+            ui?: ExtContextUI,
+        } = {};
+        ctxPartial.data = createContextData(schedule);
+        console.log("schedule stats", {
+            taskCount: ctxPartial.data.tasks.length,
+            eventCount: ctxPartial.data.events.length,
+            objectCount: ctxPartial.data.objects.length,
+        });
+        ctxPartial.hierarchy = createContextHierarchy(ctxPartial.data);
+        ctxPartial.filters = createContextFilters(ctxPartial.data);
+        ctxPartial.ui = createContextUI(ctxPartial.data, ctxPartial.filters, ctxPartial.hierarchy);
+        let _ctx: ExtContext = ctxPartial as ExtContext;
+    }
+
+    // reload schedule
+    d3.select("#reload-schedule")
+        .on("click", () => sendMessage({ type: "reloadSchedule" }));
+
+    window.addEventListener("message", (event: MessageEvent<MessageBackToFront>) => {
+        const {type, data} = event.data;
+        switch (type) {
+            case "createEventFilter":
+                switch (data.kind) {
+                    case "before":
+                        addFilter(filterByEventBefore(ctxData!, data.eventId), false);
+                        break;
+                    case "after":
+                        addFilter(filterByEventAfter(ctxData!, data.eventId), false);
+                        break;
+                    case "concurrent":
+                        addFilter(filterByEventConcurrent(ctxData!, data.eventId), false);
+                        break;
+                }
+                break;
+            case "createObjectFilter":
+                addFilter(filterByObject(ctxData!, data.objectId, data.keepObject), false);
+                break;
+            case "createTimeline":
+                createTimeline(data);
+                break;
+            case "updateCustomFilter":
+                addCustomFilter(data.name, data.source);
+                break;
+        }
+    });
+});

--- a/shuttle-explorer/src/frontend/selection.mts
+++ b/shuttle-explorer/src/frontend/selection.mts
@@ -1,0 +1,310 @@
+/**
+ * Functions and types related to selections, i.e., clicking on a task, event,
+ * or object in the timeline and the right panel displaying additional info.
+ */
+
+import * as d3 from "d3";
+
+import { EventId } from "../common/events.mjs";
+import { Object, ObjectId } from "../common/objects.mjs";
+import { Task, TaskId } from "../common/tasks.mjs";
+import { ctx, ctxData } from "./ui.mts";
+import { updateTimelineLinks } from "./timeline.mts";
+import { clockCmp, Ordering } from "../common/clocks.mts";
+import { sendMessage } from "./main.mts";
+
+export type ExtContextUISelection = {
+    eventId: EventId | null,
+    taskId: TaskId | null,
+    objectId: ObjectId | null,
+};
+export function createContextUISelection(): ExtContextUISelection {
+    return {
+        eventId: null,
+        taskId: null,
+        objectId: null,
+    };
+}
+
+function selectEventImpl(eventId: EventId | null, doSendMessage: boolean, openTab: boolean) {
+    ctx!.timeline.events!
+        .classed("selected", false)
+        .classed("before", false)
+        .classed("after", false);
+    ctx!.selection.eventId = eventId;
+    if (eventId !== null) {
+        if (doSendMessage) {
+            sendMessage({ type: "eventClick", data: eventId });
+        }
+
+        const event = ctx!.events[eventId];
+        const taskId = event.event.taskId;
+
+        ctx!.timeline.events!
+            .classed("before", ({maxData}) =>
+                maxData.event.id < event.event.id
+                && (maxData.event.taskId === taskId || clockCmp(maxData.event, event.event) === Ordering.Less))
+            .classed("after", ({minData}) =>
+                event.event.id < minData.event.id
+                && (minData.event.taskId === taskId || clockCmp(event.event, minData.event) === Ordering.Less));
+
+        ctx!.timeline.events!
+            .filter(({minData, maxData}) => minData.event.taskId === taskId && minData.event.id <= eventId && eventId <= maxData.event.id)
+            //.filter(e => e.event.taskId === taskId && e.event.id <= eventId && eventId <= e.event.id)
+            .classed("selected", true);
+
+        // select tab
+        if (openTab) {
+            (d3.select(".panel-sidebar vscode-panels").node()! as any).activeid = "sidebar-tab-1";
+        }
+
+        // fill in sidebar
+        const infoRoot = d3.select("#sidebar-view-1")
+            .classed("show-event", true)
+            .select(".event-info");
+        const infoKind = event.event.kind; // TODO: human-readable description?
+        infoRoot
+            .select(".event-info-kind")
+            .text(infoKind);
+        infoRoot
+            .select(".event-info-time")
+            .html(`<vscode-link>Step ${event.event.id}</vscode-link> (${event.filtered ? "filtered" : `${event.keptIdx} after filters`})`)
+            .select("vscode-link")
+            .on("click", () => selectEvent(event.event.id, true));
+        infoRoot
+            .select(".event-info-task")
+            .html(`<vscode-link>Task ${event.event.taskId}</vscode-link>`)
+            .select("vscode-link")
+            .on("click", () => selectTask(event.event.taskId, true));
+        infoRoot
+            .select(".event-info-extra")
+            .text(event.event.extra ? JSON.stringify(event.event.extra) : "-");
+
+        const backtrace = event.event.backtrace;
+        infoRoot
+            .select(".event-info-backtrace-holder")
+            .classed("show", !!backtrace);
+        if (backtrace !== null) {
+            let rows = infoRoot.select(".event-info-backtrace")
+                .selectAll("vscode-data-grid-row[row-type=\"default\"]")
+                .data(event.event.backtrace ? event.event.backtrace : [])
+                .join("vscode-data-grid-row")
+                    .attr("row-type", "default");
+            rows.selectAll("vscode-data-grid-cell.col1")
+                .data(d => [d])
+                .join("vscode-data-grid-cell")
+                    .classed("col1", true)
+                    .attr("grid-column", "1")
+                    .html(({functionName}) => `<code>${functionName}</code>`);
+            rows.selectAll("vscode-data-grid-cell.col2")
+                .data(d => [d])
+                .join("vscode-data-grid-cell")
+                    .classed("col2", true)
+                    .attr("grid-column", "2")
+                    .html(({path, line, col}) => `<code>${path}:${line}:${col}</code>`)
+                    .on("click", (_ev, {btId}) => sendMessage({ type: "backtraceClick", data: [eventId, btId] }));
+        }
+
+        // filter setup
+        infoRoot.select(".event-create-filter")
+            .on("click", () => sendMessage({ type: "createEventFilterStart", data: eventId }));
+
+        // show links
+        switch (event.event.kind) {
+            case "TaskCreated":
+                if (event.event.data.taskId !== 0) {
+                    ctx!.links.current.push({
+                        source: event,
+                        target: ctx!.tasks[event.event.data.taskId],
+                    });
+                }
+                break;
+            case "SemaphoreCreated":
+            case "SemaphoreClosed":
+            case "SemaphoreAcquireFast":
+            case "SemaphoreAcquireBlocked":
+            case "SemaphoreAcquireUnblocked":
+            case "SemaphoreTryAcquire":
+            case "SemaphoreRelease":
+                ctx!.links.current.push({
+                    source: event,
+                    target: ctx!.objects[event.event.data.objectId],
+                });
+                break;
+        }
+        updateTimelineLinks();
+    } else {
+        d3.select("#sidebar-view-1").classed("show-event", false);
+    }
+}
+
+function selectTaskImpl(taskId: TaskId | null, doSendMessage: boolean, openTab: boolean) {
+    ctx!.timeline.spans!
+        .classed("selected", false);
+    ctx!.selection.taskId = taskId;
+    ctx!.timeline.spans!
+        .filter(d => d.isTask && (d.entry as Task).id === ctx!.selection.taskId)
+        .classed("selected", true);
+    if (taskId !== null) {
+        if (doSendMessage) {
+            sendMessage({ type: "taskClick", data: taskId });
+        }
+
+        // select tab
+        if (openTab) {
+            (d3.select(".panel-sidebar vscode-panels").node()! as any).activeid = "sidebar-tab-1";
+        }
+
+        // fill in sidebar
+        const task = ctxData!.tasks[taskId];
+        const infoRoot = d3.select("#sidebar-view-1")
+            .classed("show-task", true)
+            .select(".task-info");
+        infoRoot.select(".task-info-id").text(taskId);
+        infoRoot.select(".task-info-kind").text(task.isFuture ? "Future" : "Thread");
+        infoRoot.select(".task-info-name").text(task.name !== null ? task.name : "-");
+        if (task.id === 0) {
+            infoRoot.select(".task-info-created").text("-");
+        } else {
+            const cell = infoRoot
+                .select(".task-info-created")
+                .html(`<vscode-link>Task ${task.createdBy}</vscode-link>, <vscode-link>Step ${task.createdAt}</vscode-link>`);
+            cell.select("vscode-link:nth-of-type(1)")
+                .on("click", () => selectTask(task.createdBy, true));
+            cell.select("vscode-link:nth-of-type(2)")
+                .on("click", () => selectEvent(task.createdAt, true));
+        }
+        infoRoot
+            .select(".task-info-first")
+            .html(`<vscode-link>Step ${task.firstStep}</vscode-link>`)
+            .select("vscode-link")
+            .on("click", () => selectEvent(task.firstStep, true));
+        infoRoot
+            .select(".task-info-last")
+            .html(`<vscode-link>Step ${task.lastStep}</vscode-link>`)
+            .select("vscode-link")
+            .on("click", () => selectEvent(task.lastStep, true));
+
+        // show links
+        ctx!.links.current.push({
+            source: ctx!.tasks[task.id],
+            target: ctx!.events[task.createEvent!.id],
+        });
+        updateTimelineLinks();
+    } else {
+        d3.select("#sidebar-view-1").classed("show-task", false);
+    }
+}
+
+function selectObjectImpl(objectId: ObjectId | null, doSendMessage: boolean, openTab: boolean) {
+    ctx!.timeline.spans!
+        .classed("selected", false);
+    ctx!.selection.objectId = objectId;
+    ctx!.timeline.spans!
+        .filter(d => !d.isTask && (d.entry as Object).id === ctx!.selection.objectId)
+        .classed("selected", true);
+    if (objectId !== null) {
+        if (doSendMessage) {
+            sendMessage({ type: "objectClick", data: objectId });
+        }
+
+        // select tab
+        if (openTab) {
+            (d3.select(".panel-sidebar vscode-panels").node()! as any).activeid = "sidebar-tab-1";
+        }
+
+        // fill in sidebar
+        const object = ctxData!.objects[objectId];
+        const infoRoot = d3.select("#sidebar-view-1")
+            .classed("show-object", true)
+            .select(".object-info");
+        infoRoot.select(".object-info-id").text(objectId);
+        infoRoot.select(".object-info-kind").text(object.kind !== null ? object.kind : "Batch semaphore");
+        infoRoot.select(".object-info-name").text(object.name !== null ? object.name : "-");
+        const cell = infoRoot
+            .select(".object-info-created")
+            .html(`<vscode-link>Task ${object.createdBy}</vscode-link>, <vscode-link>Step ${object.firstStep}</vscode-link>`);
+        cell.select("vscode-link:nth-of-type(1)")
+            .on("click", () => selectTask(object.createdBy, true));
+        cell.select("vscode-link:nth-of-type(2)")
+            .on("click", () => selectEvent(object.firstStep, true)); // TODO: unnecessary?
+        // TODO: object-info-seen
+        infoRoot
+            .select(".object-info-first")
+            .html(`<vscode-link>Step ${object.firstStep}</vscode-link>`)
+            .select("vscode-link")
+            .on("click", () => selectEvent(object.firstStep, true));
+        infoRoot
+            .select(".object-info-last")
+            .html(`<vscode-link>Step ${object.lastStep}</vscode-link>`)
+            .select("vscode-link")
+            .on("click", () => selectEvent(object.lastStep, true));
+
+        // filter setup
+        infoRoot.select(".object-create-filter")
+            .on("click", () => sendMessage({ type: "createObjectFilterStart", data: objectId }));
+
+        // show links
+        ctx!.links.current.push({
+            source: ctx!.objects[object.id],
+            target: ctx!.events[object.createEvent!.id],
+        });
+        updateTimelineLinks();
+    } else {
+        d3.select("#sidebar-view-1").classed("show-object", false);
+    }
+}
+
+/**
+ * Select the given event.
+ * @param sendMessage Should the backend be notified?
+ */
+export function selectEvent(eventId: EventId, sendMessage: boolean) {
+    deselect();
+    selectEventImpl(eventId, sendMessage, true);
+}
+
+/**
+ * Select the given task.
+ * @param sendMessage Should the backend be notified?
+ */
+export function selectTask(taskId: TaskId, sendMessage: boolean) {
+    deselect();
+    selectTaskImpl(taskId, sendMessage, true);
+}
+
+/**
+ * Select the given object.
+ * @param sendMessage Should the backend be notified?
+ */
+export function selectObject(objectId: ObjectId, sendMessage: boolean) {
+    deselect();
+    selectObjectImpl(objectId, sendMessage, true);
+}
+
+/**
+ * Make sure the same item is selected, e.g., after updating filters.
+ */
+export function reselect() {
+    if (ctx!.selection.eventId !== null) {
+        selectEventImpl(ctx!.selection.eventId, false, false);
+    } else if (ctx!.selection.taskId !== null) {
+        selectTaskImpl(ctx!.selection.taskId, false, false);
+    } else if (ctx!.selection.objectId !== null) {
+        selectObjectImpl(ctx!.selection.objectId, false, false);
+    }
+}
+
+/**
+ * Deselect the currently selected task, event, or object.
+ */
+export function deselect() {
+    // remove links
+    ctx!.links.current.length = 0;
+    updateTimelineLinks();
+
+    // deselect rects
+    selectEventImpl(null, false, false);
+    selectTaskImpl(null, false, false);
+    selectObjectImpl(null, false, false);
+}

--- a/shuttle-explorer/src/frontend/timeline.mts
+++ b/shuttle-explorer/src/frontend/timeline.mts
@@ -1,0 +1,155 @@
+import * as d3 from "d3";
+
+import { Object } from "../common/objects.mts";
+import { Task } from "../common/tasks.mts";
+import { EventUI } from "./events.mts";
+import { HierarchyEntryUI } from "./hierarchy.mts";
+import { ctx, ctxData, eventHeight, rowHeight } from "./ui.mts";
+import { getZoomTrees, minEventWidth, ZoomTree } from "./zoom.mts";
+import { selectEvent } from "./selection.mts";
+import { clockCmp, Ordering } from "../common/clocks.mts";
+
+const linkGen = d3.link(d3.curveBumpY);
+
+export type ExtContextUITimeline = {
+    x: d3.ScaleLinear<number, number>,
+    xScaled: d3.ScaleLinear<number, number>,
+    xAxis: d3.Axis<d3.NumberValue>,
+    xAxisEl: d3.Selection<SVGGElement, unknown, HTMLElement, null> | null,
+    eventWidth: number,
+    root: d3.Selection<d3.BaseType, unknown, any, null>,
+    rows: d3.Selection<d3.BaseType, HierarchyEntryUI, d3.BaseType, null> | null,
+    spans: d3.Selection<d3.BaseType, HierarchyEntryUI, d3.BaseType, HierarchyEntryUI> | null,
+    events: d3.Selection<d3.BaseType, ZoomTree<EventUI>, d3.BaseType, HierarchyEntryUI> | null,
+    showingCdag: boolean,
+    cdagColumns: number,
+    shownEvents: number,
+    showingObjects: boolean,
+};
+
+export function updateTimeline(updateEvents: boolean) {
+    updateTimelineRows();
+    if (updateEvents) {
+        updateTimelineEvents();
+        updateTimelineSpans();
+        updateTimelineBlocked();
+    }
+    updateTimelineLinks();
+}
+
+function updateTimelineRows() {
+    ctx!.timeline.rows!
+        .transition()
+            .duration(200)
+            .attr("transform", ({visibleIndex}) => `translate(0,${visibleIndex * rowHeight - 9})`)
+            .attr("style", ({visible}) => `opacity: ${visible ? 1 : 0};`);
+}
+
+function updateTimelineSpans() {
+    const leftX = d3.local<number>();
+    const rightX = d3.local<number>();
+    ctx!.timeline.spans!
+        .classed("selected", d => d.isTask
+            ? ctx!.selection.taskId === (d.entry as Task).id
+            : ctx!.selection.objectId === (d.entry as Object).id)
+        .each(function ({entry: {firstStep, lastStep}}) {
+            leftX.set(this as Element, Math.max(ctx!.timeline.xScaled(ctx!.events[firstStep].shownIdx) - 2, -2));
+            rightX.set(this as Element, Math.min(ctx!.timeline.xScaled(ctx!.events[lastStep].shownIdx + (ctx!.events[lastStep].filtered ? 0 : 1)) + 2, ctx!.width));
+        })
+        .attr("transform", function () { return `translate(${leftX.get(this as Element)},0)`; })
+        .attr("width", function () {
+            if (rightX.get(this as Element)! <= leftX.get(this as Element)!) { return "1px"; }
+            return `${rightX.get(this as Element)! - leftX.get(this as Element)!}px`;
+        });
+}
+
+function updateTimelineBlocked() {
+    /*
+    // TODO: disabled
+    ctx!.timeline.rows!
+        .selectAll("rect.blocked")
+        .data(d => d.isTask ? (d as Task).blockedAt : [])
+        .join("svg:rect")
+            .classed("blocked", true)
+            .attr("transform", (at) => `translate(${ctx!.timeline.xScaled(ctxData!.events[at].keptIdx) + 2},2)`)
+            .attr("height", `${eventHeight}px`)
+            .attr("width", "5px");
+            */
+}
+
+export function updateTimelineLinks() {
+    // TODO: toggle somehow
+    /*
+    ctx!.links.current.length = 0;
+    for (let event of ctx!.events) {
+        for (let prevEvent of event.causallyDependsOn) {
+            ctx!.links.current.push({
+                source: event,
+                target: prevEvent,
+            });
+        }
+    }
+    */
+
+    ctx!.links.root!
+        .selectAll("path.link")
+        .data(ctx!.links.current)
+        .join("path")
+            .classed("link", true)
+            .attr("d", ({source, target}) => {
+                if (!source || !target) { return ""; }
+                let sourceEvent = "isTask" in source ? ctx!.events[source.entry.firstStep] : source;
+                let targetEvent = "isTask" in target ? ctx!.events[target.entry.firstStep] : target;
+                let sourceTask = "isTask" in source ? source : ctx!.tasks[sourceEvent.event.taskId];
+                let targetTask = "isTask" in target ? target : ctx!.tasks[targetEvent.event.taskId];
+                if (!sourceTask.visible || !targetTask.visible) { return ""; }
+                return linkGen({
+                    source: [ctx!.timeline.xScaled(sourceEvent.shownIdx) + Math.min(ctx!.timeline.eventWidth, 4), sourceTask.visibleIndex * rowHeight],
+                    target: [ctx!.timeline.xScaled(targetEvent.shownIdx) + Math.min(ctx!.timeline.eventWidth, 4), targetTask.visibleIndex * rowHeight],
+                });
+            });
+}
+
+export function updateTimelineEvents() {
+    ctx!.timeline.events = ctx!.timeline.rows!
+        .selectAll(".event")
+        .data(({entry: {flatIndex}, visible}) => visible && ctx!.zoom.trees[flatIndex] !== null ? getZoomTrees(ctx!, ctx!.zoom.trees[flatIndex][0][0]) : [])
+        .join("svg:rect")
+            .attr("transform", ({minData}) => `translate(${ctx!.timeline.xScaled(minData.shownIdx)},2)`)
+            .attr("height", `${eventHeight}px`)
+            // TODO: don't apply max if the event is the right-most in its task to avoid visually overflowing the task row
+            .attr("width", ({minData, maxData}) => `${Math.max(minEventWidth, ctx!.timeline.xScaled(maxData.shownIdx + 1) - ctx!.timeline.xScaled(minData.shownIdx))}px`)
+            .classed("event", true)
+            .classed("summary", ({count}) => count > 1)
+            .classed("selected", ({minData, maxData}) => ctx!.selection!.eventId !== null
+                && minData.event.taskId === ctxData!.events[ctx!.selection!.eventId].taskId
+                && minData.event.id <= ctx!.selection!.eventId
+                && ctx!.selection!.eventId <= maxData.event.id)
+            .classed("before", ({maxData}) => ctx!.selection!.eventId !== null
+                && maxData.event.id < ctx!.selection!.eventId
+                && (maxData.event.taskId === ctxData!.events[ctx!.selection!.eventId].taskId
+                    || clockCmp(maxData.event, ctxData!.events[ctx!.selection!.eventId]) === Ordering.Less))
+            .classed("after", ({minData}) => ctx!.selection!.eventId !== null
+                && ctx!.selection!.eventId < minData.event.id
+                && (minData.event.taskId === ctxData!.events[ctx!.selection!.eventId].taskId
+                    || clockCmp(ctxData!.events[ctx!.selection!.eventId], minData.event) === Ordering.Less))
+            .on("click", (_ev, {keptData}) => { if (keptData !== null) selectEvent(keptData.event.id, true); });
+            /*
+            .on("mouseover", (_ev, {id}) => sendMessage({ type: "eventHover", data: id }))
+            .on("mouseout", (_ev, {id}) => sendMessage({ type: "eventHoverOff", data: id }))
+            * /;
+/*
+    ctx!.timeline.events = ctx!.timeline.rows!
+        .selectAll(".event")
+        .data(({entry: {events}}) => events.map(({id}) => ctx!.events[id]).filter(({filtered}) => !filtered))
+        .join("svg:rect")
+            .attr("transform", ({shownIdx}) => `translate(${ctx!.timeline.xScaled(shownIdx)},2)`)
+            .attr("height", `${eventHeight}px`)
+            .attr("width", `${ctx!.timeline.eventWidth}px`)
+            .classed("event", true)
+            .classed("selected", ({event: {id}}) => ctx!.selection.eventId === id)
+            .on("mouseover", (_ev, {event: {id}}) => sendMessage({ type: "eventHover", data: id }))
+            .on("mouseout", (_ev, {event: {id}}) => sendMessage({ type: "eventHoverOff", data: id }))
+            .on("click", (_ev, {event: {id}}) => selectEvent(id, true));
+            */
+}

--- a/shuttle-explorer/src/frontend/ui.mts
+++ b/shuttle-explorer/src/frontend/ui.mts
@@ -1,0 +1,582 @@
+import * as d3 from "d3";
+
+import { ExtContextData, ExtContextFilters, ExtContextHierarchy } from "../common/context.mts";
+import { Filter, filterByCategory, initFilter } from "../common/filters.mts";
+import { eventCategories } from "../common/events.mts";
+import { Task } from "../common/tasks.mts";
+import { Object } from "../common/objects.mts";
+import { createContextUISelection, deselect, ExtContextUISelection, reselect, selectEvent, selectObject, selectTask } from "./selection.mts";
+import { createContextUIZoom, ExtContextUIZoom, updateClipHorizontal, updateZoomTrees } from "./zoom.mts";
+import { createEventUI, EventUI } from "./events.mts";
+import { createObjectUI, createTaskUI, HierarchyEntryUI, ObjectUI, TaskUI } from "./hierarchy.mts";
+import { updateCdag } from "./cdag.mts";
+import { ExtContextUITimeline, updateTimeline } from "./timeline.mts";
+import { sendMessage } from "./main.mts";
+
+// dimension constants
+export const rowHeight = 17;
+export const leftPanelWidth = 100;
+export const marginTop = 20;
+export const eventHeight = 13;
+
+const minEventsOnScreen = 4;
+const marginRight = 20;
+const depthOffset = 10;
+
+export let ctxData: ExtContextData | null = null;
+export let ctxFilters: ExtContextFilters | null = null;
+export let ctxHierarchy: ExtContextHierarchy | null = null;
+export let ctx: ExtContextUI | null = null;
+
+export type ExtContextUI = {
+    width: number,
+    height: number,
+    root: d3.Selection<d3.BaseType, unknown, any, null>,
+    events: EventUI[],
+    tasks: TaskUI[],
+    objects: ObjectUI[],
+    hierarchy: HierarchyEntryUI[],
+    timeline: ExtContextUITimeline,
+    zoom: ExtContextUIZoom,
+    main: {
+        root: d3.Selection<d3.BaseType, unknown, any, null>,
+    },
+    left: {
+        root: d3.Selection<SVGSVGElement, unknown, HTMLElement, any>,
+    },
+    right: {
+        scrollRoot: d3.Selection<HTMLDivElement, unknown, any, any>,
+        root: d3.Selection<SVGSVGElement, unknown, HTMLElement, any>,
+    },
+    links: {
+        current: {
+            source: HierarchyEntryUI | EventUI,
+            target: HierarchyEntryUI | EventUI,
+        }[],
+        root: d3.Selection<d3.BaseType, unknown, HTMLElement, any> | null,
+        pathRoot: d3.Selection<SVGGElement, unknown, HTMLElement, null> | null,
+        entryRoot: d3.Selection<SVGGElement, unknown, HTMLElement, null> | null,
+    },
+    selection: ExtContextUISelection,
+};
+
+// TODO: rename function?
+function updateFilters() {
+    // re-number events based on filtered events
+    let keptIdx = 0;
+    for (let event of ctx!.events) {
+        event.filtered = false;
+        event.keptIdx = keptIdx;
+        for (const filter of ctxFilters!.chain) {
+            if (filter.enabled && !filter.check(filter.data, event.event)) {
+                event.filtered = true;
+                break;
+            }
+        }
+        if (!event.filtered) {
+            keptIdx++;
+        }
+    }
+    ctxFilters!.keptEvents = keptIdx;
+
+    updateCdag(ctx!);
+
+    // update scale
+    ctx!.timeline.shownEvents = ctx!.timeline.showingCdag ? ctx!.timeline.cdagColumns : ctxFilters!.keptEvents;
+    ctx!.timeline.x.domain([0, ctx!.timeline.shownEvents]);
+    ctx!.timeline.eventWidth = ctx!.timeline.xScaled(1) - ctx!.timeline.xScaled(0);
+
+    for (const event of ctx!.events) {
+        event.shownIdx = ctx!.timeline.showingCdag ? event.cdagKeptIdx : event.keptIdx;
+    }
+
+    updateZoomTrees(ctx!);
+}
+
+function updateFilterList() {
+    d3.select("#filters-user")
+        .selectAll("vscode-checkbox")
+        .data(ctxFilters!.chain.filter(({builtin}) => !builtin))
+        .join("vscode-checkbox")
+            .attr("checked", ({enabled}) => enabled)
+            .html(({title, totalCount}) => `${title} <vscode-badge>${totalCount}</vscode-badge> <i class="codicon codicon-trash"></i>`)
+            .on("change", (ev, filter) => {
+                filter.enabled = ev.target.checked;
+                updateFilters();
+                reselect();
+                const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+                ctx!.zoom.zoom!.scaleExtent([1, Math.max(zoomToMinEvents, 1)]);
+                updateZoom(null);
+            })
+            .select(".codicon-trash")
+                .on("click", (_ev, filter) => {
+                    const index = ctxFilters!.chain.indexOf(filter);
+                    if (index !== -1) {
+                        ctxFilters!.chain.splice(index, 1);
+                        updateFilterList();
+                        reselect();
+                        const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+                        ctx!.zoom.zoom!.scaleExtent([1, Math.max(zoomToMinEvents, 1)]);
+                        updateZoom(null);
+                    }
+                });
+    updateFilters();
+}
+
+export function addCustomFilter(title: string, source: string) {
+    try {
+        const evalResult = eval(source);
+        let init = null;
+        let check = null;
+        // TODO: a bit naive
+        if (typeof evalResult === "function") {
+            check = evalResult;
+        } else if (typeof evalResult === "object") {
+            if ("init" in evalResult) { init = evalResult.init; }
+            if ("check" in evalResult) { check = evalResult.check; }
+        } else {
+            throw "unknown return type";
+        }
+        if (!check) {
+            check = () => true;
+        }
+        addFilter(initFilter(ctxData!, {
+            title,
+            enabled: true,
+            builtin: false,
+            data: {},
+            init,
+            check,
+        }), true);
+    } catch (error) {
+        // TODO: toast error to user
+        console.log("custom filter error", error);
+    }
+}
+
+export function addFilter(filter: Filter<any>, forceUpdate: boolean) {
+    let exists = false;
+    for (let i = 0; i < ctxFilters!.chain.length; i++) {
+        if (!filter.builtin && ctxFilters!.chain[i].title === filter.title) {
+            exists = true;
+            if (forceUpdate) {
+                ctxFilters!.chain[i].init = filter.init;
+                ctxFilters!.chain[i].check = filter.check;
+            }
+            break;
+        }
+    }
+    if (!exists) {
+        // reveal the filters panel
+        (d3.select(".panel-sidebar vscode-panels").node()! as any).activeid = "sidebar-tab-2";
+
+        ctxFilters!.chain.push(filter);
+        // TODO: this is duplicated a couple of times, move into a function:
+        updateFilterList();
+        reselect();
+        const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+        ctx!.zoom.zoom!.scaleExtent([1, Math.max(zoomToMinEvents, 1)]);
+        updateZoom(null);
+    } else if (forceUpdate) {
+        // TODO: this is duplicated a couple of times, move into a function:
+        updateFilterList();
+        reselect();
+        const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+        ctx!.zoom.zoom!.scaleExtent([1, Math.max(zoomToMinEvents, 1)]);
+        updateZoom(null);
+    }
+}
+
+function updateZoom(ev: {transform: d3.ZoomTransform} | null) {
+    if (ev) {
+        ctx!.zoom.lastZoomTransform = ev.transform;
+    }
+    if (ctx!.zoom.lastZoomTransform !== null) {
+        ctx!.timeline.xScaled = ctx!.zoom.lastZoomTransform.rescaleX(ctx!.timeline.x);
+    }
+    const xAxisTicks = ctx!.timeline.xScaled.ticks().filter(Number.isInteger);
+    ctx!.timeline.xAxis.tickValues(xAxisTicks);
+    ctx!.timeline.eventWidth = ctx!.timeline.xScaled(1) - ctx!.timeline.xScaled(0);
+    ctx!.timeline.xAxisEl!.call(ctx!.timeline.xAxis.scale(ctx!.timeline.xScaled));
+    updateClipHorizontal(ctx!);
+    updateTimeline(true);
+}
+
+function updateHeight() {
+    let visibleNodes = 1;
+    if (ctx!.hierarchy.length > 0) {
+        visibleNodes = ctx!.hierarchy[ctx!.hierarchy.length - 1].visibleIndex + 1;
+    }
+    ctx!.height = (visibleNodes + 1) * rowHeight;
+    // TODO: changing viewbox messes with the animations: only change it after the transition
+    ctx!.left.root
+        .attr("viewBox", [0, 0, leftPanelWidth, ctx!.height + marginTop - 10]);
+    ctx!.right.root
+        .attr("viewBox", [0, 0, ctx!.width - marginRight - leftPanelWidth, ctx!.height + marginTop - 10]);
+}
+
+// TODO: move to hierarchy.mts
+function updateLeftPanel() {
+    const durationToggleEntry = 200;
+
+    // links joining entries
+    ctx!.links.pathRoot!
+        .selectAll("path")
+        .data(ctx!.hierarchy)
+        .join("path")
+            .transition()
+                .duration(durationToggleEntry)
+                .attr("d", ({visibleIndex, entry: {createdBy}}) => visibleIndex === 0 ? "" :
+                    `M${ctxData!.tasks[createdBy].depth * depthOffset},${marginTop + ctx!.tasks[createdBy].visibleIndex * rowHeight}`
+                    + ` V${marginTop + visibleIndex * rowHeight}`
+                    + ` h${depthOffset}`)
+                .attr("style", ({visible}) => `opacity: ${visible ? 1 : 0};`);
+
+    // the entries themselves
+    const hierarchyEntries = ctx!.links.entryRoot!
+        .selectAll("g")
+        .data(ctx!.hierarchy)
+        .join("g");
+    hierarchyEntries
+        .transition()
+            .duration(durationToggleEntry)
+            .attr("transform", ({visibleIndex}) => `translate(0,${marginTop + visibleIndex * rowHeight})`)
+            .attr("style", ({visible}) => visible ? "opacity: 1;" : "opacity: 0;")
+            .on("start", () => { hierarchyEntries.filter(({visible}) => visible).attr("style", "display: block;"); })
+            .on("end", () => { hierarchyEntries.filter(({visible}) => !visible).attr("style", "display: none;"); });
+    const entryCircle = hierarchyEntries
+        .selectAll("circle")
+        .data(d => [d])
+        .join("circle")
+            .attr("cx", ({entry: {depth}}) => depth * depthOffset)
+            .attr("r", 4.5)
+            .attr("fill", ({entry: {children}}) => children.length ? null : "#999");
+    const entryPM = hierarchyEntries
+        .selectAll("text.pm")
+        .data(d => d.entry.children.length ? [d] : [])
+        .join("text")
+            .classed("pm", true)
+            .attr("stroke", "#fff")
+            .attr("transform", ({entry: {depth}}) => `translate(${-3 + depth * depthOffset},2.5)`)
+            .text(({open}) => open ? "–" : "+");
+    entryCircle
+        .on("click", (_ev, entry) => {
+            entry.open = !entry.open;
+            updateVisible();
+        });
+    entryPM // TODO: avoid this duplicate listener
+        .on("click", (_ev, entry) => {
+            entry.open = !entry.open;
+            updateVisible();
+        });
+    hierarchyEntries
+        .selectAll("text.entry")
+        .data(d => [d])
+        .join("text")
+            .classed("entry", true)
+            .attr("dy", "0.32em")
+            .attr("x", ({entry: {depth}}) => depth * depthOffset + 8)
+            .text(d => d.entry.name !== null ? d.entry.name : (d.isTask ? `task ${(d.entry as Task).id}` : `object ${(d.entry as Object).id}`))
+            .on("click", (_ev, d) => d.isTask ? selectTask((d.entry as Task).id, true) : selectObject((d.entry as Object).id, true));
+}
+
+function updateVisible() {
+    let visibleIndex = -1;
+    function walk(entry: HierarchyEntryUI, visible: boolean) {
+        if (!entry.isTask && !ctx!.timeline.showingObjects) {
+            visible = false;
+        }
+        entry.visible = visible;
+        entry.visibleIndex = visible ? ++visibleIndex : visibleIndex;
+        entry.entry.children.forEach((child) => walk(ctx!.hierarchy[child.flatIndex], visible && entry.open));
+    }
+    walk(ctx!.hierarchy[0], true);
+    updateHeight();
+    updateTimeline(false);
+    updateLeftPanel();
+}
+
+function updateCdagToggle() {
+    let cdag = ctx!.timeline.showingCdag;
+    for (let event of ctx!.events) {
+        event.shownIdx = cdag ? event.cdagKeptIdx : event.keptIdx;
+    }
+    ctx!.timeline.shownEvents = cdag ? ctx!.timeline.cdagColumns : ctxFilters!.keptEvents;
+    d3.select("#toggle-cdag").classed("selected", cdag);
+}
+
+export function createContextUI(
+    argCtxData: ExtContextData,
+    argCtxFilters: ExtContextFilters,
+    argCtxHierarchy: ExtContextHierarchy,
+): ExtContextUI {
+    // are we setting up for the first time?
+    const firstSetup = !ctx;
+
+    ctxData = argCtxData;
+    ctxFilters = argCtxFilters;
+    ctxHierarchy = argCtxHierarchy;
+
+    const width = (d3.select("main div.panel-main").node()! as HTMLDivElement).clientWidth;
+    const x = d3.scaleLinear([0, ctxFilters!.keptEvents], [0, width - marginRight - leftPanelWidth]);
+
+    // create/get DOM roots
+    const root = d3.select("main");
+
+    // root: top panel (X axis)
+    const rootTop = d3.select<SVGSVGElement, unknown>("svg.panel-top")
+        .attr("width", width - marginRight - leftPanelWidth)
+        .attr("height", marginTop)
+        .attr("viewBox", [0, 0, width - marginRight - leftPanelWidth, marginTop])
+        .attr("style", "max-width: 100%; height: auto; font: 10px sans-serif; overflow: visible;")
+        .html("");
+
+    // root: main panel (hierarchy and timeline)
+    const rootMain = root.select("div.panel-main");
+    rootMain.html("");
+
+    const scrollHorizontal = rootMain.append("div")
+        .classed("panel-main-right", true);
+    const rootRight = scrollHorizontal.append("svg")
+        .attr("width", width - marginRight - leftPanelWidth)
+        .attr("style", "height: auto; font: 10px sans-serif; overflow: hidden;");
+
+    const tasksUI = ctxData.tasks.map(createTaskUI);
+    const objectsUI = ctxData.objects.map(createObjectUI);
+    const hierarchyUI = ctxHierarchy.hierarchy.map(e => e.isTask ? tasksUI[(e as Task).id] : objectsUI[(e as Object).id]);
+
+    // keep hierarchy open to a max depth of 3 by default
+    let visibleIndex = -1;
+    function walk(entry: HierarchyEntryUI, depth: number): void {
+        entry.visible = depth <= 3;
+        entry.visibleIndex = entry.visible ? ++visibleIndex : visibleIndex;
+        entry.entry.children.forEach((child) => walk(hierarchyUI[child.flatIndex], depth + 1));
+    }
+    if (hierarchyUI.length > 0) {
+        walk(hierarchyUI[0], 0);
+    }
+
+    ctx = {
+        width,
+        height: 1,
+        root,
+        events: ctxData.events.map(createEventUI),
+        tasks: tasksUI,
+        objects: objectsUI,
+        hierarchy: hierarchyUI,
+        timeline: {
+            x,
+            xScaled: x,
+            xAxis: d3.axisTop(x)
+                .tickFormat(d3.format("d")),
+            xAxisEl: null,
+            eventWidth: x(1) - x(0),
+            root: rootRight.append("svg:g")
+                .attr("transform", `translate(0,${marginTop})`),
+            rows: null,
+            spans: null,
+            events: null,
+            showingCdag: false,
+            cdagColumns: 0,
+            shownEvents: ctxFilters!.keptEvents,
+            showingObjects: true,
+        },
+        zoom: createContextUIZoom(),
+        main: {
+            root: rootMain,
+        },
+        left: {
+            root: rootMain.append("svg")
+                .attr("width", leftPanelWidth)
+                .attr("style", "height: auto; font: 10px sans-serif; overflow: hidden;")
+                .classed("panel-main-left", true),
+        },
+        right: {
+            scrollRoot: scrollHorizontal,
+            root: rootRight,
+        },
+        links: {
+            current: [],
+            root: null,
+            pathRoot: null,
+            entryRoot: null,
+        },
+        selection: createContextUISelection(),
+    };
+
+    updateHeight();
+    updateFilters();
+    updateCdagToggle();
+
+    // create arrow tip
+    ctx!.right.root.append("svg:defs").append("svg:marker")
+        .attr("id", "arrow")
+        .attr("viewBox", [0, 0, 10, 10])
+        .attr("refX", 5)
+        .attr("refY", 5)
+        .attr("markerWidth", 6)
+        .attr("markerHeight", 6)
+        .attr("orient", "auto-start-reverse")
+        .append("svg:path")
+            .attr("d", "M 0 0 L 10 5 L 0 10 z");
+
+    // create X axis for time (in samples)
+    ctx!.timeline.xAxisEl = rootTop.append("g")
+        .attr("transform", `translate(0,${marginTop})`)
+        .call(ctx!.timeline.xAxis);
+
+    // create event timeline
+    let timelineMain = ctx!.right.root.append("g")
+        .attr("transform", `translate(0,${marginTop})`);
+
+    // background to catch zoom and drag events
+    timelineMain.append("svg:rect")
+        .attr("transform", `translate(0,-${marginTop})`)
+        .attr("width", "2000")
+        .attr("height", "2000")
+        .attr("fill", "transparent")
+        .on("click", deselect);
+
+    // setup zoom
+    const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+    ctx!.zoom.zoom = d3.zoom<SVGGElement, any>()
+        .scaleExtent([1, Math.max(zoomToMinEvents, 1)])
+        .translateExtent([[0, 0], [width - marginRight - leftPanelWidth, 0]])
+        // prevent scrolling then apply the default filter
+        .filter((event: MouseEvent): boolean => {
+            event.preventDefault();
+            return (!event.ctrlKey || event.type === 'wheel') && !event.button;
+        })
+        .on("zoom", updateZoom);
+    timelineMain.call(ctx!.zoom.zoom!);
+    updateClipHorizontal(ctx!);
+
+    // timeline rows
+    ctx!.timeline.rows = timelineMain
+        .selectAll("g.tl-row")
+        .data(ctx!.hierarchy)
+        .join("svg:g")
+            .classed("tl-row", true);
+
+    // show task/object spans
+    ctx!.timeline.spans = ctx!.timeline.rows
+        .selectAll("rect.to-span")
+        .data(d => [d])
+        .join("svg:rect")
+            .attr("height", `${eventHeight + 4}px`)
+            .classed("to-span", true)
+            .classed("task", ({isTask}) => isTask)
+            .classed("object", ({isTask}) => !isTask)
+            .on("click", (_ev, d) => d.isTask
+                ? selectTask((d.entry as Task).id, true)
+                : selectObject((d.entry as Object).id, true));
+    ctx!.links.root = timelineMain.append("svg:g")
+        .classed("tl-links", true);
+    updateTimeline(true);
+
+    // select event zero
+    selectEvent(0, false);
+
+    // left panel: hierarchy of tasks and objects
+    ctx!.links.pathRoot = ctx!.left.root.append("g")
+        .attr("fill", "none")
+        .attr("stroke", "#999")
+        .attr("transform", `translate(15,0)`);
+    ctx!.links.entryRoot = ctx!.left.root.append("g")
+        .attr("transform", `translate(15,0)`);
+    updateLeftPanel();
+
+    if (firstSetup) {
+        // change file icon to reload icon
+        d3.select("#reload-schedule .codicon")
+            .classed("codicon-file", false)
+            .classed("codicon-refresh", true);
+
+        // setup fit-to-width
+        window.addEventListener("resize", () => {
+            // TODO: throttle (only set one?)
+            requestAnimationFrame(() => {
+                ctx!.width = (ctx!.main.root.node()! as HTMLDivElement).clientWidth;
+                x.range([0, ctx!.width - marginRight - leftPanelWidth]);
+                ctx!.zoom.zoom!.translateExtent([[0, 0], [ctx!.width - marginRight - leftPanelWidth, 0]]);
+                rootTop
+                    .attr("width", ctx!.width - marginRight - leftPanelWidth)
+                    .attr("viewBox", [0, 0, ctx!.width - marginRight - leftPanelWidth, marginTop]);
+                ctx!.right.root
+                    .attr("width", ctx!.width - marginRight - leftPanelWidth);
+                updateZoom(null);
+                updateHeight();
+            });
+        });
+
+        // setup keyboard navigation
+        window.addEventListener("keydown", (ev) => {
+            switch (ev.code) {
+                case "ArrowLeft":
+                case "ArrowRight":
+                    const left = ev.code === "ArrowLeft";
+                    if (ctx!.timeline.shownEvents > 0) {
+                        // select leftmost/rightmost visible event
+                        let [startScan, endScan, deltaScan] = left ? [ctx!.events.length - 1, -1, -1] : [0, ctx!.events.length, 1];
+                        if (ctx!.selection.eventId !== null) {
+                            // select next visible event to the left/right
+                            startScan = ctx!.selection.eventId + deltaScan;
+                        }
+                        for (let eventId = startScan; eventId !== endScan; eventId += deltaScan) {
+                            if (!ctx!.events[eventId].filtered) {
+                                selectEvent(eventId, true);
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                default:
+                    return;
+            }
+            ev.preventDefault();
+        });
+    }
+
+    // filter checkboxes, badges
+    for (let category of eventCategories) {
+        d3.select(`#filters-${category}`)
+            .on("change", (ev) => {
+                filterByCategory.data.enabledCategories[category] = ev.target.checked;
+
+                // TODO: duplication
+                updateFilters();
+                reselect();
+                const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+                ctx!.zoom.zoom!.scaleExtent([1, Math.max(zoomToMinEvents, 1)]);
+                updateZoom(null);
+            });
+        d3.select(`#filters-${category} vscode-badge`).text(filterByCategory.data.categoryCounts[category]!);
+    }
+    d3.select("#filters-user").html("");
+    d3.select("#filters-add")
+        .on("click", (_ev) => sendMessage({type: "createCustomFilter"}));
+
+    // causal graph toggle
+    d3.select("#toggle-cdag")
+        .on("click", (_ev) => {
+            ctx!.timeline.showingCdag = !ctx!.timeline.showingCdag;
+            updateCdagToggle();
+
+            // TODO: duplication
+            updateFilters();
+            reselect();
+            const zoomToMinEvents = ctx!.timeline.shownEvents / minEventsOnScreen;
+            ctx!.zoom.zoom!.scaleExtent([1, Math.max(zoomToMinEvents, 1)]);
+            updateZoom(null);
+        });
+
+    // object toggle
+    d3.select("#toggle-objects")
+        .on("click", (_ev) => {
+            ctx!.timeline.showingObjects = !ctx!.timeline.showingObjects;
+            d3.select("#toggle-objects").classed("selected", ctx!.timeline.showingObjects);
+            updateVisible();
+        });
+
+    return ctx;
+}

--- a/shuttle-explorer/src/frontend/zoom.mts
+++ b/shuttle-explorer/src/frontend/zoom.mts
@@ -1,0 +1,275 @@
+import * as d3 from "d3";
+
+import { leftPanelWidth, ExtContextUI, marginTop, rowHeight } from "./ui.mts";
+import { ExtContextData, ExtContextFilters, ExtContextHierarchy } from "../common/context.mts";
+import { EventUI } from "./events.mts";
+
+export type ZoomTree<T> = {
+    // for each extreme, we store:
+    // - border: is there a border on this side? i.e. if there is another tree,
+    //   is its emptiness different from ours; if there is nothing, is our tree
+    //   full?
+    // - data: reference to the actual minimum/maximum entry
+    // - dataId: the ID of the minimum/maximum entry
+    // - id: bound of the tree (may extend beyond the minimum/maximum entry),
+    //   inclusive on both sides
+    minBorder: boolean,
+    minData: T,
+    minDataId: number,
+    minId: number,
+    maxBorder: boolean,
+    maxData: T,
+    maxDataId: number,
+    maxId: number,
+    // one (leftmost) element in this tree that was not filtered, for selection purposes
+    keptData: T | null,
+    // count of elements in this tree
+    count: number,
+    left: ZoomTree<T> | null,
+    right: ZoomTree<T> | null,
+};
+
+export type HierarchyZoomTrees = ZoomTree<EventUI>[][] | null;
+
+export type ExtContextUIZoom = {
+    zoom: d3.ZoomBehavior<SVGGElement, any> | null,
+    lastZoomTransform: d3.ZoomTransform | null,
+    // for each entry in the hierarchy, a list of zoom levels, each containing trees
+    trees: HierarchyZoomTrees[],
+    // for each zoom level, how wide would a (full) tree be at 1x scale?
+    treeSize: number[],
+
+    // current zoom level
+    level: number,
+    // horizontal clipping: smallest shownIdx shown
+    minIdx: number,
+    // horizontal clipping: largest shownIdx shown
+    maxIdx: number,
+    // vertical clipping: smallest visibleIndex shown
+    minHierarchyIdx: number,
+    // vertical clipping: largest visibleIndex shown
+    maxHierarchyIdx: number,
+};
+export function createContextUIZoom(): ExtContextUIZoom {
+    return {
+        zoom: null,
+        lastZoomTransform: null,
+        trees: [],
+        treeSize: [],
+        level: 0,
+        minIdx: 0,
+        maxIdx: 0,
+        minHierarchyIdx: 0,
+        maxHierarchyIdx: 0,
+    };
+}
+
+function nearestPowerOf2(n: number): number {
+    return 1 << 31 - Math.clz32(n);
+}
+
+export function updateZoomTrees(ctx: ExtContextUI) {
+    // update zoom trees
+    let topSize = nearestPowerOf2(ctx!.timeline.shownEvents);
+    if (topSize !== ctx!.timeline.shownEvents) {
+        topSize *= 2;
+    }
+
+    ctx.zoom.trees.length = 0;
+    let maxDepth = 0;
+    for (let i = 0; i < ctx.hierarchy.length; i++) {
+        const entry = ctx.hierarchy[i];
+        if (!entry.isTask || entry.entry.events.length === 0) {
+            ctx.zoom.trees.push(null);
+            continue;
+        }
+        const minData = ctx.events[entry.entry.events[0].id];
+        const maxData = ctx.events[entry.entry.events[entry.entry.events.length - 1].id];
+        const root: ZoomTree<EventUI> = {
+            minBorder: true,
+            minData,
+            minDataId: minData.shownIdx,
+            minId: minData.shownIdx,
+            maxBorder: true,
+            maxData,
+            maxDataId: maxData.shownIdx,
+            maxId: maxData.shownIdx,
+            keptData: null,
+            count: entry.entry.events.length,
+            left: null,
+            right: null,
+        };
+        for (let idx = 0; idx < entry.entry.events.length; idx++) {
+            if (ctx.events[entry.entry.events[idx].id].filtered) { continue; }
+            root.keptData = ctx.events[entry.entry.events[idx].id];
+            break;
+        }
+
+        let levels: ZoomTree<EventUI>[][] = [];
+        function walk(
+            parent: ZoomTree<EventUI>,
+            targetSize: number,
+            minEntryIdx: number, // inclusive
+            maxEntryIdx: number, // inclusive
+            depth: number,
+        ) {
+            if (depth >= levels.length) {
+                levels.push([]);
+            }
+            levels[depth].push(parent);
+
+            // this is an empty or singleton tree, do nothing
+            if (maxEntryIdx <= minEntryIdx || targetSize < 2) {
+                return;
+            }
+
+            // figure out the bounds of the left and right subtrees
+            // the total size is the span of the bounds
+            const size = parent.maxId + 1 - parent.minId;
+            // the left size is the nearest (smaller) power of two
+            const halfSize = Math.floor(targetSize / 2);
+            const leftSize = halfSize;
+
+            // actual bounds
+            const leftMax = parent.minId + leftSize - 1;
+            const rightMin = leftMax + 1;
+
+            // binary search for the split point in the entry's event array
+            // (entry's event array is a sequence of events which may not be
+            //  consecutive, and may contain only events belonging to the left
+            //  subtree, or only events belonging to the right subtree)
+            let splitMin = minEntryIdx;
+            let splitMax = maxEntryIdx;
+            let splitIdx = Math.floor((splitMax + splitMin) / 2);
+            while (
+                // did we not yet reach the left/right-most split?
+                0 <= splitIdx && splitIdx < entry.entry.events.length - 1
+                && splitMin < splitMax
+                // did we not yet find the split?
+                && !(ctx.events[entry.entry.events[splitIdx].id].shownIdx <= leftMax && ctx.events[entry.entry.events[splitIdx + 1].id].shownIdx >= rightMin)
+            ) {
+                // TODO: this assertion is violated in CDAG view, probably due to Schedule events?
+                console.assert(ctx.events[entry.entry.events[splitIdx].id].shownIdx > leftMax || ctx.events[entry.entry.events[splitIdx + 1].id].shownIdx < rightMin);
+                if (ctx.events[entry.entry.events[splitIdx].id].shownIdx > leftMax) {
+                    // split is farther to the left, so move right bound down
+                    splitMax = splitIdx - 1;
+                } else {
+                    // split is farther to the right, so move left bound up
+                    splitMin = splitIdx + 1;
+                }
+                splitIdx = Math.floor((splitMax + splitMin) / 2);
+            }
+            console.assert(-1 <= splitIdx && splitIdx <= entry.entry.events.length);
+
+            // how many events are actually in the subtrees?
+            let leftCount = 0;
+            let rightCount = 0;
+            let leftKept = null;
+            let rightKept = null;
+            for (let idx = minEntryIdx; idx <= maxEntryIdx; idx++) {
+                if (ctx.events[entry.entry.events[idx].id].filtered) { continue; }
+                if (idx <= splitIdx) {
+                    leftKept = ctx.events[entry.entry.events[idx].id];
+                    leftCount++;
+                } else if (idx >= splitIdx + 1) {
+                    rightKept = ctx.events[entry.entry.events[idx].id];
+                    rightCount++;
+                }
+            }
+            const interBorder = (leftCount > 0) !== (rightCount > 0);
+
+            if (leftCount > 0) {
+                const maxData = ctx.events[entry.entry.events[splitIdx].id];
+                parent.left = {
+                    minBorder: parent.minBorder,
+                    minData: parent.minData,
+                    minDataId: parent.minDataId,
+                    minId: parent.minId,
+                    maxBorder: interBorder,
+                    maxData,
+                    maxDataId: maxData.shownIdx,
+                    maxId: leftMax,
+                    keptData: leftKept,
+                    count: leftCount,
+                    left: null,
+                    right: null,
+                };
+                walk(parent.left, halfSize, minEntryIdx, splitIdx, depth + 1);
+            }
+            if (rightCount > 0) {
+                const minData = ctx.events[entry.entry.events[splitIdx + 1].id];
+                parent.right = {
+                    minBorder: interBorder,
+                    minData,
+                    minDataId: minData.shownIdx,
+                    minId: rightMin,
+                    maxBorder: parent.maxBorder,
+                    maxData: parent.maxData,
+                    maxDataId: parent.maxDataId,
+                    maxId: parent.maxId,
+                    keptData: rightKept,
+                    count: rightCount,
+                    left: null,
+                    right: null,
+                };
+                walk(parent.right, halfSize, splitIdx + 1, maxEntryIdx, depth + 1);
+            }
+        }
+        walk(root, topSize, 0, entry.entry.events.length - 1, 0);
+        ctx.zoom.trees.push(levels);
+        maxDepth = Math.max(maxDepth, levels.length);
+    }
+
+    // update zoomtree sizes
+    ctx.zoom.treeSize.length = 0;
+    let treeSize = topSize;
+    for (let depth = 0; depth < maxDepth; depth++) {
+        ctx.zoom.treeSize.push(treeSize);
+        treeSize = Math.floor(treeSize / 2);
+    }
+}
+
+export const minEventWidth = 5;
+
+export function updateClipHorizontal(ctx: ExtContextUI) {
+    // which zoom tree to use?
+    let zoomLevel = 0;
+    while (
+        zoomLevel + 1 < ctx.zoom.treeSize.length
+        && ctx.timeline.xScaled(ctx.zoom.treeSize[zoomLevel + 1]) - ctx.timeline.xScaled(0) > minEventWidth
+    ) {
+        zoomLevel++;
+    }
+    ctx.zoom.level = zoomLevel;
+
+    // horizontal clipping
+    ctx.zoom.minIdx = ctx.timeline.xScaled.invert(0);
+    ctx.zoom.maxIdx = ctx.timeline.xScaled.invert(ctx.width + leftPanelWidth);
+}
+
+export function updateClipVertical(ctx: ExtContextUI) {
+    const scrollHeight = (ctx.main.root.node()! as Element).clientHeight;
+    const scrollTop = (ctx.main.root.node()! as Element).scrollTop;
+    ctx.zoom.minHierarchyIdx = Math.floor((scrollTop - marginTop) / rowHeight);
+    ctx.zoom.maxHierarchyIdx = ctx.zoom.minHierarchyIdx + Math.ceil((scrollHeight + 2 * marginTop) / rowHeight);
+}
+// TODO: implement vertical clipping
+
+export function getZoomTrees<T>(ctx: ExtContextUI, root: ZoomTree<T>): ZoomTree<T>[] {
+    let output: ZoomTree<T>[] = [];
+    function walk(tree: ZoomTree<T>, depth: number) {
+        // is this tree not visible, due to horizontal clipping?
+        if (tree.maxDataId + 1 < ctx.zoom.minIdx || tree.minDataId > ctx.zoom.maxIdx) {
+            return;
+        }
+        if ((tree.left !== null || tree.right !== null) // can this tree be split?
+            && depth < ctx.zoom.level) { // should we split it?
+            if (tree.left) { walk(tree.left, depth + 1); }
+            if (tree.right) { walk(tree.right, depth + 1); }
+        } else if (tree.count > 0 && tree.keptData !== null) {
+            output.push(tree);
+        }
+    }
+    walk(root, 0);
+    return output;
+}

--- a/shuttle-explorer/src/lib.mts
+++ b/shuttle-explorer/src/lib.mts
@@ -1,0 +1,105 @@
+import {
+    createContextData,
+    createContextHierarchy,
+    createContextFilters,
+    ExtContextData,
+    ExtContextHierarchy,
+    ExtContextFilters,
+} from "./common/context.mts";
+import { Event, EventId, writeEvent } from "./common/events.mts";
+import { Object, ObjectId, writeObject } from "./common/objects.mts";
+import { Task, TaskId, writeTask } from "./common/tasks.mts";
+import {
+    Schedule,
+    ScheduleV0,
+} from "./common/schedule.mts";
+import { Filter, initFilter } from "./common/filters.mts";
+
+export class ShuttleContext {
+    constructor(
+        private _ctxData: ExtContextData,
+        private _ctxHierarchy: ExtContextHierarchy,
+        private _ctxFilters: ExtContextFilters,
+    ) {
+
+    }
+
+    public getEvent(id: EventId): Event {
+        return this._ctxData.events[id];
+    }
+
+    public getTask(id: TaskId): Task {
+        return this._ctxData.tasks[id];
+    }
+
+    public getObject(id: ObjectId): Object {
+        return this._ctxData.objects[id];
+    }
+
+    // TODO: this stateful interface is not great for notebook work
+    public pushFilter(filter: Filter<any>) {
+        this._ctxFilters.chain.push(initFilter(this._ctxData, filter));
+    }
+
+    public applyFiltersToEvent(event: Event): boolean {
+        for (const filter of this._ctxFilters.chain) {
+            if (filter.enabled && !filter.check(filter.data, event)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public applyFilters(): Event[] {
+        return this._ctxData.events
+            .filter((event) => this.applyFiltersToEvent(event));
+    }
+
+    public saveAnnotatedSchedule(): string {
+        // re-number kept events
+        let keptId = 0;
+        let eventReindex = [];
+        let keptEvents = [];
+        for (let eventId = 0; eventId < this._ctxData.events.length; eventId++) {
+            eventReindex[eventId] = keptId;
+            if (this.applyFiltersToEvent(this._ctxData.events[eventId])) {
+                keptEvents.push(this._ctxData.events[eventId]);
+                keptId++;
+            }
+        }
+
+        // re-number tasks and objects
+        const schedule: ScheduleV0 = {
+            version: 0,
+            files: this._ctxData.source.files,
+            functions: this._ctxData.source.functions,
+            objects: this._ctxData.objects
+                .map((object) => {
+                    const ret = writeObject(object);
+                    ret.created_at = eventReindex[ret.created_at];
+                    return ret;
+                }),
+            tasks: this._ctxData.tasks
+                .map((task) => {
+                    const ret = writeTask(task);
+                    ret.first_step = eventReindex[ret.first_step];
+                    ret.last_step = eventReindex[ret.last_step];
+                    return ret;
+                }),
+            events: keptEvents
+                .map((event) => writeEvent(event)),
+        }
+        return JSON.stringify(schedule);
+    }
+}
+
+export function loadAnnotatedSchedule(dataRaw: Uint8Array | string): ShuttleContext | null {
+    const data: string = dataRaw instanceof Uint8Array
+        ? new TextDecoder("utf-8").decode(dataRaw)
+        : dataRaw;
+    const schedule: Schedule = JSON.parse(data);
+    const ctxData = createContextData(schedule);
+    const ctxHierarchy = createContextHierarchy(ctxData);
+    const ctxFilters = createContextFilters(ctxData);
+    return new ShuttleContext(ctxData, ctxHierarchy, ctxFilters);
+}

--- a/shuttle-explorer/tsconfig.json
+++ b/shuttle-explorer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"compilerOptions": {
+		"module": "Node16",
+		"target": "ES2022",
+		"lib": [
+			"ES2022",
+			"dom",
+		],
+		"sourceMap": true,
+		"rootDir": "src",
+		"allowImportingTsExtensions": true,
+		//"noEmit": true,
+		"strict": true   /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	}
+}

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,5 +1,5 @@
 //! Annotated schedules. When an execution is scheduled using the
-//! [`AnnotationScheduler`], Shuttle will produce a file that contains
+//! [`crate::scheduler::AnnotationScheduler`], Shuttle will produce a file that contains
 //! additional information about the execution, such as the kind of step that
 //! was taken (was a task created, were permits acquired from a semaphore, etc)
 //! as well as the task's vector clocks and thus any causal dependence between
@@ -464,9 +464,9 @@ cfg_if::cfg_if! {
 }
 
 /// Trait to record information about shared objects, such as their name and
-/// type. See implementation in [`BatchSemaphore`], which actually records the
+/// type. See implementation in [`crate::future::batch_semaphore::BatchSemaphore`], which actually records the
 /// name into the schedule, other types should forward calls into their
-/// underlying primitive, as in [`Mutex`].
+/// underlying primitive, as in [`crate::sync::Mutex`].
 pub trait WithName {
     /// Set the name and kind (full type path) of this object.
     fn with_name_and_kind(self, name: Option<&str>, kind: Option<&str>) -> Self;

--- a/src/annotations/mod.rs
+++ b/src/annotations/mod.rs
@@ -1,0 +1,489 @@
+//! Annotated schedules. When an execution is scheduled using the
+//! [`AnnotationScheduler`], Shuttle will produce a file that contains
+//! additional information about the execution, such as the kind of step that
+//! was taken (was a task created, were permits acquired from a semaphore, etc)
+//! as well as the task's vector clocks and thus any causal dependence between
+//! the tasks. The resulting file can be visualized using the Shuttle Explorer
+//! IDE extension.
+
+// TODO: the types defined here with `derive(Serialize)` are all parsed from
+//       JSON output by Shuttle Explorer; if any changes are made, they should
+//       also be reflected in the parsing
+// TODO: introduce version numbers to make sure breaking changes are noticed
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "annotation")] {
+        use crate::runtime::{
+            execution::ExecutionState,
+            task::{clock::VectorClock, Task, TaskId},
+        };
+        use serde::Serialize;
+        use std::cell::RefCell;
+        use std::collections::HashMap;
+        use std::thread_local;
+
+        thread_local! {
+            static ANNOTATION_STATE: RefCell<Option<AnnotationState>> = RefCell::new(None);
+        }
+
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+        pub(crate) struct ObjectId(usize);
+
+        pub(crate) const DUMMY_OBJECT_ID: ObjectId = ObjectId(usize::MAX);
+
+        pub(crate) const ANNOTATION_VERSION: usize = 0;
+
+        /// Information about a file path found in one or more backtraces in the
+        /// annotated schedule. The path is stored in this type; instances of this
+        /// type are stored in the `files` vector in `AnnotationState`, and backtrace
+        /// frames then refer to paths using the index into the vector.
+        #[derive(Serialize)]
+        struct FileInfo {
+            path: String,
+        }
+
+        /// Information about a function name found in one or more backtraces in the
+        /// annotated schedule. The name is stored in this type; instances of this
+        /// type are stored in the `functions` vector in `AnnotationState`, and
+        /// backtrace frames then refer to functions using the index into the vector.
+        #[derive(Serialize)]
+        struct FunctionInfo {
+            name: String,
+        }
+
+        /// A backtrace frame.
+        #[derive(Serialize)]
+        struct Frame(
+            // file (index into `state.files`)
+            usize,
+            // function (index into `state.functions`)
+            usize,
+            // line
+            usize,
+            // column
+            usize,
+        );
+
+        /// Information about a shared object, i.e., a synchronization primitive
+        /// based on a batch semaphore.
+        #[derive(Serialize)]
+        struct ObjectInfo {
+            created_by: TaskId,
+            created_at: usize,
+            name: Option<String>,
+            kind: Option<String>,
+        }
+
+        /// Information about a task.
+        #[derive(Serialize)]
+        struct TaskInfo {
+            created_by: TaskId,
+            first_step: usize,
+            last_step: usize,
+            name: Option<String>,
+        }
+
+        #[derive(Debug, Serialize)]
+        enum AnnotationEvent {
+            SemaphoreCreated(ObjectId),
+            SemaphoreClosed(ObjectId),
+            SemaphoreAcquireFast(ObjectId, usize),
+            SemaphoreAcquireBlocked(ObjectId, usize),
+            SemaphoreAcquireUnblocked(ObjectId, TaskId, usize),
+            SemaphoreTryAcquire(ObjectId, usize, bool),
+            SemaphoreRelease(ObjectId, usize),
+
+            TaskCreated(TaskId, bool),
+            TaskTerminated,
+
+            Random,
+            Tick,
+        }
+
+        #[derive(Serialize)]
+        struct EventInfo(
+            // which task did something/yielded?
+            TaskId,
+            // backtrace
+            Option<Vec<Frame>>,
+            // event kind
+            AnnotationEvent,
+            // (if available,) clock of the task
+            // TODO: should always be available?
+            Option<VectorClock>,
+            // which other tasks were available to schedule, if this was a scheduled tick
+            Option<Vec<TaskId>>,
+        );
+
+        #[derive(Default, Serialize)]
+        struct AnnotationState {
+            version: usize,
+            files: Vec<FileInfo>,
+            #[serde(skip)]
+            path_to_file: HashMap<String, usize>,
+            functions: Vec<FunctionInfo>,
+            #[serde(skip)]
+            name_to_function: HashMap<String, usize>,
+            objects: Vec<ObjectInfo>,
+            tasks: Vec<TaskInfo>,
+            events: Vec<EventInfo>,
+
+            #[serde(skip)]
+            last_runnable_ids: Option<Vec<TaskId>>,
+            #[serde(skip)]
+            last_task_id: Option<TaskId>,
+            #[serde(skip)]
+            max_task_id: Option<TaskId>,
+        }
+
+        impl Serialize for VectorClock {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::ser::Serializer,
+            {
+                use serde::ser::SerializeSeq;
+                let mut seq = serializer.serialize_seq(Some(self.time.len()))?;
+                for e in &self.time {
+                    seq.serialize_element(e)?;
+                }
+                seq.end()
+            }
+        }
+
+        impl Serialize for TaskId {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::ser::Serializer,
+            {
+                usize::from(*self).serialize(serializer)
+            }
+        }
+
+        fn record_event(event: AnnotationEvent) {
+            with_state(move |state| {
+                let task_id = state.last_task_id.expect("no last task ID");
+
+                let task_id_num = usize::from(task_id);
+                assert!(task_id_num < state.tasks.len());
+                state.tasks[task_id_num].first_step = state.tasks[task_id_num].first_step.min(state.events.len());
+                state.tasks[task_id_num].last_step = state.tasks[task_id_num].last_step.max(state.events.len());
+
+                use std::backtrace::{Backtrace, BacktraceStatus};
+                use std::sync::OnceLock;
+                use regex::Regex;
+
+                // Here is a fragment of a backtrace for reference:
+                // ```
+                // 2: core::panicking::assert_failed_inner
+                // 3: core::panicking::assert_failed
+                //           at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:364:5
+                // 4: shuttle_clients::tests::example_impl
+                //           at ./src/example.rs:15:5
+                // 5: core::ops::function::Fn::call
+                //           at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:79:5
+                // ```
+                // We want to capture the frames (numbered lines above) which
+                // refer to files local to the project being run, as well as
+                // the function name, and line/column info.
+                // TODO: for now, "local to the project" is detected based on
+                //       the path starting with `./src/`. Find an alternative
+                //       way to do this?
+                // The following regex matches frames with local paths. We rely
+                // on the string format of the backtrace because there is no
+                // better API. At the time of writing, even the unstable feature
+                // `backtrace_frames` does not provide a better interface.
+                // https://doc.rust-lang.org/std/backtrace/struct.BacktraceFrame.html
+                static RE: OnceLock<Regex> = OnceLock::new();
+                //                                         _num      function_name  path           line     col
+                let regex = RE.get_or_init(|| Regex::new(r"([0-9]+): ([^\n]+)\n +at (\./src/[^:]+):([0-9]+):([0-9]+)\b").unwrap());
+
+                // Whether or not the following call actually captures a backtrace
+                // depends on the environment variables `RUST_BACKTRACE` and
+                // `RUST_LIB_BACKTRACE`. See:
+                // https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
+                // TODO: alternatively, we could use `Backtrace::force_capture`
+                //       and use our own environment flag.
+                let bt = Backtrace::capture();
+                let info = if bt.status() == BacktraceStatus::Captured {
+                    Some(regex
+                        // apply regex to debug-formatted backtrace
+                        .captures_iter(&format!("{bt}"))
+                        // for each match, extract the captured groups
+                        .map(|group| group.extract().1)
+                        // then store the extracted data into a `Frame`
+                        .map(|[_num, function_name, path, line_str, col_str]| {
+                            // intern file path in `state.files`
+                            let path_idx = *state
+                                .path_to_file
+                                .entry(path.to_string())
+                                .or_insert_with(|| {
+                                    let idx = state.files.len();
+                                    state.files.push(FileInfo {
+                                        path: path.to_string(),
+                                    });
+                                    idx
+                                });
+
+                            // intern function name in `state.functions`
+                            let function_idx = *state
+                                .name_to_function
+                                .entry(function_name.to_string())
+                                .or_insert_with(|| {
+                                    let idx = state.functions.len();
+                                    state.functions.push(FunctionInfo {
+                                        name: function_name.to_string(),
+                                    });
+                                    idx
+                                });
+
+                            Frame(
+                                path_idx,                           // file
+                                function_idx,                       // function
+                                line_str.parse::<usize>().unwrap(), // line
+                                col_str.parse::<usize>().unwrap(),  // col
+                            )
+                        })
+                        .collect::<Vec<_>>())
+                } else {
+                    None
+                };
+
+                state.events.push(EventInfo(
+                    task_id,
+                    info,
+                    event,
+                    ExecutionState::try_with(|state| state.get_clock(task_id).clone()),
+                    state.last_runnable_ids.take(),
+                ))
+            });
+        }
+
+        fn with_state<R, F: FnOnce(&mut AnnotationState) -> R>(f: F) -> Option<R> {
+            ANNOTATION_STATE.with(|cell| {
+                let mut bw = cell.borrow_mut();
+                let state = bw.as_mut()?;
+                Some(f(state))
+            })
+        }
+
+        fn record_object() -> ObjectId {
+            with_state(|state| {
+                let id = ObjectId(state.objects.len());
+                state.objects.push(ObjectInfo {
+                    created_by: state.last_task_id.unwrap(),
+                    created_at: state.events.len(),
+                    name: None,
+                    kind: None,
+                });
+                id
+            })
+            .unwrap_or(DUMMY_OBJECT_ID)
+        }
+
+        pub(crate) fn start_annotations() {
+            ANNOTATION_STATE.with(|cell| {
+                let mut bw = cell.borrow_mut();
+                assert!(bw.is_none(), "annotations already started");
+                let mut state: AnnotationState = Default::default();
+                state.version = ANNOTATION_VERSION;
+                state.last_task_id = Some(0.into());
+                *bw = Some(state);
+            });
+        }
+
+        pub(crate) fn stop_annotations() {
+            ANNOTATION_STATE.with(|cell| {
+                let mut bw = cell.borrow_mut();
+                let state = bw.take().expect("annotations not started");
+                if state.max_task_id.is_none() {
+                    // nothing to output
+                    return;
+                };
+                let json = serde_json::to_string(&state).unwrap();
+                std::fs::write(
+                    std::env::var("SHUTTLE_ANNOTATION_FILE").unwrap_or_else(|_| "annotated.json".to_string()),
+                    json,
+                )
+                .unwrap();
+            });
+        }
+
+        pub(crate) fn record_semaphore_created() -> ObjectId {
+            let object_id = record_object();
+            record_event(AnnotationEvent::SemaphoreCreated(object_id));
+            object_id
+        }
+
+        pub(crate) fn record_semaphore_closed(object_id: ObjectId) {
+            record_event(AnnotationEvent::SemaphoreClosed(object_id));
+        }
+
+        pub(crate) fn record_semaphore_acquire_fast(object_id: ObjectId, num_permits: usize) {
+            record_event(AnnotationEvent::SemaphoreAcquireFast(object_id, num_permits));
+        }
+
+        pub(crate) fn record_semaphore_acquire_blocked(object_id: ObjectId, num_permits: usize) {
+            record_event(AnnotationEvent::SemaphoreAcquireBlocked(object_id, num_permits));
+        }
+
+        pub(crate) fn record_semaphore_acquire_unblocked(object_id: ObjectId, unblocked_task_id: TaskId, num_permits: usize) {
+            record_event(AnnotationEvent::SemaphoreAcquireUnblocked(
+                object_id,
+                unblocked_task_id,
+                num_permits,
+            ));
+        }
+
+        pub(crate) fn record_semaphore_try_acquire(object_id: ObjectId, num_permits: usize, successful: bool) {
+            record_event(AnnotationEvent::SemaphoreTryAcquire(object_id, num_permits, successful));
+        }
+
+        pub(crate) fn record_semaphore_release(object_id: ObjectId, num_permits: usize) {
+            record_event(AnnotationEvent::SemaphoreRelease(object_id, num_permits));
+        }
+
+        pub(crate) fn record_task_created(task_id: TaskId, is_future: bool) {
+            with_state(move |state| {
+                assert_eq!(state.tasks.len(), usize::from(task_id));
+                state.tasks.push(TaskInfo {
+                    created_by: state.last_task_id.unwrap(),
+                    first_step: usize::MAX,
+                    last_step: 0,
+                    name: None,
+                });
+            });
+            record_event(AnnotationEvent::TaskCreated(task_id, is_future));
+        }
+
+        pub(crate) fn record_task_terminated() {
+            record_event(AnnotationEvent::TaskTerminated);
+        }
+
+        pub(crate) fn record_name_for_object(object_id: ObjectId, name: Option<&str>, kind: Option<&str>) {
+            with_state(move |state| {
+                if let Some(object_info) = state.objects.get_mut(object_id.0) {
+                    if name.is_some() {
+                        object_info.name = name.map(|name| name.to_string());
+                    }
+                    if kind.is_some() {
+                        object_info.kind = kind.map(|kind| kind.to_string());
+                    }
+                } // TODO: else panic? warn?
+            });
+        }
+
+        pub(crate) fn record_name_for_task(task_id: TaskId, name: &crate::current::TaskName) {
+            with_state(|state| {
+                if let Some(task_info) = state.tasks.get_mut(usize::from(task_id)) {
+                    let name: &String = name.into();
+                    task_info.name = Some(name.to_string());
+                } // TODO: else panic? warn?
+            });
+        }
+
+        pub(crate) fn record_random() {
+            record_event(AnnotationEvent::Random);
+        }
+
+        pub(crate) fn record_schedule(choice: TaskId, runnable_tasks: &[&Task]) {
+            with_state(|state| {
+                let choice_id_num = usize::from(choice);
+                state.tasks[choice_id_num].first_step = state.tasks[choice_id_num].first_step.min(state.events.len());
+                state.tasks[choice_id_num].last_step = state.tasks[choice_id_num].last_step.max(state.events.len());
+                assert!(
+                    state.last_runnable_ids.is_none(),
+                    "multiple schedule calls without a Tick"
+                );
+                state.last_runnable_ids = Some(runnable_tasks.iter().map(|task| task.id()).collect::<Vec<_>>());
+                state.last_task_id = Some(choice);
+                state.max_task_id = state.max_task_id.max(Some(choice));
+            });
+        }
+
+        pub(crate) fn record_tick() {
+            record_event(AnnotationEvent::Tick);
+        }
+    } else {
+        use crate::runtime::task::{Task, TaskId};
+
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub(crate) struct ObjectId;
+
+        pub(crate) const DUMMY_OBJECT_ID: ObjectId = ObjectId;
+
+        #[inline(always)]
+        pub(crate) fn start_annotations() {}
+
+        #[inline(always)]
+        pub(crate) fn stop_annotations() {}
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_created() -> ObjectId {
+            DUMMY_OBJECT_ID
+        }
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_closed(_object_id: ObjectId) {}
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_acquire_fast(_object_id: ObjectId, _num_permits: usize) {}
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_acquire_blocked(_object_id: ObjectId, _num_permits: usize) {}
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_acquire_unblocked(_object_id: ObjectId, _unblocked_task_id: TaskId, _num_permits: usize) {}
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_try_acquire(_object_id: ObjectId, _num_permits: usize, _successful: bool) {}
+
+        #[inline(always)]
+        pub(crate) fn record_semaphore_release(_object_id: ObjectId, _num_permits: usize) {}
+
+        #[inline(always)]
+        pub(crate) fn record_task_created(_task_id: TaskId, _future: bool) {}
+
+        #[inline(always)]
+        pub(crate) fn record_task_terminated() {}
+
+        #[inline(always)]
+        pub(crate) fn record_name_for_object(_object_id: ObjectId, _name: Option<&str>, _kind: Option<&str>) {}
+
+        #[inline(always)]
+        pub(crate) fn record_name_for_task(_task_id: TaskId, _name: &crate::current::TaskName) {}
+
+        #[inline(always)]
+        pub(crate) fn record_random() {}
+
+        #[inline(always)]
+        pub(crate) fn record_schedule(_choice: TaskId, _runnable_tasks: &[&Task]) {}
+
+        #[inline(always)]
+        pub(crate) fn record_tick() {}
+    }
+}
+
+/// Trait to record information about shared objects, such as their name and
+/// type. See implementation in [`BatchSemaphore`], which actually records the
+/// name into the schedule, other types should forward calls into their
+/// underlying primitive, as in [`Mutex`].
+pub trait WithName {
+    /// Set the name and kind (full type path) of this object.
+    fn with_name_and_kind(self, name: Option<&str>, kind: Option<&str>) -> Self;
+
+    /// Set the name of this object.
+    fn with_name(self, name: &str) -> Self
+    where
+        Self: Sized,
+    {
+        self.with_name_and_kind(Some(name), None)
+    }
+
+    /// Set the kind (full type path) of this object.
+    fn with_kind(self, kind: &str) -> Self
+    where
+        Self: Sized,
+    {
+        self.with_name_and_kind(None, Some(kind))
+    }
+}

--- a/src/current.rs
+++ b/src/current.rs
@@ -80,7 +80,9 @@ pub fn get_name_for_task(task_id: TaskId) -> Option<TaskName> {
 
 /// Set the debug name for a task, returning the old name, if any
 pub fn set_name_for_task(task_id: TaskId, task_name: impl Into<TaskName>) -> Option<TaskName> {
-    set_label_for_task::<TaskName>(task_id, task_name.into())
+    let task_name = task_name.into();
+    crate::annotations::record_name_for_task(task_id, &task_name);
+    set_label_for_task::<TaskName>(task_id, task_name)
 }
 
 /// Gets the `TaskId` of the current task, or `None` if there is no current task.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@
 //! [Loom]: https://github.com/tokio-rs/loom
 //! [pct]: https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/asplos277-pct.pdf
 
+pub mod annotations;
 pub mod future;
 pub mod hint;
 pub mod lazy_static;
@@ -422,6 +423,28 @@ where
     use crate::scheduler::ReplayScheduler;
 
     let scheduler = ReplayScheduler::new_from_encoded(encoded_schedule);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(f);
+}
+
+/// Run the given function according to a given encoded schedule, usually produced as the output of
+/// a failing Shuttle test case, while recording an annotated schedule, for use with the Shuttle
+/// Explorer extension.
+///
+/// This function allows deterministic replay of a failing schedule, as long as `f` contains no
+/// non-determinism other than that introduced by scheduling.
+///
+/// This is a convenience function for constructing a [`Runner`] that uses
+/// an [`AnnotationScheduler`] wrapping a replay scheduler created with
+/// [`ReplayScheduler::new_from_encoded`](scheduler::ReplayScheduler::new_from_encoded).
+pub fn annotate_replay<F>(f: F, encoded_schedule: &str)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    use crate::scheduler::{AnnotationScheduler, ReplayScheduler};
+
+    let scheduler_inner = ReplayScheduler::new_from_encoded(encoded_schedule);
+    let scheduler = AnnotationScheduler::new(scheduler_inner);
     let runner = Runner::new(scheduler, Default::default());
     runner.run(f);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,7 +435,7 @@ where
 /// non-determinism other than that introduced by scheduling.
 ///
 /// This is a convenience function for constructing a [`Runner`] that uses
-/// an [`AnnotationScheduler`] wrapping a replay scheduler created with
+/// an [`crate::scheduler::AnnotationScheduler`] wrapping a replay scheduler created with
 /// [`ReplayScheduler::new_from_encoded`](scheduler::ReplayScheduler::new_from_encoded).
 pub fn annotate_replay<F>(f: F, encoded_schedule: &str)
 where

--- a/src/runtime/thread/continuation.rs
+++ b/src/runtime/thread/continuation.rs
@@ -256,6 +256,7 @@ unsafe impl Send for PooledContinuation {}
 
 /// Possibly yield back to the executor to perform a context switch.
 pub(crate) fn switch() {
+    crate::annotations::record_tick();
     if ExecutionState::maybe_yield() {
         let r = generator::yield_(ContinuationOutput::Yielded).unwrap();
         assert!(matches!(r, ContinuationInput::Resume));

--- a/src/scheduler/annotation.rs
+++ b/src/scheduler/annotation.rs
@@ -1,0 +1,47 @@
+use crate::annotations::{record_random, record_schedule, start_annotations, stop_annotations};
+use crate::runtime::task::{Task, TaskId};
+use crate::scheduler::{Schedule, Scheduler};
+
+/// An `AnnotationScheduler` wraps an inner `Scheduler` and enables the
+/// creation of an annotated schedule (for use with Shuttle Explorer).
+/// Without enabling the feature `annotation`, this wrapper does nothing.
+///
+/// Importantly, only one `AnnotationScheduler` instance should exist at a time.
+#[derive(Debug)]
+pub struct AnnotationScheduler<S: ?Sized + Scheduler>(Box<S>);
+
+impl<S: Scheduler> AnnotationScheduler<S> {
+    /// Create a new `AnnotationScheduler` by wrapping the given `Scheduler` implementation.
+    pub fn new(inner: S) -> Self {
+        start_annotations();
+        Self(Box::new(inner))
+    }
+}
+
+impl<S: Scheduler> Scheduler for AnnotationScheduler<S> {
+    fn new_execution(&mut self) -> Option<Schedule> {
+        self.0.new_execution()
+    }
+
+    fn next_task(
+        &mut self,
+        runnable_tasks: &[&Task],
+        current_task: Option<TaskId>,
+        is_yielding: bool,
+    ) -> Option<TaskId> {
+        let choice = self.0.next_task(runnable_tasks, current_task, is_yielding)?;
+        record_schedule(choice, runnable_tasks);
+        Some(choice)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        record_random();
+        self.0.next_u64()
+    }
+}
+
+impl<S: ?Sized + Scheduler> Drop for AnnotationScheduler<S> {
+    fn drop(&mut self) {
+        stop_annotations();
+    }
+}

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,6 +1,7 @@
 //! Implementations of different scheduling strategies for concurrency testing.
 use std::fmt::Debug;
 
+mod annotation;
 mod data;
 mod dfs;
 mod pct;
@@ -14,6 +15,7 @@ pub(crate) mod serialization;
 
 pub use crate::runtime::task::{Task, TaskId};
 
+pub use annotation::AnnotationScheduler;
 pub use data::{DataSource, RandomDataSource};
 pub use dfs::DfsScheduler;
 pub use pct::PctScheduler;

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -217,3 +217,17 @@ impl<T: Display + ?Sized> Display for MutexGuard<'_, T> {
         (**self).fmt(f)
     }
 }
+
+impl<T> crate::annotations::WithName for &Mutex<T> {
+    fn with_name_and_kind(self, name: Option<&str>, kind: Option<&str>) -> Self {
+        (&self.semaphore).with_name_and_kind(name, kind.or(Some("shuttle::sync::Mutex")));
+        self
+    }
+}
+
+impl<T> crate::annotations::WithName for Mutex<T> {
+    fn with_name_and_kind(self, name: Option<&str>, kind: Option<&str>) -> Self {
+        (&self).with_name_and_kind(name, kind);
+        self
+    }
+}


### PR DESCRIPTION
Added mechanism to emit annotated schedules from Shuttle. Added VS Code extension "Shuttle Explorer" to visualise such annotated schedules.

- [x] `cfg` flag to disable annotations completely (to avoid performance cost of checking a thread-local repeatedly)
- [ ] document and clean up extension

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.