### PR TITLE
Make `Lazy` struct fields private

### DIFF
--- a/shuttle/src/lazy_static.rs
+++ b/shuttle/src/lazy_static.rs
@@ -25,16 +25,10 @@ use std::marker::PhantomData;
 pub use crate::lazy_static;
 
 /// Shuttle's implementation of `lazy_static::Lazy` (aka the unstable `std::lazy::Lazy`).
-// Sadly, the fields of this thing need to be public because function pointers in const fns are
-// unstable, so an explicit instantiation is the only way to construct this struct. User code should
-// not rely on these fields.
 pub struct Lazy<T: Sync> {
-    #[doc(hidden)]
-    pub cell: Once,
-    #[doc(hidden)]
-    pub init: fn() -> T,
-    #[doc(hidden)]
-    pub _p: PhantomData<T>,
+    cell: Once,
+    init: fn() -> T,
+    _p: PhantomData<T>,
 }
 
 impl<T: Sync> std::fmt::Debug for Lazy<T> {
@@ -44,6 +38,15 @@ impl<T: Sync> std::fmt::Debug for Lazy<T> {
 }
 
 impl<T: Sync> Lazy<T> {
+    /// Constructs a new `Lazy` with a given function for lazy initialization.
+    pub const fn new(init: fn() -> T) -> Self {
+        Self {
+            cell: Once::new(),
+            init,
+            _p: PhantomData,
+        }
+    }
+
     /// Get a reference to the lazy value, initializing it first if necessary.
     pub fn get(&'static self) -> &'static T {
         // Safety: see the usage below

--- a/shuttle/src/lib.rs
+++ b/shuttle/src/lib.rs
@@ -529,12 +529,7 @@ macro_rules! __lazy_static_internal {
 
                 #[inline(always)]
                 fn __stability() -> &'static $T {
-                    static LAZY: $crate::lazy_static::Lazy<$T> =
-                        $crate::lazy_static::Lazy {
-                            cell: $crate::sync::Once::new(),
-                            init: __static_ref_initialize,
-                            _p: std::marker::PhantomData,
-                        };
+                    static LAZY: $crate::lazy_static::Lazy<$T> = $crate::lazy_static::Lazy::new(__static_ref_initialize);
                     LAZY.get()
                 }
                 __stability()


### PR DESCRIPTION
Function pointers in `const fn` got stabilized in Rust 1.61.0, which prevented us from doing this before.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.