### PR TITLE
Add AbortHandle

### DIFF
--- a/src/runtime/task/mod.rs
+++ b/src/runtime/task/mod.rs
@@ -344,6 +344,11 @@ impl Task {
         self.detached = true;
     }
 
+    pub(crate) fn abort(&mut self) {
+        // TODO: Change into actually aborting
+        self.detach();
+    }
+
     pub(crate) fn waker(&self) -> Waker {
         self.waker.clone()
     }


### PR DESCRIPTION
Adds `AbortHandle` (analogous to `tokio::task::AbortHandle`).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.