### PR TITLE
Tuning down log-level for spawn events to reduce mem. usage of default test config

### DIFF
--- a/shuttle/src/runtime/task/mod.rs
+++ b/shuttle/src/runtime/task/mod.rs
@@ -336,7 +336,7 @@ impl Task {
 
         // Note: the tests for the task signature in [`crate::tests::basic::task`] depend on tracing the task signature and creation point here
         error_span!(parent: parent_span_id, "new_task", parent = ?parent_task_id, i = schedule_len).in_scope(
-            || event!(Level::INFO, task_id = ?task.id, signature = task.signature.signature_hash(), static_create_location = task.signature.static_create_location_hash(), "created task"),
+            || event!(Level::DEBUG, task_id = ?task.id, signature = task.signature.signature_hash(), static_create_location = task.signature.static_create_location_hash(), "created task"),
         );
 
         task

--- a/shuttle/tests/basic/task.rs
+++ b/shuttle/tests/basic/task.rs
@@ -36,7 +36,7 @@ impl Subscriber for SignatureSubscriber {
 
     fn event(&self, event: &Event<'_>) {
         let metadata = event.metadata();
-        if metadata.target() == "shuttle::runtime::task" && metadata.level() == &tracing::Level::INFO {
+        if metadata.target() == "shuttle::runtime::task" && metadata.level() == &tracing::Level::DEBUG {
             struct SignatureVisitor {
                 task_id: Option<String>,
                 signature: Option<u64>,


### PR DESCRIPTION
The `test-log` crate uses `INFO` level logging by default. Thus anything at that level will be logged by default when running tests. The logs are also buffered in memory until the test has completed, which can lead to high memory consumption for tests producing verbose logs, in addition to increasing the test runtime.

While logging has already been turned off by default in CI before this PR (`RUST_LOG=off`), the default behavior with no additional environment variables causes the tests to run extremely slowly due to verbose logging. This is not a good experience for new developers of Shuttle and generally seems like a bad default. 

The primary culprit is logging task creation at `INFO` level; we have several tests which do millions of shuttle iterations, each containing multiple task spawns. This PR moves that logging to `DEBUG`, so it is off by default during testing, but can be easily re-enabled by setting `RUST_LOG=debug`. With this change, running the shuttle test suite on my machine goes from:

`cargo test --release`: from ~244s and >20 GB of RAM to ~183s and <1GB of RAM

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.