### PR TITLE
Impl Send and Sync for JoinHandle<T> regardless of T

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -136,6 +136,9 @@ pub struct JoinHandle<T> {
     result: std::sync::Arc<std::sync::Mutex<Option<Result<T>>>>,
 }
 
+unsafe impl<T> Send for JoinHandle<T> {}
+unsafe impl<T> Sync for JoinHandle<T> {}
+
 impl<T> JoinHandle<T> {
     /// Waits for the associated thread to finish.
     pub fn join(self) -> Result<T> {


### PR DESCRIPTION
https://doc.rust-lang.org/src/std/thread/mod.rs.html#1822-1824

Currently we just get `Send` and `Sync` as auto traits, which means `JoinHandle<T>` is `Send`/`Sync` only if `T` is `Send`/`Sync`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.