### PR TITLE
Generators --> Corosensei

### DIFF
--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["asynchronous", "concurrency", "development-tools::testing"]
 assoc = "0.1.3"
 bitvec = "1.0.1"
 cfg-if = "1.0"
-generator = "0.8.1"
 hex = "0.4.2"
 owo-colors = "3.5.0"
 rand_core = "0.6.4"
@@ -26,6 +25,7 @@ tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 regex = { version = "1.10.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
+corosensei = "0.2.2"
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/shuttle/src/future/mod.rs
+++ b/shuttle/src/future/mod.rs
@@ -62,8 +62,7 @@ impl AbortHandle {
     pub fn abort(&self) {
         ExecutionState::try_with(|state| {
             if !state.is_finished() {
-                let task = state.get_mut(self.task_id);
-                task.abort();
+                state.get_mut(self.task_id).abort();
             }
         });
     }
@@ -110,8 +109,7 @@ impl<T> JoinHandle<T> {
     pub fn abort(&self) {
         ExecutionState::try_with(|state| {
             if !state.is_finished() {
-                let task = state.get_mut(self.task_id);
-                task.abort();
+                state.get_mut(self.task_id).abort();
             }
         });
     }

--- a/shuttle/src/lib.rs
+++ b/shuttle/src/lib.rs
@@ -246,7 +246,7 @@ impl Config {
     /// Create a new default configuration
     pub fn new() -> Self {
         Self {
-            stack_size: 0x8000,
+            stack_size: 0xf000,
             failure_persistence: FailurePersistence::Print,
             max_steps: MaxSteps::FailAfter(1_000_000),
             max_time: None,


### PR DESCRIPTION
This PR switches Shuttle continuations to use [corosensei](https://docs.rs/corosensei/latest/corosensei/) rather than the generators library. In the context-switch heavy micro-benchmarks (for example, `shuttle/benches/counter.rs` with the `RandomScheduler`), this results in 5-20% faster scheduling throughput because of reduced context-switching overhead.

This PR is marked as a draft to allow for thorough testing on client projects and for discussion of the implementation. 

Major points for discussion:

1) There is an API change with `corosensei` where we now need to pass an explicit `yielder` in order to suspend a coroutine.  Because the continuations are kept in a pool and reused, this requires us to exfiltrate the yielder from the closure passed in to `Coroutine::with_stack` and persist it for the lifetime of the Continuation. Currently, the yielder is carried around as a raw pointer on the Task struct, but I suspect there might be a nicer way to do this. Unfortunately, naively embedding it in the Continuation struct is not possible because the Continuation is already borrowed by its `resume` method when `switch` is called.

2) There is an issue where `corosensei` [expects to catch a ForcedUnwind when dropping coroutines](https://github.com/Amanieu/corosensei/blob/bf7e695f7043aa3c4d56b3797102c9008ac1245e/src/coroutine.rs#L384). Something in the way Shuttle handles panics is intercepting the ForcedUnwind and not propagating it up to where corosensei expects it, causing it to panic. This only arises on an initial panic, or during cleanup if some Tasks are detached. The current solution is to call `force_reset` instead of `force_unwind` in these cases, which does not attempt to unwind the coroutine, but therefore may leak resources allocated on the coroutine. In these two scenarios, we probably don't care about leaking resources, because the whole test is about to exit. 


TODOS before this is ready for merging:

- [ ] test on some client projects over a longer period of time
- [ ] update the ignored test (depends on how we handle (1))
- [ ] general cleanup (remove unnecessary pub, delete commented out println's etc.)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.