### PR TITLE
Make `SHUTTLE_RANDOM_SEED` always override.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,15 +323,14 @@ where
 
 /// Run the given function under a randomized concurrency scheduler for some number of iterations.
 /// Each iteration will run a (potentially) different randomized schedule.
-/// When the environment variable SHUTTLE_RANDOM_SEED is set to a u64, this number will be used
-/// as the seed to initialize the random scheduler.
 pub fn check_random<F>(f: F, iterations: usize)
 where
     F: Fn() + Send + Sync + 'static,
 {
     use crate::scheduler::RandomScheduler;
 
-    Runner::new(RandomScheduler::new(iterations), Default::default()).run(f)
+    let runner = Runner::new(RandomScheduler::new(iterations), Default::default());
+    runner.run(f);
 }
 
 /// Run function `f` using `RandomScheduler` initialized with the provided `seed` for the given

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,24 +330,8 @@ where
     F: Fn() + Send + Sync + 'static,
 {
     use crate::scheduler::RandomScheduler;
-    use tracing::info;
 
-    let seed_env = std::env::var("SHUTTLE_RANDOM_SEED");
-    let runner = match seed_env {
-        Ok(s) => match s.as_str().parse::<u64>() {
-            Ok(seed) => {
-                info!(
-                    "Initializing RandomScheduler with the seed provided by SHUTTLE_RANDOM_SEED: {}",
-                    seed
-                );
-                Runner::new(RandomScheduler::new_from_seed(seed, iterations), Default::default())
-            }
-            Err(err) => panic!("The seed provided by SHUTTLE_RANDOM_SEED is not a valid u64: {}", err),
-        },
-        Err(_) => Runner::new(RandomScheduler::new(iterations), Default::default()),
-    };
-
-    runner.run(f);
+    Runner::new(RandomScheduler::new(iterations), Default::default()).run(f)
 }
 
 /// Run function `f` using `RandomScheduler` initialized with the provided `seed` for the given

--- a/src/scheduler/pct.rs
+++ b/src/scheduler/pct.rs
@@ -39,8 +39,25 @@ impl PctScheduler {
     }
 
     /// Construct a new PCTScheduler with a given seed.
+    ///
+    /// If the `SHUTTLE_RANDOM_SEED` environment variable is set, then that seed will be used instead.
     pub fn new_from_seed(seed: u64, max_depth: usize, max_iterations: usize) -> Self {
         assert!(max_depth > 0);
+
+        let seed_env = std::env::var("SHUTTLE_RANDOM_SEED");
+        let seed = match seed_env {
+            Ok(s) => match s.as_str().parse::<u64>() {
+                Ok(seed) => {
+                    tracing::info!(
+                        "Initializing PctScheduler with the seed provided by SHUTTLE_RANDOM_SEED: {}",
+                        seed
+                    );
+                    seed
+                }
+                Err(err) => panic!("The seed provided by SHUTTLE_RANDOM_SEED is not a valid u64: {}", err),
+            },
+            Err(_) => seed,
+        };
 
         let rng = Pcg64Mcg::seed_from_u64(seed);
 

--- a/src/scheduler/random.rs
+++ b/src/scheduler/random.rs
@@ -57,14 +57,14 @@ impl RandomScheduler {
     ///
     /// Two RandomSchedulers initialized with the same seed will make the same scheduling decisions
     /// when executing the same workloads.
+    ///
+    /// If the `SHUTTLE_RANDOM_SEED` environment variable is set, then that seed will be used instead.
     pub fn new_from_seed(seed: u64, max_iterations: usize) -> Self {
-        use tracing::info;
-
         let seed_env = std::env::var("SHUTTLE_RANDOM_SEED");
         let seed = match seed_env {
             Ok(s) => match s.as_str().parse::<u64>() {
                 Ok(seed) => {
-                    info!(
+                    tracing::info!(
                         "Initializing RandomScheduler with the seed provided by SHUTTLE_RANDOM_SEED: {}",
                         seed
                     );

--- a/src/scheduler/random.rs
+++ b/src/scheduler/random.rs
@@ -58,7 +58,25 @@ impl RandomScheduler {
     /// Two RandomSchedulers initialized with the same seed will make the same scheduling decisions
     /// when executing the same workloads.
     pub fn new_from_seed(seed: u64, max_iterations: usize) -> Self {
+        use tracing::info;
+
+        let seed_env = std::env::var("SHUTTLE_RANDOM_SEED");
+        let seed = match seed_env {
+            Ok(s) => match s.as_str().parse::<u64>() {
+                Ok(seed) => {
+                    info!(
+                        "Initializing RandomScheduler with the seed provided by SHUTTLE_RANDOM_SEED: {}",
+                        seed
+                    );
+                    seed
+                }
+                Err(err) => panic!("The seed provided by SHUTTLE_RANDOM_SEED is not a valid u64: {}", err),
+            },
+            Err(_) => seed,
+        };
+
         let rng = Pcg64Mcg::seed_from_u64(seed);
+
         Self {
             max_iterations,
             rng,


### PR DESCRIPTION
Does two things:
1. Makes it so that if `SHUTTLE_RANDOM_SEED` is set, then that seed will be used.
2. Makes the PctScheduler also honor `SHUTTLE_RANDOM_SEED` (vs just RandomScheduler previously)

Regarding 2: We added the output seed and replay on seed in https://github.com/awslabs/shuttle/pull/161. @jorajeev originally wanted PCT as well, but this was for some reason left as is. I don't see why PCT shouldn't honor `SHUTTLE_RANDOM_SEED`.

Regarding 1: Currently it is kind of annoying and also just a bad user experience (because we say "set this env var", and then, depending on how the test is setup, might just ignore it) that the test has to use `check_random` for `SHUTTLE_RANDOM_SEED` to be honored. This is made worse by the fact that we mostly don't use `check_random`, and also usually recommend creating runners/schedulers explicitly (just because this is more versatile).

I believe the original arguments for putting it in `check_random` vs inside the constructor was that 1: one can always build a new constructor which honors the environment variable and 2: if you create a scheduler through `new_from_seed` then it seems fair to expect that you'll get a scheduler initialized with this seed. My argument against these points is that `SHUTTLE_RANDOM_SEED` doesn't get set by accident, and setting it and not getting the seed overridden is both worse and significantly more likely to occur. It also makes sense for the `new_from_seed` to be overridden because what is output is the seed used for the last execution, but what is input is the seed for the first execution. Also, `new_from_seed` mostly exists such that the seed can be generated by something like proptest, in which case you for sure will want to override the seed if a failing one is found.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.