### PR TITLE
Adding stable identifiers to tasks across Shuttle test iterations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ env:
 
 jobs:
   test:
+    env:
+      RUST_LOG: off
     name: Tests
     runs-on: ubuntu-latest
     steps:

--- a/shuttle/src/runtime/execution.rs
+++ b/shuttle/src/runtime/execution.rs
@@ -2,7 +2,7 @@ use crate::runtime::failure::{init_panic_hook, persist_failure, persist_task_fai
 use crate::runtime::storage::{StorageKey, StorageMap};
 use crate::runtime::task::clock::VectorClock;
 use crate::runtime::task::labels::Labels;
-use crate::runtime::task::{ChildLabelFn, Task, TaskId, TaskName, DEFAULT_INLINE_TASKS};
+use crate::runtime::task::{ChildLabelFn, Task, TaskId, TaskName, TaskSignature, DEFAULT_INLINE_TASKS};
 use crate::runtime::thread::continuation::PooledContinuation;
 use crate::scheduler::{Schedule, Scheduler};
 use crate::thread::thread_fn;
@@ -14,7 +14,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
-use std::panic;
+use std::panic::{self, Location};
 use std::rc::Rc;
 use std::sync::Arc;
 use tracing::{trace, Span};
@@ -65,7 +65,7 @@ impl Execution {
     /// Run a function to be tested, taking control of scheduling it and any tasks it might spawn.
     /// This function runs until `f` and all tasks spawned by `f` have terminated, or until the
     /// scheduler returns `None`, indicating the execution should not be explored any further.
-    pub(crate) fn run<F>(mut self, config: &Config, f: F)
+    pub(crate) fn run<F>(mut self, config: &Config, f: F, caller: &'static Location<'static>)
     where
         F: FnOnce() + Send + 'static,
     {
@@ -79,11 +79,10 @@ impl Execution {
 
         EXECUTION_STATE.set(&state, move || {
             // Spawn `f` as the first task
-            ExecutionState::spawn_thread(
+            ExecutionState::spawn_main_thread(
                 Box::new(move || thread_fn(f, Default::default())),
                 config.stack_size,
-                Some("main-thread".to_string()),
-                Some(VectorClock::new()),
+                caller,
             );
 
             // Run the test to completion
@@ -373,9 +372,57 @@ impl ExecutionState {
         });
     }
 
+    // Note: `spawn_thread`, `spawn_main_thread`, and `spawn_future` share some similar logic.
+    // Changes to one of these functions likely need to be propagated to the other two as well.
+    pub(crate) fn spawn_main_thread(
+        f: Box<dyn FnOnce() + 'static>,
+        stack_size: usize,
+        caller: &'static Location<'static>,
+    ) -> TaskId {
+        let name = "main-thread".to_string();
+        let mut clock = VectorClock::new();
+
+        let task_id = Self::with(|state| {
+            let parent_span_id = state.top_level_span.id();
+            let task_id = TaskId(state.tasks.len());
+            let tag = state.get_tag_or_default_for_current_task();
+
+            Self::set_labels_for_new_task(state, task_id, Some(name.clone()));
+
+            clock.extend(task_id); // and extend it with an entry for the new thread
+
+            let schedule_len = state.current_schedule.len();
+
+            let task = Task::from_closure(
+                f,
+                stack_size,
+                task_id,
+                Some(name),
+                clock,
+                parent_span_id,
+                schedule_len,
+                tag,
+                None,
+                TaskSignature::new_parentless(caller),
+            );
+            state.tasks.push(task);
+
+            task_id
+        });
+        crate::annotations::record_task_created(task_id, false);
+        task_id
+    }
+
+    // Note: `spawn_thread`, `spawn_main_thread`, and `spawn_future` share some similar logic.
+    // Changes to one of these functions likely need to be propagated to the other two as well.
     /// Spawn a new task for a future. This doesn't create a yield point; the caller should do that
     /// if it wants to give the new task a chance to run immediately.
-    pub(crate) fn spawn_future<F>(future: F, stack_size: usize, name: Option<String>) -> TaskId
+    pub(crate) fn spawn_future<F>(
+        future: F,
+        stack_size: usize,
+        name: Option<String>,
+        caller: &'static Location<'static>,
+    ) -> TaskId
     where
         F: Future<Output = ()> + 'static,
     {
@@ -400,7 +447,8 @@ impl ExecutionState {
                 parent_span_id,
                 schedule_len,
                 tag,
-                state.try_current().map(|t| t.id()),
+                Some(state.current().id()),
+                state.current_mut().signature.new_child(caller),
             );
 
             state.tasks.push(task);
@@ -411,11 +459,14 @@ impl ExecutionState {
         task_id
     }
 
+    // Note: `spawn_thread`, `spawn_main_thread`, and `spawn_future` share some similar logic.
+    // Changes to one of these functions likely need to be propagated to the other two as well.
     pub(crate) fn spawn_thread(
         f: Box<dyn FnOnce() + 'static>,
         stack_size: usize,
         name: Option<String>,
         mut initial_clock: Option<VectorClock>,
+        caller: &'static Location<'static>,
     ) -> TaskId {
         let task_id = Self::with(|state| {
             let parent_span_id = state.top_level_span.id();
@@ -444,7 +495,8 @@ impl ExecutionState {
                 parent_span_id,
                 schedule_len,
                 tag,
-                state.try_current().map(|t| t.id()),
+                Some(state.current().id()),
+                state.current_mut().signature.new_child(caller),
             );
             state.tasks.push(task);
 

--- a/shuttle/tests/basic/mod.rs
+++ b/shuttle/tests/basic/mod.rs
@@ -18,6 +18,7 @@ mod replay;
 mod rwlock;
 mod shrink;
 mod tag;
+mod task;
 mod thread;
 mod timeout;
 mod tracing;

--- a/shuttle/tests/basic/task.rs
+++ b/shuttle/tests/basic/task.rs
@@ -1,0 +1,250 @@
+use shuttle::{future, scheduler::RandomScheduler, thread, Runner};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use test_log::test;
+use tracing::field::{Field, Visit};
+use tracing::{trace, Event, Id, Metadata, Subscriber};
+
+type SigCounterMap = Arc<Mutex<HashMap<u64, usize>>>;
+#[derive(Clone)]
+struct SignatureSubscriber {
+    signatures: SigCounterMap,
+    static_create_locations: SigCounterMap,
+}
+
+impl SignatureSubscriber {
+    pub fn new() -> Self {
+        Self {
+            signatures: Arc::new(Mutex::new(HashMap::new())),
+            static_create_locations: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Subscriber for SignatureSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let metadata = event.metadata();
+        if metadata.target() == "shuttle::runtime::task" && metadata.level() == &tracing::Level::INFO {
+            struct SignatureVisitor {
+                task_id: Option<String>,
+                signature: Option<u64>,
+                static_create_location: Option<u64>,
+            }
+            impl Visit for SignatureVisitor {
+                fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                    if field.name() == "task_id" {
+                        self.task_id = Some(format!("{:?}", value));
+                    }
+                }
+                fn record_u64(&mut self, field: &Field, value: u64) {
+                    if field.name() == "signature" {
+                        self.signature = Some(value);
+                    }
+                    if field.name() == "static_create_location" {
+                        self.static_create_location = Some(value);
+                    }
+                }
+            }
+            let mut visitor = SignatureVisitor {
+                task_id: None,
+                signature: None,
+                static_create_location: None,
+            };
+            event.record(&mut visitor);
+
+            if let Some(sig) = visitor.signature {
+                self.signatures
+                    .lock()
+                    .unwrap()
+                    .entry(sig)
+                    .and_modify(|counter| *counter += 1)
+                    .or_insert(1);
+            }
+            if let Some(loc) = visitor.static_create_location {
+                self.static_create_locations
+                    .lock()
+                    .unwrap()
+                    .entry(loc)
+                    .and_modify(|counter| *counter += 1)
+                    .or_insert(1);
+            }
+        }
+    }
+
+    fn enter(&self, _span: &Id) {}
+    fn exit(&self, _span: &Id) {}
+}
+
+pub fn check_any_n_same_signatures(signatures: &SigCounterMap, expected_count: usize) {
+    let signatures = signatures.lock().unwrap();
+    trace!("Total signatures captured: {}", signatures.len());
+
+    trace!("Signature counts: {:?}", signatures);
+
+    let worker_signatures: Vec<u64> = signatures
+        .iter()
+        .filter(|(_, count)| **count == expected_count)
+        .map(|(sig, _)| *sig)
+        .collect();
+
+    assert_eq!(
+        worker_signatures.len(),
+        1,
+        "Should have exactly one signature appearing {} times",
+        expected_count
+    );
+    trace!(
+        "{} tasks have the same signature: {}",
+        expected_count,
+        worker_signatures[0]
+    );
+}
+
+pub fn check_exactly_n_different_signatures(signatures: &SigCounterMap, expected_count: usize) {
+    let signatures = signatures.lock().unwrap();
+    trace!("Total signatures captured: {}", signatures.len());
+
+    trace!("Signature counts: {:?}", signatures);
+
+    let unique_signatures: Vec<u64> = signatures.keys().cloned().collect();
+    assert_eq!(
+        unique_signatures.len(),
+        expected_count,
+        "Should have {} different signatures",
+        expected_count
+    );
+    trace!(
+        "All {} tasks have different signatures: {:?}",
+        expected_count,
+        unique_signatures
+    );
+}
+
+pub fn run_test_n_iterations_with_subscriber<F>(test_fn: F, iterations: usize) -> (SigCounterMap, SigCounterMap)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    let subscriber = SignatureSubscriber::new();
+    let signatures = Arc::clone(&subscriber.signatures);
+    let static_create_locations = Arc::clone(&subscriber.static_create_locations);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let scheduler = RandomScheduler::new(iterations);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(test_fn);
+
+    (signatures, static_create_locations)
+}
+
+#[test]
+fn sync_tasks_created_at_same_src_location_have_different_signatures() {
+    fn worker_function() {}
+
+    let (signatures, static_create_locations) = run_test_n_iterations_with_subscriber(
+        || {
+            let mut handles = Vec::new();
+            for _ in 0..10 {
+                handles.push(thread::spawn(worker_function));
+            }
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        },
+        1,
+    );
+
+    check_any_n_same_signatures(&static_create_locations, 10);
+
+    check_exactly_n_different_signatures(&signatures, 11);
+}
+
+#[test]
+fn async_tasks_created_at_same_src_location_have_different_signatures() {
+    async fn async_worker_function() {}
+
+    let (signatures, static_create_locations) = run_test_n_iterations_with_subscriber(
+        || {
+            let mut handles = Vec::new();
+            for _ in 0..10 {
+                handles.push(future::spawn(async_worker_function()));
+            }
+            future::block_on(async {
+                for handle in handles {
+                    handle.await.unwrap();
+                }
+            });
+        },
+        1,
+    );
+
+    check_any_n_same_signatures(&static_create_locations, 10);
+    check_exactly_n_different_signatures(&signatures, 11);
+}
+
+#[test]
+fn sync_tasks_created_in_different_src_locations_have_different_signatures() {
+    fn worker_function() {}
+
+    let (signatures, _) = run_test_n_iterations_with_subscriber(
+        || {
+            let handle1 = thread::spawn(worker_function);
+            let handle2 = thread::spawn(worker_function);
+            handle1.join().unwrap();
+            handle2.join().unwrap();
+        },
+        1,
+    );
+
+    check_exactly_n_different_signatures(&signatures, 3);
+}
+
+#[test]
+fn async_tasks_created_in_different_src_locations_have_different_signatures() {
+    async fn async_worker_function() {}
+
+    let (signatures, _) = run_test_n_iterations_with_subscriber(
+        || {
+            let handle1 = future::spawn(async_worker_function());
+            let handle2 = future::spawn(async_worker_function());
+            future::block_on(async {
+                handle1.await.unwrap();
+                handle2.await.unwrap();
+            });
+        },
+        1,
+    );
+
+    check_exactly_n_different_signatures(&signatures, 3);
+}
+
+#[test]
+fn task_signatures_consistent_across_shuttle_iterations() {
+    fn worker_with_nested_spawn() {
+        let handle = thread::spawn(|| {});
+        handle.join().unwrap();
+    }
+
+    let (signatures, _) = run_test_n_iterations_with_subscriber(
+        || {
+            let handle1 = thread::spawn(worker_with_nested_spawn);
+            let handle2 = thread::spawn(worker_with_nested_spawn);
+            handle1.join().unwrap();
+            handle2.join().unwrap();
+        },
+        100,
+    );
+
+    check_exactly_n_different_signatures(&signatures, 5);
+}


### PR DESCRIPTION
This PR adds `TaskSignature`s to the `Task` struct in Shuttle to provide identifiers to tasks that don't change on each iteration of a Shuttle test. These identifiers can be used for debugging with multiple different schedules, for scheduling algorithms to denote specific tasks, and also are a prerequisite for stable *resource identifiers* across Shuttle test iterations.

A signature is intended to distinguish tasks with different behaviors, but is not guaranteed to be unique. To increase the flexibility of the signatures, they provide three methods to distinguish tasks at three levels of granularity: (1) static creation point, (2) dynamic single-task creation context, and (3) dynamic concurrency context. Currently these are instantiated with (1) the location given by the `track_caller` macro (2) a per-task counter that increments when multiple tasks are spawned from the same static location in a single parent task and (3) the task signature of the parent thread. Each corresponding method presents a u64, ostensibly a hash, so that the implementations of these components can change in the future. There is also a precomputed signature hash which combines (1) (2) and (3) for quick comparisons at runtime during scheduling.

I put together some basic tests using a Subscriber to check that it is working as expected. It's easy enough to add more if we want to be more comprehensive.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.