### PR TITLE
Vector Clock Feature Flag

### DIFF
--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -38,12 +38,16 @@ test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 trybuild = "1.0"
 pin-project = "1.1.3"
+# The following line is necessary to ensure vector-clocks are used for integration tests
+# To run performance tests without vector clocks using `cargo bench`, this line must be commented out
+shuttle = { path = ".", features = ["vector-clocks"] }
 
 [lib]
 bench = false
 
 [features]
 default = []
+vector-clocks = []
 annotation = ["dep:serde", "dep:serde_json", "dep:regex"]
 
 [[bench]]

--- a/shuttle/src/runtime/task/clock.rs
+++ b/shuttle/src/runtime/task/clock.rs
@@ -2,7 +2,7 @@ use crate::runtime::task::TaskId;
 use std::cmp::{Ordering, PartialOrd};
 
 #[cfg(any(test, feature = "vector-clocks"))]
-mod vc_enabled {
+mod vector_clock {
     use super::*;
     use crate::runtime::task::DEFAULT_INLINE_TASKS;
     use smallvec::{smallvec, SmallVec};
@@ -100,7 +100,7 @@ mod vc_enabled {
 /// A dummy VectorClock implementation which only provides no-op stubs to improve testing throughput when
 /// vector clocks are not necessary
 #[cfg(not(any(test, feature = "vector-clocks")))]
-mod vc_disabled {
+mod vector_clock {
     use super::*;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
@@ -154,11 +154,7 @@ mod vc_disabled {
     }
 }
 
-#[cfg(any(test, feature = "vector-clocks"))]
-pub use vc_enabled::VectorClock;
-
-#[cfg(not(any(test, feature = "vector-clocks")))]
-pub use vc_disabled::VectorClock;
+pub use vector_clock::VectorClock;
 
 #[cfg(test)]
 mod test {

--- a/shuttle/src/runtime/task/clock.rs
+++ b/shuttle/src/runtime/task/clock.rs
@@ -1,95 +1,164 @@
-use crate::runtime::task::{TaskId, DEFAULT_INLINE_TASKS};
-use smallvec::{smallvec, SmallVec};
+use crate::runtime::task::TaskId;
 use std::cmp::{Ordering, PartialOrd};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct VectorClock {
-    pub(crate) time: SmallVec<[u32; DEFAULT_INLINE_TASKS]>,
-}
+#[cfg(any(test, feature = "vector-clocks"))]
+mod vc_enabled {
+    use super::*;
+    use crate::runtime::task::DEFAULT_INLINE_TASKS;
+    use smallvec::{smallvec, SmallVec};
 
-impl VectorClock {
-    pub(crate) const fn new() -> Self {
-        Self {
-            time: SmallVec::new_const(),
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct VectorClock {
+        pub(crate) time: SmallVec<[u32; DEFAULT_INLINE_TASKS]>,
+    }
+
+    impl VectorClock {
+        pub(crate) const fn new() -> Self {
+            Self {
+                time: SmallVec::new_const(),
+            }
+        }
+
+        // Zero extend clock to accommodate `task_id` tasks.
+        pub(crate) fn extend(&mut self, task_id: TaskId) {
+            let num_new_tasks = 1 + task_id.0 - self.time.len();
+            let clock: SmallVec<[_; DEFAULT_INLINE_TASKS]> = smallvec![0u32; num_new_tasks];
+            self.time.extend_from_slice(&clock);
+        }
+
+        pub(crate) fn increment(&mut self, task_id: TaskId) {
+            self.time[task_id.0] += 1;
+        }
+
+        // Update the clock of `self` with the clock from `other`
+        pub(crate) fn update(&mut self, other: &Self) {
+            let n1 = self.time.len();
+            let n2 = other.time.len();
+            for i in 0..n1.min(n2) {
+                self.time[i] = self.time[i].max(other.time[i])
+            }
+            for i in n1..n2 {
+                // could be empty
+                self.time.push(other.time[i]);
+            }
+        }
+
+        pub fn get(&self, i: usize) -> u32 {
+            self.time[i]
         }
     }
 
-    // Zero extend clock to accommodate `task_id` tasks.
-    pub(crate) fn extend(&mut self, task_id: TaskId) {
-        let num_new_tasks = 1 + task_id.0 - self.time.len();
-        let clock: SmallVec<[_; DEFAULT_INLINE_TASKS]> = smallvec![0u32; num_new_tasks];
-        self.time.extend_from_slice(&clock);
-    }
-
-    pub(crate) fn increment(&mut self, task_id: TaskId) {
-        self.time[task_id.0] += 1;
-    }
-
-    // Update the clock of `self` with the clock from `other`
-    pub(crate) fn update(&mut self, other: &Self) {
-        let n1 = self.time.len();
-        let n2 = other.time.len();
-        for i in 0..n1.min(n2) {
-            self.time[i] = self.time[i].max(other.time[i])
-        }
-        for i in n1..n2 {
-            // could be empty
-            self.time.push(other.time[i]);
+    impl<const N: usize> From<&[u32; N]> for VectorClock {
+        fn from(v: &[u32; N]) -> Self {
+            Self {
+                time: SmallVec::from(&v[..]),
+            }
         }
     }
 
-    pub fn get(&self, i: usize) -> u32 {
-        self.time[i]
+    impl From<&[u32]> for VectorClock {
+        fn from(v: &[u32]) -> Self {
+            Self {
+                time: SmallVec::from(v),
+            }
+        }
     }
-}
 
-impl<const N: usize> From<&[u32; N]> for VectorClock {
-    fn from(v: &[u32; N]) -> Self {
-        Self {
-            time: SmallVec::from(&v[..]),
+    impl std::ops::Deref for VectorClock {
+        type Target = [u32];
+        fn deref(&self) -> &Self::Target {
+            &self.time[..]
+        }
+    }
+
+    fn unify(a: Ordering, b: Ordering) -> Option<Ordering> {
+        use Ordering::*;
+
+        match (a, b) {
+            (Equal, Equal) => Some(Equal),
+            (Less, Greater) | (Greater, Less) => None,
+            (Less, _) | (_, Less) => Some(Less),
+            (Greater, _) | (_, Greater) => Some(Greater),
+        }
+    }
+
+    impl PartialOrd for VectorClock {
+        // Compare vector clocks
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            let n1 = self.time.len();
+            let n2 = other.time.len();
+            // if (n1<n2), then other can't have happened before self, similarly for (n1>n2)
+            let mut ord = n1.cmp(&n2);
+            for i in 0..n1.min(n2) {
+                ord = unify(ord, self.time[i].cmp(&other.time[i]))?; // return if incomparable
+            }
+            Some(ord)
         }
     }
 }
 
-impl From<&[u32]> for VectorClock {
-    fn from(v: &[u32]) -> Self {
-        Self {
-            time: SmallVec::from(v),
+/// A dummy VectorClock implementation which only provides no-op stubs to improve testing throughput when
+/// vector clocks are not necessary
+#[cfg(not(any(test, feature = "vector-clocks")))]
+mod vc_disabled {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub struct VectorClock;
+
+    impl VectorClock {
+        pub(crate) const fn new() -> Self {
+            Self
+        }
+
+        pub(crate) fn extend(&mut self, _task_id: TaskId) {
+            // No-op when vector clocks are disabled
+        }
+
+        pub(crate) fn increment(&mut self, _task_id: TaskId) {
+            // No-op when vector clocks are disabled
+        }
+
+        pub(crate) fn update(&mut self, _other: &Self) {
+            // No-op when vector clocks are disabled
+        }
+
+        pub fn get(&self, _i: usize) -> u32 {
+            0
+        }
+    }
+
+    impl<const N: usize> From<&[u32; N]> for VectorClock {
+        fn from(_v: &[u32; N]) -> Self {
+            Self
+        }
+    }
+
+    impl From<&[u32]> for VectorClock {
+        fn from(_v: &[u32]) -> Self {
+            Self
+        }
+    }
+
+    impl std::ops::Deref for VectorClock {
+        type Target = [u32];
+        fn deref(&self) -> &Self::Target {
+            &[]
+        }
+    }
+
+    impl PartialOrd for VectorClock {
+        fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+            Some(Ordering::Equal)
         }
     }
 }
 
-impl std::ops::Deref for VectorClock {
-    type Target = [u32];
-    fn deref(&self) -> &Self::Target {
-        &self.time[..]
-    }
-}
+#[cfg(any(test, feature = "vector-clocks"))]
+pub use vc_enabled::VectorClock;
 
-fn unify(a: Ordering, b: Ordering) -> Option<Ordering> {
-    use Ordering::*;
-
-    match (a, b) {
-        (Equal, Equal) => Some(Equal),
-        (Less, Greater) | (Greater, Less) => None,
-        (Less, _) | (_, Less) => Some(Less),
-        (Greater, _) | (_, Greater) => Some(Greater),
-    }
-}
-
-impl PartialOrd for VectorClock {
-    // Compare vector clocks
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let n1 = self.time.len();
-        let n2 = other.time.len();
-        // if (n1<n2), then other can't have happened before self, similarly for (n1>n2)
-        let mut ord = n1.cmp(&n2);
-        for i in 0..n1.min(n2) {
-            ord = unify(ord, self.time[i].cmp(&other.time[i]))?; // return if incomparable
-        }
-        Some(ord)
-    }
-}
+#[cfg(not(any(test, feature = "vector-clocks")))]
+pub use vc_disabled::VectorClock;
 
 #[cfg(test)]
 mod test {

--- a/shuttle/src/runtime/task/mod.rs
+++ b/shuttle/src/runtime/task/mod.rs
@@ -205,6 +205,7 @@ impl Task {
         tag: Option<Arc<dyn Tag>>,
         parent_task_id: Option<TaskId>,
     ) -> Self {
+        #[cfg(any(test, feature = "vector-clocks"))]
         assert!(id.0 < clock.time.len());
         let mut continuation = ContinuationPool::acquire(stack_size);
         continuation.initialize(f);


### PR DESCRIPTION
This PR adds a feature flag for vector clocks to boost Shuttle's testing throughput when they are not needed.

This feature flag is *disabled* by default in production, but *always enabled* for tests because many tests leverage vector clocks for assertions to check correctness. In the micro-benchmarks for the Shuttle repository, this results in performance gains of 5-25%:

[criterion.tar.gz](https://github.com/user-attachments/files/21477778/criterion.tar.gz)

When disabled, the VectorClock struct is replaced by an empty struct for which all operations are i.e. a no-op.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.