### PR TITLE
Add UniformRandomWalk Scheduler to Shuttle

### DIFF
--- a/shuttle/src/future/mod.rs
+++ b/shuttle/src/future/mod.rs
@@ -11,6 +11,7 @@ use crate::runtime::thread;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::future::Future;
+use std::panic::Location;
 use std::pin::Pin;
 use std::result::Result;
 use std::sync::Arc;
@@ -18,14 +19,14 @@ use std::task::{Context, Poll, Waker};
 
 pub mod batch_semaphore;
 
-fn spawn_inner<F>(fut: F) -> JoinHandle<F::Output>
+fn spawn_inner<F>(fut: F, caller: &'static Location<'static>) -> JoinHandle<F::Output>
 where
     F: Future + 'static,
     F::Output: 'static,
 {
     let stack_size = ExecutionState::with(|s| s.config.stack_size);
     let inner = Arc::new(std::sync::Mutex::new(JoinHandleInner::default()));
-    let task_id = ExecutionState::spawn_future(Wrapper::new(fut, inner.clone()), stack_size, None);
+    let task_id = ExecutionState::spawn_future(Wrapper::new(fut, inner.clone()), stack_size, None, caller);
 
     thread::switch();
 
@@ -33,22 +34,26 @@ where
 }
 
 /// Spawn a new async task that the executor will run to completion.
+#[track_caller]
 pub fn spawn<F>(fut: F) -> JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
     F::Output: Send + 'static,
 {
-    spawn_inner(fut)
+    let caller = Location::caller();
+    spawn_inner(fut, caller)
 }
 
 /// Spawn a new async task that the executor will run to completion.
 /// This is just `spawn` without the `Send` bound, and it mirrors `spawn_local` from Tokio.
+#[track_caller]
 pub fn spawn_local<F>(fut: F) -> JoinHandle<F::Output>
 where
     F: Future + 'static,
     F::Output: 'static,
 {
-    spawn_inner(fut)
+    let caller = Location::caller();
+    spawn_inner(fut, caller)
 }
 
 /// An owned permission to abort a spawned task, without awaiting its completion.

--- a/shuttle/src/lib.rs
+++ b/shuttle/src/lib.rs
@@ -321,6 +321,18 @@ where
     runner.run(f);
 }
 
+/// Run the given function under a *uniformly* random scheduler for some number of iterations.
+/// Each iteration will run a (potentially) different randomized schedule.
+pub fn check_urw<F>(f: F, iterations: usize)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    use crate::scheduler::UniformRandomScheduler;
+
+    let runner = Runner::new(UniformRandomScheduler::new(iterations), Default::default());
+    runner.run(f);
+}
+
 /// Run the given function under a randomized concurrency scheduler for some number of iterations.
 /// Each iteration will run a (potentially) different randomized schedule.
 pub fn check_random<F>(f: F, iterations: usize)

--- a/shuttle/src/runtime/execution.rs
+++ b/shuttle/src/runtime/execution.rs
@@ -2,7 +2,7 @@ use crate::runtime::failure::{init_panic_hook, persist_failure, persist_task_fai
 use crate::runtime::storage::{StorageKey, StorageMap};
 use crate::runtime::task::clock::VectorClock;
 use crate::runtime::task::labels::Labels;
-use crate::runtime::task::{ChildLabelFn, Task, TaskId, TaskName, DEFAULT_INLINE_TASKS};
+use crate::runtime::task::{ChildLabelFn, Task, TaskId, TaskName, TaskSignature, DEFAULT_INLINE_TASKS};
 use crate::runtime::thread::continuation::PooledContinuation;
 use crate::scheduler::{Schedule, Scheduler};
 use crate::thread::thread_fn;
@@ -14,7 +14,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
-use std::panic;
+use std::hash::DefaultHasher;
+use std::panic::{self, Location};
 use std::rc::Rc;
 use std::sync::Arc;
 use tracing::{trace, Span};
@@ -65,6 +66,7 @@ impl Execution {
     /// Run a function to be tested, taking control of scheduling it and any tasks it might spawn.
     /// This function runs until `f` and all tasks spawned by `f` have terminated, or until the
     /// scheduler returns `None`, indicating the execution should not be explored any further.
+    #[track_caller]
     pub(crate) fn run<F>(mut self, config: &Config, f: F)
     where
         F: FnOnce() + Send + 'static,
@@ -77,6 +79,7 @@ impl Execution {
 
         let _guard = init_panic_hook(config.clone());
 
+        let caller = Location::caller();
         EXECUTION_STATE.set(&state, move || {
             // Spawn `f` as the first task
             ExecutionState::spawn_thread(
@@ -84,6 +87,7 @@ impl Execution {
                 config.stack_size,
                 Some("main-thread".to_string()),
                 Some(VectorClock::new()),
+                caller,
             );
 
             // Run the test to completion
@@ -375,7 +379,12 @@ impl ExecutionState {
 
     /// Spawn a new task for a future. This doesn't create a yield point; the caller should do that
     /// if it wants to give the new task a chance to run immediately.
-    pub(crate) fn spawn_future<F>(future: F, stack_size: usize, name: Option<String>) -> TaskId
+    pub(crate) fn spawn_future<F>(
+        future: F,
+        stack_size: usize,
+        name: Option<String>,
+        caller: &'static Location<'static>,
+    ) -> TaskId
     where
         F: Future<Output = ()> + 'static,
     {
@@ -401,6 +410,7 @@ impl ExecutionState {
                 schedule_len,
                 tag,
                 state.try_current().map(|t| t.id()),
+                create_signature(state, caller),
             );
 
             state.tasks.push(task);
@@ -416,6 +426,7 @@ impl ExecutionState {
         stack_size: usize,
         name: Option<String>,
         mut initial_clock: Option<VectorClock>,
+        caller: &'static Location<'static>,
     ) -> TaskId {
         let task_id = Self::with(|state| {
             let parent_span_id = state.top_level_span.id();
@@ -445,6 +456,7 @@ impl ExecutionState {
                 schedule_len,
                 tag,
                 state.try_current().map(|t| t.id()),
+                create_signature(state, caller),
             );
             state.tasks.push(task);
 
@@ -577,6 +589,10 @@ impl ExecutionState {
         self.try_get(self.current_task.id()?)
     }
 
+    pub(crate) fn try_current_mut(&mut self) -> Option<&mut Task> {
+        self.try_get_mut(self.current_task.id()?)
+    }
+
     pub(crate) fn get(&self, id: TaskId) -> &Task {
         self.try_get(id).unwrap()
     }
@@ -587,6 +603,10 @@ impl ExecutionState {
 
     pub(crate) fn try_get(&self, id: TaskId) -> Option<&Task> {
         self.tasks.get(id.0)
+    }
+
+    pub(crate) fn try_get_mut(&mut self, id: TaskId) -> Option<&mut Task> {
+        self.tasks.get_mut(id.0)
     }
 
     pub(crate) fn in_cleanup(&self) -> bool {
@@ -787,5 +807,15 @@ impl ExecutionState {
 impl Drop for ExecutionState {
     fn drop(&mut self) {
         assert!(self.has_cleaned_up || std::thread::panicking());
+    }
+}
+
+fn create_signature(state: &mut ExecutionState, spawn_call_site: &'static Location<'static>) -> TaskSignature {
+    let mut hasher = DefaultHasher::new();
+    if let Some(t) = state.try_current_mut() {
+        t.signature.new_child(spawn_call_site, &mut hasher)
+    } else {
+        // If we can't find the current task, then the new child is parentless
+        TaskSignature::new_parentless(spawn_call_site, &mut hasher)
     }
 }

--- a/shuttle/src/runtime/task/mod.rs
+++ b/shuttle/src/runtime/task/mod.rs
@@ -9,8 +9,11 @@ use crate::thread::LocalKey;
 use bitvec::prelude::*;
 use std::any::Any;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::panic::Location;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Waker};
@@ -146,6 +149,78 @@ where
     }
 }
 
+/// A task signature is an identifier that is intended to be *mostly* stable across executions
+/// and allow for categorization of tasks according to how they were created. It provides three
+/// levels of granularity: static (compile-time) spawn location, dynamic (run-time) context where
+/// that spawn location was reached. The static spawn location and signature are each represented
+/// by a u64 so that the details of how they are computed can be non-breaking changes in the future.
+/// Hashes are all pre-computed for fast checking of equality of signatures at runtime.
+#[derive(Debug, Clone)]
+pub(crate) struct TaskSignature {
+    /// The task creation stack is a tuple of (create location, number of tasks created at that location in the parent)
+    task_creation_stack: Vec<(&'static Location<'static>, u32)>,
+    spawn_call_site_hash: u64,
+    signature_hash: u64,
+    child_counters: HashMap<&'static Location<'static>, u32>,
+}
+
+impl TaskSignature {
+    pub(crate) fn new_parentless(spawn_call_site: &'static Location<'static>, hasher: &mut impl Hasher) -> TaskSignature {
+        let task_creation_stack = vec![(spawn_call_site, 0)];
+        task_creation_stack.hash(hasher);
+        Self {
+            task_creation_stack,
+            spawn_call_site_hash: 0,
+            signature_hash: hasher.finish(),
+            child_counters: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn new_child(&mut self, spawn_call_site: &'static Location<'static>, hasher: &mut impl Hasher) -> Self {
+        let counter = self.child_counters.entry(spawn_call_site).or_insert(0);
+        *counter += 1;
+        let mut task_creation_stack = self.task_creation_stack.clone();
+        task_creation_stack.push((spawn_call_site, *counter));
+
+        spawn_call_site.hash(hasher);
+        let spawn_call_site_hash = hasher.finish();
+
+        task_creation_stack.hash(hasher);
+
+        Self {
+            task_creation_stack,
+            spawn_call_site_hash,
+            signature_hash: hasher.finish(),
+            child_counters: HashMap::new(),
+        }
+    }
+
+    /// Hash of the static location within the source code where the task was spawned
+    pub(crate) fn static_create_location_hash(self: &TaskSignature) -> u64 {
+        self.spawn_call_site_hash
+    }
+
+    /// Combined signature of the static location and dynamic context
+    /// context where the task was spawned.
+    pub(crate) fn signature_hash(self: &TaskSignature) -> u64 {
+        self.signature_hash
+    }
+}
+
+impl Hash for TaskSignature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.task_creation_stack.hash(state);
+    }
+}
+
+impl PartialEq for TaskSignature {
+    fn eq(&self, other: &Self) -> bool {
+        self.signature_hash == other.signature_hash
+    }
+}
+
+impl Eq for TaskSignature {}
+
 /// A `Task` represents a user-level unit of concurrency. Each task has an `id` that is unique within
 /// the execution, and a `state` reflecting whether the task is runnable (enabled) or not.
 #[derive(Debug)]
@@ -188,6 +263,11 @@ pub struct Task {
     // Arbitrarily settable tag which is inherited from the parent.
     #[allow(deprecated)]
     tag: Option<Arc<dyn Tag>>,
+
+    /// The signature of a Task; this is an identifier that is *not* guaranteed to be unique but should be *mostly*
+    /// stable across iterations in a single Shuttle test. Tasks with the same signature are very likely to exhibit
+    /// similar behavior
+    pub(crate) signature: TaskSignature,
 }
 
 #[allow(deprecated)]
@@ -204,6 +284,7 @@ impl Task {
         schedule_len: usize,
         tag: Option<Arc<dyn Tag>>,
         parent_task_id: Option<TaskId>,
+        signature: TaskSignature,
     ) -> Self {
         #[cfg(all(any(test, feature = "vector-clocks"), not(feature = "bench-no-vector-clocks")))]
         assert!(id.0 < clock.time.len());
@@ -233,14 +314,17 @@ impl Task {
             span_stack,
             local_storage: StorageMap::new(),
             tag: None,
+            signature,
         };
 
         if let Some(tag) = tag {
             task.set_tag(tag);
         }
 
-        error_span!(parent: parent_span_id, "new_task", parent = ?parent_task_id, i = schedule_len)
-            .in_scope(|| event!(Level::INFO, "created task: {:?}", task.id));
+        // Note: the tests for the task signature in [`crate::tests::basic::task`] depend on tracing the task signature and creation point here
+        error_span!(parent: parent_span_id, "new_task", parent = ?parent_task_id, i = schedule_len).in_scope(
+            || event!(Level::INFO, task_id = ?task.id, signature = task.signature.signature_hash(), static_create_location = task.signature.static_create_location_hash(), "created task"),
+        );
 
         task
     }
@@ -256,6 +340,7 @@ impl Task {
         schedule_len: usize,
         tag: Option<Arc<dyn Tag>>,
         parent_task_id: Option<TaskId>,
+        signature: TaskSignature,
     ) -> Self {
         Self::new(
             f,
@@ -267,6 +352,7 @@ impl Task {
             schedule_len,
             tag,
             parent_task_id,
+            signature,
         )
     }
 
@@ -281,6 +367,7 @@ impl Task {
         schedule_len: usize,
         tag: Option<Arc<dyn Tag>>,
         parent_task_id: Option<TaskId>,
+        signature: TaskSignature,
     ) -> Self
     where
         F: Future<Output = ()> + 'static,
@@ -304,6 +391,7 @@ impl Task {
             schedule_len,
             tag,
             parent_task_id,
+            signature,
         )
     }
 

--- a/shuttle/src/runtime/task/mod.rs
+++ b/shuttle/src/runtime/task/mod.rs
@@ -160,17 +160,22 @@ pub(crate) struct TaskSignature {
     /// The task creation stack is a tuple of (create location, number of tasks created at that location in the parent)
     task_creation_stack: Vec<(&'static Location<'static>, u32)>,
     spawn_call_site_hash: u64,
+    parent_signature_hash: u64,
     signature_hash: u64,
     child_counters: HashMap<&'static Location<'static>, u32>,
 }
 
 impl TaskSignature {
-    pub(crate) fn new_parentless(spawn_call_site: &'static Location<'static>, hasher: &mut impl Hasher) -> TaskSignature {
+    pub(crate) fn new_parentless(
+        spawn_call_site: &'static Location<'static>,
+        hasher: &mut impl Hasher,
+    ) -> TaskSignature {
         let task_creation_stack = vec![(spawn_call_site, 0)];
         task_creation_stack.hash(hasher);
         Self {
             task_creation_stack,
             spawn_call_site_hash: 0,
+            parent_signature_hash: 0,
             signature_hash: hasher.finish(),
             child_counters: HashMap::new(),
         }
@@ -189,6 +194,7 @@ impl TaskSignature {
 
         Self {
             task_creation_stack,
+            parent_signature_hash: self.signature_hash,
             spawn_call_site_hash,
             signature_hash: hasher.finish(),
             child_counters: HashMap::new(),
@@ -204,6 +210,11 @@ impl TaskSignature {
     /// context where the task was spawned.
     pub(crate) fn signature_hash(self: &TaskSignature) -> u64 {
         self.signature_hash
+    }
+
+    /// Signature hash of the parent of this task
+    pub(crate) fn parent_signature_hash(self: &TaskSignature) -> u64 {
+        self.parent_signature_hash
     }
 }
 
@@ -226,6 +237,7 @@ impl Eq for TaskSignature {}
 #[derive(Debug)]
 pub struct Task {
     pub(super) id: TaskId,
+    pub(super) parent_task_id: Option<TaskId>,
     pub(super) state: TaskState,
     pub(super) detached: bool,
     park_state: ParkState,
@@ -301,6 +313,7 @@ impl Task {
 
         let mut task = Self {
             id,
+            parent_task_id,
             state: TaskState::Runnable,
             continuation,
             clock,
@@ -398,6 +411,11 @@ impl Task {
     /// Returns the identifier of this task.
     pub fn id(&self) -> TaskId {
         self.id
+    }
+
+    /// Returns the identifier of the task that spawned this task.
+    pub fn parent_task_id(&self) -> Option<TaskId> {
+        self.parent_task_id
     }
 
     pub(crate) fn runnable(&self) -> bool {

--- a/shuttle/src/scheduler/mod.rs
+++ b/shuttle/src/scheduler/mod.rs
@@ -9,6 +9,7 @@ mod random;
 mod replay;
 mod round_robin;
 mod uncontrolled_nondeterminism;
+mod urw;
 
 pub(crate) mod metrics;
 pub(crate) mod serialization;
@@ -23,6 +24,7 @@ pub use random::RandomScheduler;
 pub use replay::ReplayScheduler;
 pub use round_robin::RoundRobinScheduler;
 pub use uncontrolled_nondeterminism::UncontrolledNondeterminismCheckScheduler;
+pub use urw::UniformRandomScheduler;
 
 /// A `Schedule` determines the order in which tasks are to be executed
 // TODO would be nice to make this generic in the type of `seed`, but for now all our seeds are u64s

--- a/shuttle/src/scheduler/urw.rs
+++ b/shuttle/src/scheduler/urw.rs
@@ -1,0 +1,231 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::runtime::task::{Task, TaskId};
+use crate::scheduler::data::random::RandomDataSource;
+use crate::scheduler::data::DataSource;
+use crate::scheduler::{Schedule, Scheduler};
+use rand::rngs::OsRng;
+use rand::seq::SliceRandom;
+use rand::{RngCore, SeedableRng};
+use rand_pcg::Pcg64Mcg;
+use tracing::{info, trace, warn};
+
+/// A scheduler which implements Uniform Random Walk (URW) from "Selectively Uniform Concurrency Testing" by
+/// Huan Zhao, Dylan Wolff, Umang Mathur, and Abhik Roychoudhury - ASPLOS '25. The URW algorithm samples
+/// all interleavings *uniformly* given an accurate estimate of the number of events which will take place
+/// on each task. This implementation uses a single trial run of the program to generate these estimates.
+/// During the trial run, it uses vanilla random walk (the same algorithm as [`crate::scheduler::RandomScheduler`]).
+///
+/// The RNG used is contained within the scheduler, allowing it to be reused across executions in
+/// order to get different random schedules each time. The scheduler has an optional bias towards
+/// remaining on the current task.
+#[derive(Debug)]
+pub struct UniformRandomScheduler {
+    max_iterations: usize,
+    rng: Pcg64Mcg,
+    iterations: usize,
+    data_source: RandomDataSource,
+    current_seed: CurrentSeedDropGuard,
+    /// Number of events remaining on each task in the current execution
+    task_event_counts: Option<Vec<usize>>,
+    /// Event count estimates for each task by signature
+    signature_event_counts: HashMap<u64, usize>,
+    /// Indicates a parent-child relation between the task with signature .0 and .1
+    signature_parents: Vec<(u64, u64)>,
+}
+
+#[derive(Debug, Default)]
+struct CurrentSeedDropGuard {
+    inner: Option<u64>,
+}
+
+impl CurrentSeedDropGuard {
+    fn clear(&mut self) {
+        self.inner = None
+    }
+
+    fn update(&mut self, seed: u64) {
+        self.inner = Some(seed)
+    }
+}
+
+impl Drop for CurrentSeedDropGuard {
+    fn drop(&mut self) {
+        if let Some(s) = self.inner {
+            eprintln!(
+                "failing seed:\n\"\n{s}\n\"\nTo replay the failure, set the environment variable SHUTTLE_RANDOM_SEED to the seed and run `shuttle::check_urw`."
+            )
+        }
+    }
+}
+
+impl UniformRandomScheduler {
+    /// Construct a new UniformRandomScheduler with a freshly seeded RNG.
+    pub fn new(max_iterations: usize) -> Self {
+        Self::new_from_seed(OsRng.next_u64(), max_iterations)
+    }
+
+    /// Construct a UniformRandomScheduler with a given seed.
+    /// Two UniformRandomSchedulers initialized with the same seed will make the same scheduling decisions when executing the same workloads.
+    /// If the `SHUTTLE_RANDOM_SEED` environment variable is set, then that seed will be used instead.
+    pub fn new_from_seed(seed: u64, max_iterations: usize) -> Self {
+        let seed_env = std::env::var("SHUTTLE_RANDOM_SEED");
+        let seed = match seed_env {
+            Ok(s) => match s.as_str().parse::<u64>() {
+                Ok(seed) => {
+                    tracing::info!(
+                        "Initializing UniformRandomScheduler with the seed provided by SHUTTLE_RANDOM_SEED: {}",
+                        seed
+                    );
+                    seed
+                }
+                Err(err) => panic!("The seed provided by SHUTTLE_RANDOM_SEED is not a valid u64: {err}"),
+            },
+            Err(_) => seed,
+        };
+
+        let rng = Pcg64Mcg::seed_from_u64(seed);
+
+        Self {
+            max_iterations,
+            rng,
+            iterations: 0,
+            data_source: RandomDataSource::initialize(seed),
+            current_seed: CurrentSeedDropGuard::default(),
+            task_event_counts: None,
+            signature_event_counts: HashMap::new(),
+            signature_parents: Vec::new(),
+        }
+    }
+
+    #[inline]
+    fn events_counted_but_not_initialized(&self) -> bool {
+        self.task_event_counts.is_none() && !self.signature_event_counts.is_empty()
+    }
+}
+
+impl Scheduler for UniformRandomScheduler {
+    fn new_execution(&mut self) -> Option<Schedule> {
+        if self.iterations >= self.max_iterations {
+            self.current_seed.clear();
+            self.signature_event_counts.clear();
+            self.signature_parents.clear();
+            self.task_event_counts = None;
+            None
+        } else {
+            if self.events_counted_but_not_initialized() {
+                // If we have never initialized the event counts before, we need to aggregate the count estimates
+                // from each child task to its parents
+                info!("Finished estimation of event counts for URW");
+                info!(
+                    "Estimated event counts for URW (pre-parent subsumption): {:?}",
+                    self.signature_event_counts
+                );
+                // Iterating in reverse spawn order to ensure counts are propagated to grandparents correctly
+                for (parent_sig, child_sig) in self.signature_parents.iter().rev() {
+                    let child_ct = *self.signature_event_counts.get(child_sig).unwrap();
+                    self.signature_event_counts
+                        .entry(*parent_sig)
+                        .and_modify(|parent_ct| *parent_ct += child_ct);
+                }
+                info!(
+                    "Estimated event counts for URW (post-parent subsumption): {:?}",
+                    self.signature_event_counts
+                );
+
+                // The implemenation of URW currently assumes that each task has a unique signature in a single execution.
+                // Thus the number of spawns events should equal the number of unique child signatures
+                debug_assert!(
+                    self.signature_event_counts
+                        .keys()
+                        .cloned()
+                        .collect::<HashSet<_>>()
+                        .len()
+                        == self.signature_event_counts.len()
+                );
+
+                self.task_event_counts = Some(Vec::new());
+            } else if let Some(ec) = self.task_event_counts.as_mut() {
+                // Clear any remaining event counts for the next iteration. Counts are re-initialized
+                // on `spawn` in the next iteration
+                ec.clear();
+            }
+            self.iterations += 1;
+            let seed = self.data_source.reinitialize();
+            self.rng = Pcg64Mcg::seed_from_u64(seed);
+            self.current_seed.update(seed);
+            Some(Schedule::new(seed))
+        }
+    }
+
+    fn next_task(&mut self, runnable: &[&Task], _current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
+        if let Some(task_event_counts) = self.task_event_counts.as_mut() {
+            // If the event counts have been estimated...
+
+            // We need to loop over the tasks to identify if there has been a `spawn` event
+            // In the future, if we embed a `next_event` enum field into the Task struct, this code can be
+            // simplified to a single conditional
+            for t in runnable {
+                let tid: usize = get_tid(t);
+                if tid == task_event_counts.len() {
+                    // Spawn: should remove child events from the parent and map remaining events to the correct task id
+                    let child_events = *self
+                        .signature_event_counts
+                        .get(&t.signature.signature_hash())
+                        .unwrap_or_else(|| {
+                            // TODO: we can probably handle unseen tasks less naively than estimating a single event
+                            warn!(
+                                "No event count for spawn of task with signature {}",
+                                t.signature.signature_hash()
+                            );
+                            &1
+                        });
+                    task_event_counts.push(child_events);
+                    if let Some(ptid) = t.parent_task_id() {
+                        let ptid: usize = ptid.into();
+                        task_event_counts[ptid] = task_event_counts[ptid].saturating_sub(child_events).max(1);
+                    }
+                } else if tid > task_event_counts.len() {
+                    panic!("TID's expected to be spawned in ascending order in increments of 1");
+                }
+                // Any runnable task must have at least one remaining event
+                assert!(task_event_counts[tid] >= 1);
+            }
+
+            let next_tid = runnable
+                .choose_weighted(&mut self.rng, |t| task_event_counts[get_tid(t)])
+                .unwrap()
+                .id();
+            let next_tid_usize: usize = next_tid.into();
+            task_event_counts[next_tid_usize] = task_event_counts[next_tid_usize].saturating_sub(1).max(1);
+
+            trace!("URW remaining event counts: {:?}", task_event_counts);
+            Some(next_tid)
+        } else {
+            // Delegate scheduling to vanilla RW when estimating counts
+            let t = runnable.choose(&mut self.rng).unwrap();
+
+            // If we don't have event counts yet, use the current run to estimate event counts (1-shot)
+            self.signature_event_counts
+                .entry(t.signature.signature_hash())
+                .and_modify(|c| *c += 1)
+                .or_insert_with(|| {
+                    // Spawn
+                    self.signature_parents
+                        .push((t.signature.parent_signature_hash(), t.signature.signature_hash()));
+                    1
+                });
+
+            Some(t.id())
+        }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.data_source.next_u64()
+    }
+}
+
+#[inline]
+fn get_tid(task: &Task) -> usize {
+    task.id().into()
+}

--- a/shuttle/src/thread.rs
+++ b/shuttle/src/thread.rs
@@ -4,6 +4,7 @@ use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::TaskId;
 use crate::runtime::thread;
 use std::marker::PhantomData;
+use std::panic::Location;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
@@ -76,6 +77,7 @@ impl<'scope> Scope<'scope, '_> {
     /// Unlike non-scoped threads, threads spawned with this function may
     /// borrow non-`'static` data from the outside the scope. See [`scope`] for
     /// details.
+    #[track_caller]
     pub fn spawn<F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
     where
         F: FnOnce() -> T + Send + 'scope,
@@ -99,9 +101,10 @@ impl<'scope> Scope<'scope, '_> {
             }
         };
 
+        let caller = Location::caller();
         // SAFETY: main task is blocked until all scoped closures complete so all captured references remain valid
         ScopedJoinHandle {
-            handle: unsafe { spawn_named_unchecked(scope_closure, None, None) },
+            handle: unsafe { spawn_named_unchecked(scope_closure, None, None, caller) },
             finished,
             _marker: PhantomData,
         }
@@ -138,16 +141,23 @@ where
 ///
 /// The join handle can be used (via the `join` method) to block until the child thread has
 /// finished.
+#[track_caller]
 pub fn spawn<F, T>(f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T,
     F: Send + 'static,
     T: Send + 'static,
 {
-    spawn_named(f, None, None)
+    let caller = Location::caller();
+    spawn_named(f, None, None, caller)
 }
 
-fn spawn_named<F, T>(f: F, name: Option<String>, stack_size: Option<usize>) -> JoinHandle<T>
+fn spawn_named<F, T>(
+    f: F,
+    name: Option<String>,
+    stack_size: Option<usize>,
+    caller: &'static Location<'static>,
+) -> JoinHandle<T>
 where
     F: FnOnce() -> T,
     F: Send + 'static,
@@ -155,11 +165,16 @@ where
 {
     // SAFETY: F is static so all captured references must be `static and therefore
     // will outlive the spawned continuation
-    unsafe { spawn_named_unchecked(f, name, stack_size) }
+    unsafe { spawn_named_unchecked(f, name, stack_size, caller) }
 }
 
 /// Must ensure all captured references in f are valid for at least as long as the spawned continuation will run
-unsafe fn spawn_named_unchecked<F, T>(f: F, name: Option<String>, stack_size: Option<usize>) -> JoinHandle<T>
+unsafe fn spawn_named_unchecked<F, T>(
+    f: F,
+    name: Option<String>,
+    stack_size: Option<usize>,
+    caller: &'static Location<'static>,
+) -> JoinHandle<T>
 where
     F: FnOnce() -> T,
     T: Send,
@@ -175,7 +190,7 @@ where
         let f: Box<dyn FnOnce()> = Box::new(move || thread_fn(f, result));
         let f: Box<dyn FnOnce() + 'static> = unsafe { std::mem::transmute(f) };
 
-        ExecutionState::spawn_thread(f, stack_size, name.clone(), None)
+        ExecutionState::spawn_thread(f, stack_size, name.clone(), None, caller)
     };
 
     thread::switch();
@@ -381,13 +396,15 @@ impl Builder {
     }
 
     /// Spawns a new thread by taking ownership of the Builder, and returns an `io::Result` to its `JoinHandle`.
+    #[track_caller]
     pub fn spawn<F, T>(self, f: F) -> std::io::Result<JoinHandle<T>>
     where
         F: FnOnce() -> T,
         F: Send + 'static,
         T: Send + 'static,
     {
-        Ok(spawn_named(f, self.name, self.stack_size))
+        let caller = Location::caller();
+        Ok(spawn_named(f, self.name, self.stack_size, caller))
     }
 }
 

--- a/shuttle/tests/basic/mod.rs
+++ b/shuttle/tests/basic/mod.rs
@@ -18,6 +18,7 @@ mod replay;
 mod rwlock;
 mod shrink;
 mod tag;
+mod task;
 mod thread;
 mod timeout;
 mod tracing;

--- a/shuttle/tests/basic/task.rs
+++ b/shuttle/tests/basic/task.rs
@@ -1,0 +1,250 @@
+use shuttle::{future, scheduler::RandomScheduler, thread, Runner};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use test_log::test;
+use tracing::field::{Field, Visit};
+use tracing::{trace, Event, Id, Metadata, Subscriber};
+
+type SigCounterMap = Arc<Mutex<HashMap<u64, usize>>>;
+#[derive(Clone)]
+struct SignatureSubscriber {
+    signatures: SigCounterMap,
+    static_create_locations: SigCounterMap,
+}
+
+impl SignatureSubscriber {
+    pub fn new() -> Self {
+        Self {
+            signatures: Arc::new(Mutex::new(HashMap::new())),
+            static_create_locations: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Subscriber for SignatureSubscriber {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let metadata = event.metadata();
+        if metadata.target() == "shuttle::runtime::task" && metadata.level() == &tracing::Level::INFO {
+            struct SignatureVisitor {
+                task_id: Option<String>,
+                signature: Option<u64>,
+                static_create_location: Option<u64>,
+            }
+            impl Visit for SignatureVisitor {
+                fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                    if field.name() == "task_id" {
+                        self.task_id = Some(format!("{:?}", value));
+                    }
+                }
+                fn record_u64(&mut self, field: &Field, value: u64) {
+                    if field.name() == "signature" {
+                        self.signature = Some(value);
+                    }
+                    if field.name() == "static_create_location" {
+                        self.static_create_location = Some(value);
+                    }
+                }
+            }
+            let mut visitor = SignatureVisitor {
+                task_id: None,
+                signature: None,
+                static_create_location: None,
+            };
+            event.record(&mut visitor);
+
+            if let Some(sig) = visitor.signature {
+                self.signatures
+                    .lock()
+                    .unwrap()
+                    .entry(sig)
+                    .and_modify(|counter| *counter += 1)
+                    .or_insert(1);
+            }
+            if let Some(loc) = visitor.static_create_location {
+                self.static_create_locations
+                    .lock()
+                    .unwrap()
+                    .entry(loc)
+                    .and_modify(|counter| *counter += 1)
+                    .or_insert(1);
+            }
+        }
+    }
+
+    fn enter(&self, _span: &Id) {}
+    fn exit(&self, _span: &Id) {}
+}
+
+pub fn check_any_n_same_signatures(signatures: &SigCounterMap, expected_count: usize) {
+    let signatures = signatures.lock().unwrap();
+    trace!("Total signatures captured: {}", signatures.len());
+
+    trace!("Signature counts: {:?}", signatures);
+
+    let worker_signatures: Vec<u64> = signatures
+        .iter()
+        .filter(|(_, count)| **count == expected_count)
+        .map(|(sig, _)| *sig)
+        .collect();
+
+    assert_eq!(
+        worker_signatures.len(),
+        1,
+        "Should have exactly one signature appearing {} times",
+        expected_count
+    );
+    trace!(
+        "{} tasks have the same signature: {}",
+        expected_count,
+        worker_signatures[0]
+    );
+}
+
+pub fn check_exactly_n_different_signatures(signatures: &SigCounterMap, expected_count: usize) {
+    let signatures = signatures.lock().unwrap();
+    trace!("Total signatures captured: {}", signatures.len());
+
+    trace!("Signature counts: {:?}", signatures);
+
+    let unique_signatures: Vec<u64> = signatures.keys().cloned().collect();
+    assert_eq!(
+        unique_signatures.len(),
+        expected_count,
+        "Should have {} different signatures",
+        expected_count
+    );
+    trace!(
+        "All {} tasks have different signatures: {:?}",
+        expected_count,
+        unique_signatures
+    );
+}
+
+pub fn run_test_n_iterations_with_subscriber<F>(test_fn: F, iterations: usize) -> (SigCounterMap, SigCounterMap)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    let subscriber = SignatureSubscriber::new();
+    let signatures = Arc::clone(&subscriber.signatures);
+    let static_create_locations = Arc::clone(&subscriber.static_create_locations);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let scheduler = RandomScheduler::new(iterations);
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(test_fn);
+
+    (signatures, static_create_locations)
+}
+
+#[test]
+fn sync_tasks_created_at_same_src_location_have_different_signatures() {
+    fn worker_function() {}
+
+    let (signatures, static_create_locations) = run_test_n_iterations_with_subscriber(
+        || {
+            let mut handles = Vec::new();
+            for _ in 0..10 {
+                handles.push(thread::spawn(worker_function));
+            }
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        },
+        1,
+    );
+
+    check_any_n_same_signatures(&static_create_locations, 10);
+
+    check_exactly_n_different_signatures(&signatures, 11);
+}
+
+#[test]
+fn async_tasks_created_at_same_src_location_have_different_signatures() {
+    async fn async_worker_function() {}
+
+    let (signatures, static_create_locations) = run_test_n_iterations_with_subscriber(
+        || {
+            let mut handles = Vec::new();
+            for _ in 0..10 {
+                handles.push(future::spawn(async_worker_function()));
+            }
+            future::block_on(async {
+                for handle in handles {
+                    handle.await.unwrap();
+                }
+            });
+        },
+        1,
+    );
+
+    check_any_n_same_signatures(&static_create_locations, 10);
+    check_exactly_n_different_signatures(&signatures, 11);
+}
+
+#[test]
+fn sync_tasks_created_in_different_src_locations_have_different_signatures() {
+    fn worker_function() {}
+
+    let (signatures, _) = run_test_n_iterations_with_subscriber(
+        || {
+            let handle1 = thread::spawn(worker_function);
+            let handle2 = thread::spawn(worker_function);
+            handle1.join().unwrap();
+            handle2.join().unwrap();
+        },
+        1,
+    );
+
+    check_exactly_n_different_signatures(&signatures, 3);
+}
+
+#[test]
+fn async_tasks_created_in_different_src_locations_have_different_signatures() {
+    async fn async_worker_function() {}
+
+    let (signatures, _) = run_test_n_iterations_with_subscriber(
+        || {
+            let handle1 = future::spawn(async_worker_function());
+            let handle2 = future::spawn(async_worker_function());
+            future::block_on(async {
+                handle1.await.unwrap();
+                handle2.await.unwrap();
+            });
+        },
+        1,
+    );
+
+    check_exactly_n_different_signatures(&signatures, 3);
+}
+
+#[test]
+fn task_signatures_consistent_across_shuttle_iterations() {
+    fn worker_with_nested_spawn() {
+        let handle = thread::spawn(|| {});
+        handle.join().unwrap();
+    }
+
+    let (signatures, _) = run_test_n_iterations_with_subscriber(
+        || {
+            let handle1 = thread::spawn(worker_with_nested_spawn);
+            let handle2 = thread::spawn(worker_with_nested_spawn);
+            handle1.join().unwrap();
+            handle2.join().unwrap();
+        },
+        100,
+    );
+
+    check_exactly_n_different_signatures(&signatures, 5);
+}

--- a/shuttle/tests/demo/mod.rs
+++ b/shuttle/tests/demo/mod.rs
@@ -1,2 +1,3 @@
 mod async_match_deadlock;
 mod bounded_buffer;
+mod surw;

--- a/shuttle/tests/demo/surw.rs
+++ b/shuttle/tests/demo/surw.rs
@@ -1,0 +1,168 @@
+use shuttle::{
+    future,
+    scheduler::{RandomScheduler, UniformRandomScheduler},
+    sync::atomic::{AtomicUsize, Ordering},
+    thread, Runner,
+};
+use std::sync::Arc;
+use test_log::test;
+
+/// These examples are inspired by the motivating examples of "Selectively Uniform Concurrency Testing" by
+/// Huan Zhao, Dylan Wolff, Umang Mathur, and Abhik Roychoudhury - ASPLOS '25. Generally they create very
+/// uneven thread counts, which cause a naive random walk to strongly bias away from schedules in which the
+/// an event on one short thread is delayed until after many events on other threads.
+
+const NUM_EVENTS: usize = 25;
+const NUM_SHUTTLE_ITERATIONS_URW: usize = 1000;
+
+fn test_uneven_execution<F, S>(executor: F, scheduler: S, expect_found: bool)
+where
+    F: Fn(Arc<AtomicUsize>, Arc<AtomicUsize>) + Send + Sync + 'static,
+    S: shuttle::scheduler::Scheduler + 'static,
+{
+    let has_found_schedule = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let has_found_schedule_inner = Arc::clone(&has_found_schedule);
+
+    let runner = Runner::new(scheduler, Default::default());
+    runner.run(move || {
+        if has_found_schedule_inner.load(std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+
+        let counter = Arc::new(AtomicUsize::new(1usize));
+        let counter1 = Arc::clone(&counter);
+        let counter2 = Arc::clone(&counter);
+
+        executor(counter1, counter2);
+
+        has_found_schedule_inner.store(counter.load(Ordering::SeqCst) == 0, std::sync::atomic::Ordering::SeqCst);
+    });
+
+    assert_eq!(
+        expect_found,
+        has_found_schedule.load(std::sync::atomic::Ordering::SeqCst)
+    );
+}
+
+#[test]
+fn non_uniform_random_degrades_for_uneven_task_lengths() {
+    test_uneven_execution(
+        |counter1, counter2| {
+            let future1 = async move {
+                counter1.store(0, Ordering::SeqCst);
+            };
+            let future2 = async move {
+                for _ in 0..NUM_EVENTS {
+                    counter2.store(1, Ordering::SeqCst);
+                }
+            };
+
+            let t1 = future::spawn(future1);
+            let t2 = future::spawn(future2);
+
+            future::block_on(async {
+                t1.await.ok();
+                t2.await.ok();
+            });
+        },
+        RandomScheduler::new(NUM_SHUTTLE_ITERATIONS_URW * 10),
+        false, // Random scheduler cannot find this bug even with an order of magnitude more executions
+    );
+}
+
+#[test]
+fn uneven_task_lengths_async() {
+    test_uneven_execution(
+        |counter1, counter2| {
+            let future1 = async move {
+                counter1.store(0, Ordering::SeqCst);
+            };
+            let future2 = async move {
+                for _ in 0..NUM_EVENTS {
+                    counter2.store(1, Ordering::SeqCst);
+                }
+            };
+
+            let t1 = future::spawn(future1);
+            let t2 = future::spawn(future2);
+
+            future::block_on(async {
+                t1.await.ok();
+                t2.await.ok();
+            });
+        },
+        UniformRandomScheduler::new(NUM_SHUTTLE_ITERATIONS_URW),
+        true,
+    );
+}
+
+#[test]
+fn uneven_thread_lengths() {
+    test_uneven_execution(
+        |counter1, counter2| {
+            let t1 = thread::spawn(move || {
+                counter1.store(0, Ordering::SeqCst);
+            });
+            let t2 = thread::spawn(move || {
+                for _ in 0..NUM_EVENTS {
+                    counter2.store(1, Ordering::SeqCst);
+                }
+            });
+
+            t1.join().ok();
+            t2.join().ok();
+        },
+        UniformRandomScheduler::new(NUM_SHUTTLE_ITERATIONS_URW),
+        true,
+    );
+}
+
+#[test]
+fn uneven_task_creation_uniformity() {
+    test_uneven_execution(
+        |counter1, counter2| {
+            let t1 = thread::spawn(move || {
+                counter1.store(0, Ordering::SeqCst);
+            });
+
+            let mut handles = Vec::new();
+            for _i in 0..NUM_EVENTS {
+                let counter2 = counter2.clone();
+                handles.push(thread::spawn(move || {
+                    counter2.store(1, Ordering::SeqCst);
+                }));
+            }
+            for h in handles {
+                h.join().ok();
+            }
+            t1.join().ok();
+        },
+        UniformRandomScheduler::new(NUM_SHUTTLE_ITERATIONS_URW),
+        true,
+    );
+}
+
+#[test]
+fn non_uniform_degrades_for_uneven_task_creation() {
+    test_uneven_execution(
+        |counter1, counter2| {
+            let t1 = thread::spawn(move || {
+                counter1.store(0, Ordering::SeqCst);
+            });
+
+            let mut handles = Vec::new();
+            for _i in 0..NUM_EVENTS {
+                let counter2 = counter2.clone();
+                handles.push(thread::spawn(move || {
+                    counter2.store(1, Ordering::SeqCst);
+                }));
+            }
+            for h in handles {
+                h.join().ok();
+            }
+            t1.join().ok();
+        },
+        RandomScheduler::new(NUM_SHUTTLE_ITERATIONS_URW * 10),
+        false,
+    );
+}


### PR DESCRIPTION
This PR adds UniformRandomScheduler to implement URW from the [Selectively Uniform Random Walk](https://dl.acm.org/doi/10.1145/3669940.3707214) (ASPLOS'25).

For event count estimates, the scheduler does a single trial run in the first iteration, and uses these estimates for all future iterations. This is a relatively naive approach, which we can likely improve with better heuristics in future changes. 

Notably, these changes are dependent on https://github.com/awslabs/shuttle/pull/196, so you can look at the commit directly to see [the changes for this PR in isolation](https://github.com/awslabs/shuttle/commit/02606b6b27272120adc7114a1c101138340c07cb) until that has been merged.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.