### PR TITLE
FIX: Fix RwLock not treating multiple readers correctly in release mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: cargo test
-        run: cargo test
+        run: cargo test --release
 
   fmt:
     name: rustfmt

--- a/src/runtime/task/labels.rs
+++ b/src/runtime/task/labels.rs
@@ -222,7 +222,7 @@ impl Labels {
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.map.as_ref().map_or(true, |map| map.is_empty())
+        self.map.as_ref().is_none_or(|map| map.is_empty())
     }
 
     /// Get the number of Labels available.

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -222,7 +222,7 @@ impl<T: ?Sized> RwLock<T> {
                 state.holder = RwLockHolder::Read(readers);
             }
             (RwLockType::Read, RwLockHolder::Read(readers)) => {
-                debug_assert!(readers.insert(me));
+                assert!(readers.insert(me));
             }
             _ => {
                 panic!(

--- a/tests/future/batch_semaphore.rs
+++ b/tests/future/batch_semaphore.rs
@@ -671,7 +671,7 @@ mod early_acquire_drop_tests {
                                 }
                                 dropped_acquire_must_release(&SEM, behavior.clone())
                             },
-                            10_000,
+                            1000,
                         );
                     }
                 }


### PR DESCRIPTION
Turns out `RwLock` doesn't function correctly when run in release mode, as we don't insert to the readers when there already is a reader. This PR fixes that.

Surprised this hasn't been an issue previously, I guess `RwLock` just isn't used much.

Discovered this when I tried to update the workflow to run the tests in release mode, where some of the `RwLock` tests failed.

This (and similar issues) might explain the instances where we have seen non-replayable schedules generated in release mode and replayed in debug mode, or vice versa.

I should do a pass and check if all tests replay with schedules created in the opposite mode.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.