### PR TITLE
Update panic message in UncontrolledNondeterminismCheckScheduler to be less verbose

### DIFF
--- a/src/scheduler/uncontrolled_nondeterminism.rs
+++ b/src/scheduler/uncontrolled_nondeterminism.rs
@@ -90,7 +90,7 @@ impl<S: Scheduler> Scheduler for UncontrolledNondeterminismCheckScheduler<S> {
                         .map(|t| t.id())
                         .collect::<SmallVec<[TaskId; DEFAULT_INLINE_TASKS]>>();
                     if *runnables.as_slice() != *runnable_ids {
-                        panic!("possible nondeterminism: set of runnable tasks is different than expected (expected {runnables:?} but got {runnable_tasks:?})");
+                        panic!("possible nondeterminism: set of runnable tasks is different than expected.\nExpected:\n{runnables:?}\nbut got:\n{runnable_ids:?}");
                     }
 
                     if *was_yielding != is_yielding {


### PR DESCRIPTION
The update to `Scheduler` making it take `&[&Task]`s instead of `&[&TaskId]`s, made this panic message needlessly verbose. `runnables` is `TaskId`s, and `runnable_tasks` is `Task`s, which makes it hard to discover the difference in tasks.

Updated the panic message to make it easier to spot the difference while at it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.