### PR TITLE
Add functionality in RandomScheduler to persist the seed before running an iteration

### DIFF
--- a/shuttle/src/scheduler/random.rs
+++ b/shuttle/src/scheduler/random.rs
@@ -94,6 +94,9 @@ impl Scheduler for RandomScheduler {
         } else {
             self.iterations += 1;
             let seed = self.data_source.reinitialize();
+            if let Ok(path) = std::env::var("SHUTTLE_ALWAYS_PERSIST_SEED") {
+                std::fs::write(path, seed.to_string()).expect("Failed to write seed to file");
+            }
             self.rng = Pcg64Mcg::seed_from_u64(seed);
             self.current_seed.update(seed);
             Some(Schedule::new(seed))


### PR DESCRIPTION
The RandomScheduler will persist the seed used in the next iteration to a file pointed to by the  `SHUTTLE_ALWAYS_PERSIST_SEED` environment variable.

This functionality may help us debug crashes in shuttle tests where the failing schedule is not persisted at the end of the test.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.