### PR TITLE
Add mutex panic test. Export LockResult and friends from shuttle::sync.

### DIFF
--- a/shuttle/src/sync/mod.rs
+++ b/shuttle/src/sync/mod.rs
@@ -21,5 +21,7 @@ pub use rwlock::RwLock;
 pub use rwlock::RwLockReadGuard;
 pub use rwlock::RwLockWriteGuard;
 
+pub use std::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
+
 // TODO implement true support for `Arc`
 pub use std::sync::{Arc, Weak};

--- a/shuttle/src/sync/mutex.rs
+++ b/shuttle/src/sync/mutex.rs
@@ -1,11 +1,11 @@
 use crate::current;
 use crate::future::batch_semaphore::{BatchSemaphore, Fairness};
 use crate::runtime::task::TaskId;
+use crate::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::ops::{Deref, DerefMut};
 use std::panic::{RefUnwindSafe, UnwindSafe};
-use std::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
 use tracing::trace;
 
 /// A mutex, the same as [`std::sync::Mutex`].

--- a/shuttle/tests/basic/mutex.rs
+++ b/shuttle/tests/basic/mutex.rs
@@ -1,8 +1,8 @@
 use shuttle::scheduler::PctScheduler;
-use shuttle::sync::Mutex;
+use shuttle::sync::{Mutex, TryLockError};
 use shuttle::{check_dfs, check_random, thread, Runner};
 use std::collections::HashSet;
-use std::sync::{Arc, TryLockError};
+use std::sync::Arc;
 use test_log::test;
 
 #[test]


### PR DESCRIPTION
#193 made me suggest using `catch_unwind` to allow tasks to panic under Shuttle. I was wondering whether this would have issues with accidentally poisoning locks held by other tasks, as the locks are held by the same thread (since Shuttle is single threaded), so I updated our `mutex_poison` and `rwlock_poison` tests to test for this. Also made Shuttle export `LockResult` and friends because I think we want API parity.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.