### PR TITLE
Fix BatchSemaphore bug causing deadlocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { version = "1.0", optional = true }
 criterion = { version = "0.4.0", features = ["html_reports"] }
 futures = "0.3.15"
 proptest = "1.0.0"
+proptest-derive = "0.5.0"
 regex = "1.5.5"
 tempfile = "3.2.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }


### PR DESCRIPTION

This PR fixes a bug in BatchSemaphore that caused deadlocks in the presence of tasks that gave up waiting for requested permits, under the policy of strict fairness.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.