### PR TITLE
Fix lifetime warnings

### DIFF
--- a/shuttle/src/sync/mutex.rs
+++ b/shuttle/src/sync/mutex.rs
@@ -89,7 +89,7 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// If the lock could not be acquired at this time, then Err is returned. This function does not
     /// block.
-    pub fn try_lock(&self) -> TryLockResult<MutexGuard<T>> {
+    pub fn try_lock(&self) -> TryLockResult<MutexGuard<'_, T>> {
         let me = current::me();
 
         let mut state = self.state.borrow_mut();

--- a/shuttle/src/sync/rwlock.rs
+++ b/shuttle/src/sync/rwlock.rs
@@ -114,7 +114,7 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// Note that unlike [`std::sync::RwLock::try_read`], if the current thread already holds this
     /// read lock, `try_read` will return Err.
-    pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<T>> {
+    pub fn try_read(&self) -> TryLockResult<RwLockReadGuard<'_, T>> {
         if self.try_lock(RwLockType::Read) {
             match self.inner.try_read() {
                 Ok(guard) => Ok(RwLockReadGuard {
@@ -138,7 +138,7 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// If the access could not be granted at this time, then Err is returned. This function does
     /// not block.
-    pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<T>> {
+    pub fn try_write(&self) -> TryLockResult<RwLockWriteGuard<'_, T>> {
         if self.try_lock(RwLockType::Write) {
             match self.inner.try_write() {
                 Ok(guard) => Ok(RwLockWriteGuard {


### PR DESCRIPTION
The latest version of stable has a new warning which fails the `shuttle` build (e.g. https://github.com/awslabs/shuttle/actions/runs/16810934541/job/47617230393?pr=191).

This PR resolves these linter errors.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.