### PR TITLE
Print task backtraces on deadlock

### DIFF
--- a/shuttle/src/runtime/execution.rs
+++ b/shuttle/src/runtime/execution.rs
@@ -143,7 +143,7 @@ impl Execution {
                             })
                             .collect::<Vec<_>>();
 
-                        // Collecting backtraces is expensive, so we only want to do it if the use opts in to collecting them.
+                        // Collecting backtraces is expensive, so we only want to do it if the user opts in to collecting them.
                         if !backtrace_enabled() {
                             eprintln!("Test deadlocked, and `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE` are not set. If either of those are set then the backtrace of each task will be collected and printed as part of the panic message.")
                         }


### PR DESCRIPTION
Prints a backtrace for each task on failure. Uses `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE` to decide whether to capture backtraces (as this is somewhat expensive), which is the same signaling mechanism used by `Backtrace::capture()`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.