### PR TITLE
Adding GH workflow to automatically compare performance of benchmarks on PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Benchmarks (with vector clocks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
       - name: cargo bench

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
       - name: cargo test
@@ -26,7 +26,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
       - name: Install rustfmt
@@ -38,7 +38,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
       - name: Install clippy
@@ -46,22 +46,25 @@ jobs:
       - name: clippy
         run: cargo clippy --all-targets -- -D clippy::all
 
-  bench:
-    name: Benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
-      - name: cargo bench
-        run: cargo bench --features bench-no-vector-clocks
-
   docs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
       - name: cargo doc
         run: cargo doc --no-deps
+
+  bench:
+    name: Benchmarks 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - uses: boa-dev/criterion-compare-action@v3
+        with:
+          cwd: "shuttle"
+          features: "bench-no-vector-clocks"
+          branchName: ${{ github.base_ref }}

--- a/shuttle/benches/buffer.rs
+++ b/shuttle/benches/buffer.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion};
 use shuttle::scheduler::{PctScheduler, RandomScheduler, Scheduler};
 use shuttle::sync::{Condvar, Mutex};
 use shuttle::{thread, Runner};
@@ -78,7 +78,6 @@ fn bounded_buffer_check(scheduler: impl Scheduler + 'static) {
 
 pub fn bounded_buffer_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("buffer");
-    g.throughput(Throughput::Elements(ITERATIONS as u64));
 
     g.bench_function("pct", |b| {
         b.iter(|| {

--- a/shuttle/benches/counter.rs
+++ b/shuttle/benches/counter.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
 use shuttle::scheduler::{PctScheduler, RandomScheduler, Scheduler};
 use shuttle::sync::atomic::{AtomicUsize, Ordering};
 use shuttle::{future, thread, Runner};
@@ -62,7 +62,6 @@ fn counter_sync(scheduler: impl Scheduler + 'static, num_tasks: u32, num_events_
 
 pub fn counter_async_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("counter async");
-    g.throughput(Throughput::Elements((ITERATIONS * TOTAL_EVENTS as usize) as u64));
     g.warm_up_time(Duration::from_secs(1));
 
     g.bench_function("pct-narrow", |b| {
@@ -96,7 +95,6 @@ pub fn counter_async_benchmark(c: &mut Criterion) {
 
 pub fn counter_sync_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("counter sync");
-    g.throughput(Throughput::Elements((ITERATIONS * TOTAL_EVENTS as usize) as u64));
     g.warm_up_time(Duration::from_secs(1));
 
     g.bench_function("pct-narrow", |b| {

--- a/shuttle/benches/create.rs
+++ b/shuttle/benches/create.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion};
 use shuttle::scheduler::{PctScheduler, RandomScheduler, Scheduler};
 use shuttle::sync::atomic::{AtomicUsize, Ordering};
 use shuttle::{future, thread, Runner};
@@ -54,7 +54,6 @@ fn counter_sync(scheduler: impl Scheduler + 'static, num_tasks: u32) {
 
 pub fn create_async_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("create async");
-    g.throughput(Throughput::Elements(ITERATIONS as u64));
 
     g.bench_function("pct-narrow", |b| {
         b.iter(|| {
@@ -87,7 +86,6 @@ pub fn create_async_benchmark(c: &mut Criterion) {
 
 pub fn create_sync_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("create sync");
-    g.throughput(Throughput::Elements(ITERATIONS as u64));
 
     g.bench_function("pct-narrow", |b| {
         b.iter(|| {

--- a/shuttle/benches/lock.rs
+++ b/shuttle/benches/lock.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
 use shuttle::scheduler::{PctScheduler, RandomScheduler, Scheduler};
 use shuttle::sync::Mutex;
 use shuttle::{thread, Runner};
@@ -38,7 +38,6 @@ fn lock_benchmark(scheduler: impl Scheduler + 'static, num_tasks: u32, num_event
 
 pub fn lock_sync_benchmark(c: &mut Criterion) {
     let mut g = c.benchmark_group("lock sync");
-    g.throughput(Throughput::Elements((ITERATIONS * TOTAL_EVENTS as usize) as u64));
     g.warm_up_time(Duration::from_secs(1));
 
     g.bench_function("pct-narrow", |b| {


### PR DESCRIPTION
This PR adds a Github workflow which runs `cargo bench --features bench-no-vector-clocks` on each PR for (a) the branch being PR'ed and (b) the main branch of Shuttle. The [Github action](https://github.com/boa-dev/criterion-compare-action) comments on the PR with the results of the comparison. As the benchmarks are run in CI, the numbers should be taken with a grain of salt, but they can give a quick, broad intuition for the performance effects of changes which can be investigated further if necessary.

Notably, there is a bug in the open-source action that is doing this (https://github.com/boa-dev/criterion-compare-action/issues/22) which causes throughput to be displayed incorrectly. Because throughput and latency are essentially the same in these closed, fixed workload benchmarks (`tput = constant workload / latency`) I have removed throughput reporting from the benchmarks so that the comparison renders properly.

See https://github.com/dylanjwolff/shuttle/pull/5 for an example of what this will look like.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.