### PR TITLE
Add thread::scope

### DIFF
--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -80,7 +80,7 @@ impl Execution {
         EXECUTION_STATE.set(&state, move || {
             // Spawn `f` as the first task
             ExecutionState::spawn_thread(
-                move || thread_fn(f, Default::default()),
+                Box::new(move || thread_fn(f, Default::default())),
                 config.stack_size,
                 Some("main-thread".to_string()),
                 Some(VectorClock::new()),
@@ -406,14 +406,12 @@ impl ExecutionState {
         task_id
     }
 
-    pub(crate) fn spawn_thread<F>(
-        f: F,
+    pub(crate) fn spawn_thread(
+        f: Box<dyn FnOnce() + 'static>,
         stack_size: usize,
         name: Option<String>,
         mut initial_clock: Option<VectorClock>,
     ) -> TaskId
-    where
-        F: FnOnce() + Send + 'static,
     {
         let task_id = Self::with(|state| {
             let parent_span_id = state.top_level_span.id();

--- a/src/runtime/execution.rs
+++ b/src/runtime/execution.rs
@@ -411,8 +411,7 @@ impl ExecutionState {
         stack_size: usize,
         name: Option<String>,
         mut initial_clock: Option<VectorClock>,
-    ) -> TaskId
-    {
+    ) -> TaskId {
         let task_id = Self::with(|state| {
             let parent_span_id = state.top_level_span.id();
             let task_id = TaskId(state.tasks.len());

--- a/tests/basic/thread.rs
+++ b/tests/basic/thread.rs
@@ -37,7 +37,7 @@ fn thread_yield_point() {
 
 #[test]
 fn thread_scope() {
-    check_random(
+    check_dfs(
         || {
             let mut trigger = false;
             thread::scope(|s| {
@@ -47,13 +47,13 @@ fn thread_scope() {
             });
             assert!(trigger);
         },
-        100,
+        None,
     );
 }
 
 #[test]
 fn thread_scope_multiple() {
-    check_random(
+    check_dfs(
         || {
             let mut data = vec![1, 2, 3, 4, 5, 6];
 
@@ -75,13 +75,13 @@ fn thread_scope_multiple() {
 
             assert_eq!(data, vec![10, 20, 30, 104, 105, 106]);
         },
-        100,
+        None,
     );
 }
 
 #[test]
 fn thread_scope_join() {
-    check_random(
+    check_dfs(
         || {
             let num = Mutex::new(10);
 
@@ -105,7 +105,7 @@ fn thread_scope_join() {
 
             assert_eq!(*num.lock().unwrap(), 110);
         },
-        100,
+        None,
     );
 }
 

--- a/tests/basic/thread.rs
+++ b/tests/basic/thread.rs
@@ -36,6 +36,80 @@ fn thread_yield_point() {
 }
 
 #[test]
+fn thread_scope() {
+    check_random(
+        || {
+            let mut trigger = false;
+            thread::scope(|s| {
+                s.spawn(|| {
+                    trigger = true;
+                });
+            });
+            assert!(trigger);
+        },
+        100,
+    );
+}
+
+#[test]
+fn thread_scope_multiple() {
+    check_random(
+        || {
+            let mut data = vec![1, 2, 3, 4, 5, 6];
+
+            thread::scope(|s| {
+                let (left, right) = data.split_at_mut(3);
+
+                s.spawn(|| {
+                    for x in left {
+                        *x *= 10;
+                    }
+                });
+
+                s.spawn(|| {
+                    for x in right {
+                        *x += 100;
+                    }
+                });
+            });
+
+            assert_eq!(data, vec![10, 20, 30, 104, 105, 106]);
+        },
+        100,
+    );
+}
+
+#[test]
+fn thread_scope_join() {
+    check_random(
+        || {
+            let num = Mutex::new(10);
+
+            thread::scope(|s| {
+                let handle = s.spawn(|| {
+                    let mut num_guard = num.lock().unwrap();
+                    *num_guard *= 10;
+                    *num_guard
+                });
+
+                assert_eq!(handle.join().unwrap(), 100);
+
+                let handle = s.spawn(|| {
+                    let mut num_guard = num.lock().unwrap();
+                    *num_guard += 10;
+                    *num_guard
+                });
+
+                assert_eq!(handle.join().unwrap(), 110);
+            });
+
+            assert_eq!(*num.lock().unwrap(), 110);
+        },
+        100,
+    );
+}
+
+#[test]
 fn thread_join() {
     check_random(
         || {


### PR DESCRIPTION
<!-- Enter your PR description here -->
Adds `thread::scope`, which allows threads to borrow non-'static data.
---

Hello, I’ve been using shuttle in my own projects and found it really useful! I prefer using thread::scope instead of thread::spawn in my code when I can, so I initially vendored Shuttle and added scoped thread support locally.

After seeing #153, I decided to fork and upstream my changes in this pull request. I've included some test cases as well.

One change which may be undesirable is the removal of `Send` bounds from task spawning and changing the functions to take a boxed closure directly. The former was due to scoped threads relying on `Rc<RefCell>` to track the number of running threads. The latter came about because I needed to box the closure early in `spawn_named` (now renamed to `spawn_named_unchecked`) to erase scoped lifetimes. I don't think removing `Send` is too much of an issue since the runtime is single-threaded, but correct me if I'm wrong. Anyways, this was the way I found to support scoped threads.

Resolves #153 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.