### PR TITLE
Remove replay instructions from console output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@
 //!
 //! ```text
 //! test panicked in task "task-0" with schedule: "910102ccdedf9592aba2afd70104"
-//! pass that schedule string into `shuttle::replay` to reproduce the failure
 //! ```
 //!
 //! We can use Shuttle's [`replay`] function to replay the execution that causes the failure:

--- a/src/runtime/failure.rs
+++ b/src/runtime/failure.rs
@@ -67,14 +67,13 @@ fn persist_failure_inner(schedule: &Schedule, message: String, config: &Config) 
     // Try to persist to a file, but fall through to stdout if that fails for some reason
     if let FailurePersistence::File(directory) = &config.failure_persistence {
         match persist_failure_to_file(&serialized_schedule, directory.as_ref()) {
-            Ok(path) => return format!("{}\nfailing schedule persisted to file: {}\npass that path to `shuttle::replay_from_file` to replay the failure", message, path.display()),
-            Err(e) => eprintln!("failed to persist schedule to file (error: {}), falling back to printing the schedule", e),
+            Ok(path) => return format!("{message}\nfailing schedule persisted to file: {}", path.display()),
+            Err(e) => {
+                eprintln!("failed to persist schedule to file (error: {e}), falling back to printing the schedule")
+            }
         }
     }
-    format!(
-        "{}\nfailing schedule:\n\"\n{}\n\"\npass that string to `shuttle::replay` to replay the failure",
-        message, serialized_schedule
-    )
+    format!("{}\nfailing schedule:\n\"\n{}\n\"", message, serialized_schedule)
 }
 
 /// Persist the given serialized schedule to a file and return the new file's path. The file will be

--- a/src/scheduler/random.rs
+++ b/src/scheduler/random.rs
@@ -39,10 +39,7 @@ impl CurrentSeedDropGuard {
 impl Drop for CurrentSeedDropGuard {
     fn drop(&mut self) {
         if let Some(s) = self.inner {
-            eprintln!(
-                "failing seed:\n\"\n{}\n\"\nTo replay the failure, either:\n    1) pass the seed to `shuttle::check_random_with_seed, or\n    2) set the environment variable SHUTTLE_RANDOM_SEED to the seed and run `shuttle::check_random`.",
-                s
-            )
+            eprintln!("RandomScheduler failing seed: {s}")
         }
     }
 }


### PR DESCRIPTION
The output saying to use `shuttle::{replay, replay_from_file, check_random_with_seed}` is confusing when Shuttle is part of a bigger testing framework that manages how test failures should be replayed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.