### PR TITLE
Fix: make ThreadRng::default no longer give a Clippy error

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -18,7 +18,11 @@ pub mod rngs {
     /// single RNG. This RNG is automatically seeded by Shuttle, and cannot be re-seeded, so this
     /// sharing should be indistinguishable from truly thread-local behavior.
     #[derive(Debug, Default, Clone)]
-    pub struct ThreadRng;
+    pub struct ThreadRng {
+        // If this doesn't exist then usage of `ThreadRng::default()` will result in the following Clippy error:
+        // `error: use of `default` to create a unit struct`
+        pub(super) _field: (),
+    }
 
     impl RngCore for ThreadRng {
         #[inline]
@@ -48,7 +52,7 @@ pub mod rngs {
 /// method chaining style, e.g. `thread_rng().gen::<i32>()`, or cached locally, e.g.
 /// `let mut rng = thread_rng();`.
 pub fn thread_rng() -> rngs::ThreadRng {
-    rngs::ThreadRng
+    rngs::ThreadRng { _field: () }
 }
 
 pub use rand::{Rng, RngCore};

--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -507,7 +507,7 @@ impl Task {
     /// Returns the `tag` which was there previously.
     pub(crate) fn set_tag(&mut self, tag: Arc<dyn Tag>) -> Option<Arc<dyn Tag>> {
         TASK_ID_TO_TAGS.with(|cell| cell.borrow_mut().insert(self.id(), tag.clone()));
-        std::mem::replace(&mut self.tag, Some(tag))
+        self.tag.replace(tag)
     }
 }
 

--- a/src/scheduler/serialization.rs
+++ b/src/scheduler/serialization.rs
@@ -64,10 +64,7 @@ mod varint {
                     if last == 0x01 {
                         return Ok(result + (1 << offset));
                     } else {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            "varint exceeded 64 bits long",
-                        ));
+                        return Err(std::io::Error::other("varint exceeded 64 bits long"));
                     }
                 }
             }


### PR DESCRIPTION
Currently use of `ThreadRng::default` results in a Clippy error. After this change it does not.


Also fixes some Clippies

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.