### PR TITLE
Next Event on Task struct

### DIFF
--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -1,7 +1,7 @@
 //! A counting semaphore supporting both async and sync operations.
 use crate::current;
 use crate::runtime::execution::ExecutionState;
-use crate::runtime::task::{clock::VectorClock, TaskId};
+use crate::runtime::task::{clock::VectorClock, Event, TaskId};
 use crate::runtime::thread;
 use crate::sync_types::{ResourceSignature, ResourceType};
 use std::cell::RefCell;
@@ -342,7 +342,6 @@ impl BatchSemaphoreState {
 pub struct BatchSemaphore {
     state: RefCell<BatchSemaphoreState>,
     fairness: Fairness,
-    #[allow(unused)]
     signature: ResourceSignature,
 }
 
@@ -445,8 +444,9 @@ impl BatchSemaphore {
 
     /// Closes the semaphore. This prevents the semaphore from issuing new
     /// permits and notifies all pending waiters.
+    #[track_caller]
     pub fn close(&self) {
-        thread::switch();
+        thread::switch(Event::batch_semaphore_rel(&self.signature));
         self.close_no_scheduling_point();
     }
 
@@ -495,8 +495,9 @@ impl BatchSemaphore {
     /// If the permits are available, returns Ok(())
     /// If the semaphore is closed, returns `Err(TryAcquireError::Closed)`
     /// If there aren't enough permits, returns `Err(TryAcquireError::NoPermits)`
+    #[track_caller]
     pub fn try_acquire(&self, num_permits: usize) -> Result<(), TryAcquireError> {
-        thread::switch();
+        thread::switch(Event::batch_semaphore_acq(&self.signature));
 
         self.init_object_id();
         let mut state = self.state.borrow_mut();
@@ -599,6 +600,7 @@ impl BatchSemaphore {
     }
 
     /// Acquire the specified number of permits (async API)
+    #[track_caller]
     pub fn acquire(&self, num_permits: usize) -> Acquire<'_> {
         // No switch here; switch should be triggered on polling future
         self.init_object_id();
@@ -606,13 +608,15 @@ impl BatchSemaphore {
     }
 
     /// Acquire the specified number of permits (blocking API)
+    #[track_caller]
     pub fn acquire_blocking(&self, num_permits: usize) -> Result<(), AcquireError> {
         crate::future::block_on(self.acquire(num_permits))
     }
 
     /// Release `num_permits` back to the Semaphore
+    #[track_caller]
     pub fn release(&self, num_permits: usize) {
-        thread::switch();
+        thread::switch(Event::batch_semaphore_rel(&self.signature));
 
         self.init_object_id();
         if num_permits == 0 {
@@ -742,6 +746,7 @@ pub struct Acquire<'a> {
 }
 
 impl<'a> Acquire<'a> {
+    #[track_caller]
     fn new(semaphore: &'a BatchSemaphore, num_permits: usize) -> Self {
         let waiter = Arc::new(Waiter::new(num_permits));
         Self {
@@ -786,7 +791,7 @@ impl Future for Acquire<'_> {
         let blocking_is_not_commutative = self.semaphore.fairness == Fairness::StrictlyFair;
 
         if self.never_polled && (will_succeed || blocking_is_not_commutative) {
-            thread::switch();
+            thread::switch(Event::batch_semaphore_acq(&self.semaphore.signature));
         }
         self.never_polled = false;
 
@@ -878,6 +883,13 @@ impl Future for Acquire<'_> {
                             self.waiter.is_queued.store(true, Ordering::SeqCst);
                         }
                         trace!("Acquire::poll for waiter {:?} that is enqueued", self.waiter);
+
+                        let event = Event::batch_semaphore_acq(&self.semaphore.signature);
+                        // SAFETY: This is safe because the current task immediately suspends after this future
+                        // returns Poll::Pending (src/future/mod.rs). Whenever a task resumes, the `next_event`
+                        // is unset, so there is no opportunity to corrupt the reference to our signature while
+                        // it is set as the `next_task`.
+                        ExecutionState::with(|s| unsafe { s.current_mut().set_next_event(event) });
                         Poll::Pending
                     }
                     Err(TryAcquireError::Closed) => unreachable!(),
@@ -892,6 +904,13 @@ impl Future for Acquire<'_> {
                 // actual poller would never be woken.
                 *self.waiter.waker.lock().unwrap() = Some(cx.waker().clone());
                 self.waiter.set_task_id(ExecutionState::me());
+
+                let event = Event::batch_semaphore_acq(&self.semaphore.signature);
+                // SAFETY: This is safe because the current task immediately suspends after this future
+                // returns Poll::Pending (shuttle-std/src/future.rs). Whenever a task resumes, the
+                // `next_event` is unset, so there is no opportunity to corrupt the reference to our
+                // signature while it is set as the `next_task`.
+                ExecutionState::with(|s| unsafe { s.current_mut().set_next_event(event) });
                 Poll::Pending
             }
         }

--- a/shuttle-engine/src/future/mod.rs
+++ b/shuttle-engine/src/future/mod.rs
@@ -17,7 +17,7 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
             Poll::Ready(result) => break result,
             Poll::Pending => {
                 ExecutionState::with(|state| state.current_mut().sleep_unless_woken());
-                thread::switch();
+                thread::switch_keeping_current_event();
             }
         }
     }

--- a/shuttle-engine/src/runtime/execution.rs
+++ b/shuttle-engine/src/runtime/execution.rs
@@ -2,7 +2,7 @@ use crate::runtime::failure::{init_panic_hook, persist_failure};
 use crate::runtime::storage::{StorageKey, StorageMap};
 use crate::runtime::task::clock::VectorClock;
 use crate::runtime::task::labels::Labels;
-use crate::runtime::task::{ChildLabelFn, Task, TaskId, TaskName, TaskSignature, DEFAULT_INLINE_TASKS};
+use crate::runtime::task::{ChildLabelFn, Event, Task, TaskId, TaskName, TaskSignature, DEFAULT_INLINE_TASKS};
 use crate::runtime::thread;
 use crate::runtime::thread::continuation::PooledContinuation;
 use crate::scheduler::{Schedule, Scheduler};
@@ -583,7 +583,8 @@ impl ExecutionState {
     where
         F: Future<Output = ()> + 'static,
     {
-        thread::switch();
+        let signature = ExecutionState::with(|state| state.current_mut().signature.new_child(caller));
+        thread::switch(Event::Spawn(&signature));
         let task_id = Self::with(|state| {
             let schedule_len = CurrentSchedule::len();
             let parent_span_id = state.top_level_span.id();
@@ -606,7 +607,7 @@ impl ExecutionState {
                 schedule_len,
                 tag,
                 Some(state.current().id()),
-                state.current_mut().signature.new_child(caller),
+                signature,
             );
 
             state.add_task(task);
@@ -626,7 +627,8 @@ impl ExecutionState {
         mut initial_clock: Option<VectorClock>,
         caller: &'static Location<'static>,
     ) -> TaskId {
-        thread::switch();
+        let signature = ExecutionState::with(|state| state.current_mut().signature.new_child(caller));
+        thread::switch(Event::Spawn(&signature));
         let task_id = Self::with(|state| {
             let parent_span_id = state.top_level_span.id();
             let task_id = TaskId(state.tasks.len());
@@ -653,7 +655,7 @@ impl ExecutionState {
                 CurrentSchedule::len(),
                 tag,
                 Some(state.current().id()),
-                state.current_mut().signature.new_child(caller),
+                signature,
             );
             state.add_task(task);
 
@@ -829,6 +831,10 @@ impl ExecutionState {
         self.tasks.get(id.0)
     }
 
+    pub(crate) fn try_current_mut(&mut self) -> Option<&mut Task> {
+        self.tasks.get_mut(self.current_task.id()?.0)
+    }
+
     pub fn in_cleanup(&self) -> bool {
         self.in_cleanup
     }
@@ -973,7 +979,7 @@ impl ExecutionState {
             .scheduler
             .borrow_mut()
             .next_task(task_refs, self.current_task.id(), is_yielding)
-            .map(ScheduledTask::Some)
+            .map(|task| ScheduledTask::Some(task.id()))
             .unwrap_or(ScheduledTask::Stopped);
 
         // Tracing this `in_scope` is purely a matter of taste. We do it because

--- a/shuttle-engine/src/runtime/runner.rs
+++ b/shuttle-engine/src/runtime/runner.rs
@@ -237,12 +237,12 @@ impl<S: Scheduler> Scheduler for PortfolioStoppableScheduler<S> {
         }
     }
 
-    fn next_task(
+    fn next_task<'a>(
         &mut self,
-        runnable_tasks: &[&Task],
+        runnable_tasks: &'a [&'a Task],
         current_task: Option<TaskId>,
         is_yielding: bool,
-    ) -> Option<TaskId> {
+    ) -> Option<&'a Task> {
         if self.stop_signal.load(Ordering::SeqCst) {
             None
         } else {

--- a/shuttle-engine/src/runtime/task/mod.rs
+++ b/shuttle-engine/src/runtime/task/mod.rs
@@ -255,6 +255,132 @@ impl PartialEq for TaskSignature {
 
 impl Eq for TaskSignature {}
 
+pub type Loc = &'static Location<'static>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Event<'a> {
+    AtomicRead(&'a ResourceSignature, Loc),
+    AtomicWrite(&'a ResourceSignature, Loc),
+    AtomicReadWrite(&'a ResourceSignature, Loc),
+    BatchSemaphoreAcq(&'a ResourceSignature, Loc),
+    BatchSemaphoreRel(&'a ResourceSignature, Loc),
+    BarrierWait(&'a ResourceSignature, Loc),
+    CondvarWait(&'a ResourceSignature, Loc),
+    CondvarNotify(Loc),
+    Park(Loc),
+    Unpark(&'a TaskSignature, Loc),
+    ChannelSend(&'a ResourceSignature, Loc),
+    ChannelRecv(&'a ResourceSignature, Loc),
+    Spawn(&'a TaskSignature),
+    Yield(Loc),
+    Sleep(Loc),
+    Exit,
+    Join(&'a TaskSignature, Loc),
+    Unknown,
+}
+
+impl<'a> std::fmt::Display for Event<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Event::AtomicRead(_, loc) => write!(f, "AtomicRead at {}", loc),
+            Event::AtomicWrite(_, loc) => write!(f, "AtomicWrite at {}", loc),
+            Event::AtomicReadWrite(_, loc) => write!(f, "AtomicReadWrite at {}", loc),
+            Event::BatchSemaphoreAcq(_, loc) => write!(f, "BatchSemaphoreAcq at {}", loc),
+            Event::BatchSemaphoreRel(_, loc) => write!(f, "BatchSemaphoreRel at {}", loc),
+            Event::BarrierWait(_, loc) => write!(f, "BarrierWait at {}", loc),
+            Event::CondvarWait(_, loc) => write!(f, "CondvarWait at {}", loc),
+            Event::CondvarNotify(loc) => write!(f, "CondvarNotify at {}", loc),
+            Event::Park(loc) => write!(f, "Park at {}", loc),
+            Event::Unpark(_, loc) => write!(f, "Unpark at {}", loc),
+            Event::ChannelSend(_, loc) => write!(f, "ChannelSend at {}", loc),
+            Event::ChannelRecv(_, loc) => write!(f, "ChannelRecv at {}", loc),
+            Event::Spawn(sig) => write!(f, "Spawn at {}", sig.task_creation_stack.last().unwrap().0),
+            Event::Yield(loc) => write!(f, "Yield at {}", loc),
+            Event::Sleep(loc) => write!(f, "Sleep at {}", loc),
+            Event::Exit => write!(f, "Exit"),
+            Event::Join(_, loc) => write!(f, "Join at {}", loc),
+            Event::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+impl<'a> Event<'a> {
+    #[track_caller]
+    pub fn atomic_read(sig: &'a ResourceSignature) -> Self {
+        Self::AtomicRead(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn atomic_write(sig: &'a ResourceSignature) -> Self {
+        Self::AtomicWrite(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn atomic_read_write(sig: &'a ResourceSignature) -> Self {
+        Self::AtomicReadWrite(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn batch_semaphore_acq(sig: &'a ResourceSignature) -> Self {
+        Self::BatchSemaphoreAcq(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn batch_semaphore_rel(sig: &'a ResourceSignature) -> Self {
+        Self::BatchSemaphoreRel(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn barrier_wait(sig: &'a ResourceSignature) -> Self {
+        Self::BarrierWait(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn condvar_wait(sig: &'a ResourceSignature) -> Self {
+        Self::CondvarWait(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn condvar_notify() -> Self {
+        Self::CondvarNotify(Location::caller())
+    }
+
+    #[track_caller]
+    pub fn park() -> Self {
+        Self::Park(Location::caller())
+    }
+
+    #[track_caller]
+    pub fn unpark(sig: &'a TaskSignature) -> Self {
+        Self::Unpark(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn channel_send(sig: &'a ResourceSignature) -> Self {
+        Self::ChannelSend(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn channel_recv(sig: &'a ResourceSignature) -> Self {
+        Self::ChannelRecv(sig, Location::caller())
+    }
+
+    #[track_caller]
+    pub fn yield_now() -> Self {
+        Self::Yield(Location::caller())
+    }
+
+    #[track_caller]
+    pub fn sleep() -> Self {
+        Self::Sleep(Location::caller())
+    }
+
+    #[track_caller]
+    pub fn join(sig: &'a TaskSignature) -> Self {
+        Self::Join(sig, Location::caller())
+    }
+}
+
 /// A `Task` represents a user-level unit of concurrency. Each task has an `id` that is unique within
 /// the execution, and a `state` reflecting whether the task is runnable (enabled) or not.
 #[derive(Debug)]
@@ -275,6 +401,8 @@ pub struct Task {
     waker: Waker,
     // Remember whether the waker was invoked while we were running
     woken: bool,
+
+    next_event: Event<'static>,
 
     name: Option<String>,
 
@@ -351,6 +479,7 @@ impl Task {
             waiter: None,
             waker,
             woken: false,
+            next_event: Event::Unknown,
             detached: false,
             park_state: ParkState::default(),
             name,
@@ -425,7 +554,7 @@ impl Task {
                 let cx = &mut Context::from_waker(&waker);
                 while future.as_mut().poll(cx).is_pending() {
                     ExecutionState::with(|state| state.current_mut().sleep_unless_woken());
-                    thread::switch();
+                    thread::switch_keeping_current_event();
                 }
             }),
             stack_size,
@@ -681,6 +810,30 @@ impl Task {
                 "".into()
             }
         )
+    }
+
+    /// Get the next_event with a downcast lifetime tied to self. This prevents the caller from
+    /// borrowing as `'static`, which is only used to avoid borrow-checker issues and spurious
+    /// lifetime annotations on the Task struct
+    /// SAFETY: The borrowed lifetime should not extend past resuming the task after a switch
+    pub fn next_event(&self) -> &Event<'_> {
+        unsafe { std::mem::transmute(&self.next_event) }
+    }
+
+    /// Transmutes an Event reference to a `'static` lifetime to avoid borrow checker issues when
+    /// switching coroutines
+    ///
+    /// # Safety
+    ///
+    /// For this to be safe, the next event must be unset with `unset_next_event` before
+    /// the actual lifetime of the event expires. In general, as long as the event is unset when
+    /// the task is resumed, this will be safe.
+    pub unsafe fn set_next_event(&mut self, event: Event<'_>) {
+        self.next_event = unsafe { std::mem::transmute::<Event<'_>, Event<'static>>(event) };
+    }
+
+    pub fn unset_next_event(&mut self) {
+        self.next_event = Event::Unknown;
     }
 }
 

--- a/shuttle-engine/src/runtime/thread/continuation.rs
+++ b/shuttle-engine/src/runtime/thread/continuation.rs
@@ -1,5 +1,6 @@
 use crate::config::{ContinuationFunctionBehavior, UNGRACEFUL_SHUTDOWN_CONFIG};
 use crate::runtime::execution::ExecutionState;
+use crate::runtime::task::Event;
 use corosensei::Yielder;
 use corosensei::{stack::DefaultStack, Coroutine, CoroutineResult};
 use scoped_tls::scoped_thread_local;
@@ -7,7 +8,6 @@ use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::ops::Deref;
 use std::ops::DerefMut;
-use std::panic::Location;
 use std::rc::Rc;
 use tracing::trace;
 
@@ -342,9 +342,29 @@ unsafe impl Send for PooledContinuation {}
 /// operation `Y1`, it suffices to check that `Y1` commutes with all operations `Z` on the same resource,
 /// as operations on other resources should commute trivially.
 #[track_caller]
-pub fn switch() {
+pub fn switch(event: Event<'_>) {
+    // SAFETY we cast the lifetime of the Event to 'static when embedding it into the current Task
+    // This is safe because (1) we have a valid reference to the Event's data for the scope of this function
+    // and (2) the static reference is dropped at the end of the scope of this function when the next_event
+    // is set back to Unknown in `switch_keep_event`
+    ExecutionState::with(|s| s.try_current_mut().map(|c| unsafe { c.set_next_event(event) }));
+    switch_keeping_current_event()
+}
+
+/// This function should be identical to `continuation::switch` except that the burden of setting the next event on the current
+/// task before switching is on the *caller* of this function. In contrast, `continuation::switch` takes the next event as an
+/// argument and sets it for you. This is useful for futures, which yield by returning Poll::Pending rather than calling `switch`
+/// explicitly, and thus can't pass the `next_event` as an argument. Instead, Futures can set the next event on the current task
+/// before returning `Poll::Pending`, and the Shuttle async runtime will call `switch_keep_current_event` to preserve that event.
+/// The next event is always unset by this function when the caller resumes/continues from the switch.
+#[track_caller]
+pub fn switch_keeping_current_event() {
     crate::annotations::record_tick();
-    trace!("switch from {}", Location::caller());
+
+    trace!(
+        "switch from {:?}",
+        ExecutionState::with(|s| s.try_current_mut().map(|c| format!("{}", c.next_event())))
+    );
     if ExecutionState::maybe_yield() {
         let yielder = ExecutionState::with(|state| state.current().yielder);
 
@@ -356,6 +376,7 @@ pub fn switch() {
             ContinuationInput::Resume => {}
         };
     }
+    ExecutionState::with(|s| s.try_current_mut().map(|c| c.unset_next_event()));
 }
 
 #[cfg(test)]

--- a/shuttle-engine/src/runtime/thread/mod.rs
+++ b/shuttle-engine/src/runtime/thread/mod.rs
@@ -1,3 +1,4 @@
 pub mod continuation;
 
 pub use continuation::switch;
+pub use continuation::switch_keeping_current_event;

--- a/shuttle-engine/src/scheduler/metrics.rs
+++ b/shuttle-engine/src/scheduler/metrics.rs
@@ -24,6 +24,43 @@ pub struct MetricsScheduler<S: ?Sized + Scheduler> {
 
     random_choices: usize,
     random_choices_metric: CountSummaryMetric,
+
+    atomic_read: usize,
+    atomic_read_metric: CountSummaryMetric,
+    atomic_write: usize,
+    atomic_write_metric: CountSummaryMetric,
+    atomic_read_write: usize,
+    atomic_read_write_metric: CountSummaryMetric,
+    batch_semaphore_acq: usize,
+    batch_semaphore_acq_metric: CountSummaryMetric,
+    batch_semaphore_rel: usize,
+    batch_semaphore_rel_metric: CountSummaryMetric,
+    barrier_wait: usize,
+    barrier_wait_metric: CountSummaryMetric,
+    condvar_wait: usize,
+    condvar_wait_metric: CountSummaryMetric,
+    condvar_notify: usize,
+    condvar_notify_metric: CountSummaryMetric,
+    park: usize,
+    park_metric: CountSummaryMetric,
+    unpark: usize,
+    unpark_metric: CountSummaryMetric,
+    channel_send: usize,
+    channel_send_metric: CountSummaryMetric,
+    channel_recv: usize,
+    channel_recv_metric: CountSummaryMetric,
+    spawn: usize,
+    spawn_metric: CountSummaryMetric,
+    yield_event: usize,
+    yield_event_metric: CountSummaryMetric,
+    sleep: usize,
+    sleep_metric: CountSummaryMetric,
+    exit: usize,
+    exit_metric: CountSummaryMetric,
+    join: usize,
+    join_metric: CountSummaryMetric,
+    unknown: usize,
+    unknown_metric: CountSummaryMetric,
 }
 
 impl<S: Scheduler> MetricsScheduler<S> {
@@ -46,6 +83,43 @@ impl<S: Scheduler> MetricsScheduler<S> {
 
             random_choices: 0,
             random_choices_metric: CountSummaryMetric::new(),
+
+            atomic_read: 0,
+            atomic_read_metric: CountSummaryMetric::new(),
+            atomic_write: 0,
+            atomic_write_metric: CountSummaryMetric::new(),
+            atomic_read_write: 0,
+            atomic_read_write_metric: CountSummaryMetric::new(),
+            batch_semaphore_acq: 0,
+            batch_semaphore_acq_metric: CountSummaryMetric::new(),
+            batch_semaphore_rel: 0,
+            batch_semaphore_rel_metric: CountSummaryMetric::new(),
+            barrier_wait: 0,
+            barrier_wait_metric: CountSummaryMetric::new(),
+            condvar_wait: 0,
+            condvar_wait_metric: CountSummaryMetric::new(),
+            condvar_notify: 0,
+            condvar_notify_metric: CountSummaryMetric::new(),
+            park: 0,
+            park_metric: CountSummaryMetric::new(),
+            unpark: 0,
+            unpark_metric: CountSummaryMetric::new(),
+            channel_send: 0,
+            channel_send_metric: CountSummaryMetric::new(),
+            channel_recv: 0,
+            channel_recv_metric: CountSummaryMetric::new(),
+            spawn: 0,
+            spawn_metric: CountSummaryMetric::new(),
+            yield_event: 0,
+            yield_event_metric: CountSummaryMetric::new(),
+            sleep: 0,
+            sleep_metric: CountSummaryMetric::new(),
+            exit: 0,
+            exit_metric: CountSummaryMetric::new(),
+            join: 0,
+            join_metric: CountSummaryMetric::new(),
+            unknown: 0,
+            unknown_metric: CountSummaryMetric::new(),
         }
     }
 }
@@ -62,6 +136,44 @@ impl<S: ?Sized + Scheduler> MetricsScheduler<S> {
 
         self.random_choices_metric.record(self.random_choices);
         self.random_choices = 0;
+
+        // Record and reset event counters
+        self.atomic_read_metric.record(self.atomic_read);
+        self.atomic_read = 0;
+        self.atomic_write_metric.record(self.atomic_write);
+        self.atomic_write = 0;
+        self.atomic_read_write_metric.record(self.atomic_read_write);
+        self.atomic_read_write = 0;
+        self.batch_semaphore_acq_metric.record(self.batch_semaphore_acq);
+        self.batch_semaphore_acq = 0;
+        self.batch_semaphore_rel_metric.record(self.batch_semaphore_rel);
+        self.batch_semaphore_rel = 0;
+        self.barrier_wait_metric.record(self.barrier_wait);
+        self.barrier_wait = 0;
+        self.condvar_wait_metric.record(self.condvar_wait);
+        self.condvar_wait = 0;
+        self.condvar_notify_metric.record(self.condvar_notify);
+        self.condvar_notify = 0;
+        self.park_metric.record(self.park);
+        self.park = 0;
+        self.unpark_metric.record(self.unpark);
+        self.unpark = 0;
+        self.channel_send_metric.record(self.channel_send);
+        self.channel_send = 0;
+        self.channel_recv_metric.record(self.channel_recv);
+        self.channel_recv = 0;
+        self.spawn_metric.record(self.spawn);
+        self.spawn = 0;
+        self.yield_event_metric.record(self.yield_event);
+        self.yield_event = 0;
+        self.sleep_metric.record(self.sleep);
+        self.sleep = 0;
+        self.exit_metric.record(self.exit);
+        self.exit = 0;
+        self.join_metric.record(self.join);
+        self.join = 0;
+        self.unknown_metric.record(self.unknown);
+        self.unknown = 0;
     }
 }
 
@@ -83,24 +195,48 @@ impl<S: Scheduler> Scheduler for MetricsScheduler<S> {
         self.inner.new_execution()
     }
 
-    fn next_task(
+    fn next_task<'a>(
         &mut self,
-        runnable_tasks: &[&Task],
+        runnable_tasks: &'a [&'a Task],
         current_task: Option<TaskId>,
         is_yielding: bool,
-    ) -> Option<TaskId> {
-        let choice = self.inner.next_task(runnable_tasks, current_task, is_yielding)?;
+    ) -> Option<&'a Task> {
+        let chosen_task = self.inner.next_task(runnable_tasks, current_task, is_yielding)?;
+
+        // Update event counters based on the chosen task's next_event
+        use crate::runtime::task::Event;
+        match chosen_task.next_event() {
+            Event::AtomicRead(_, _) => self.atomic_read += 1,
+            Event::AtomicWrite(_, _) => self.atomic_write += 1,
+            Event::AtomicReadWrite(_, _) => self.atomic_read_write += 1,
+            Event::BatchSemaphoreAcq(_, _) => self.batch_semaphore_acq += 1,
+            Event::BatchSemaphoreRel(_, _) => self.batch_semaphore_rel += 1,
+            Event::BarrierWait(_, _) => self.barrier_wait += 1,
+            Event::CondvarWait(_, _) => self.condvar_wait += 1,
+            Event::CondvarNotify(_) => self.condvar_notify += 1,
+            Event::Park(_) => self.park += 1,
+            Event::Unpark(_, _) => self.unpark += 1,
+            Event::ChannelSend(_, _) => self.channel_send += 1,
+            Event::ChannelRecv(_, _) => self.channel_recv += 1,
+            Event::Spawn(_) => self.spawn += 1,
+            Event::Yield(_) => self.yield_event += 1,
+            Event::Sleep(_) => self.sleep += 1,
+            Event::Exit => self.exit += 1,
+            Event::Join(_, _) => self.join += 1,
+            Event::Unknown => self.unknown += 1,
+        }
 
         self.steps += 1;
-        if choice != self.last_task {
+        let choice_id = chosen_task.id();
+        if choice_id != self.last_task {
             self.context_switches += 1;
             if runnable_tasks.iter().any(|t| t.id() == self.last_task) {
                 self.preemptions += 1;
             }
         }
-        self.last_task = choice;
+        self.last_task = choice_id;
 
-        Some(choice)
+        Some(chosen_task)
     }
 
     fn next_u64(&mut self) -> u64 {
@@ -125,6 +261,24 @@ impl<S: ?Sized + Scheduler> Drop for MetricsScheduler<S> {
             context_switches = %self.context_switches_metric,
             preemptions = %self.preemptions_metric,
             random_choices = %self.random_choices_metric,
+            atomic_read = %self.atomic_read_metric,
+            atomic_write = %self.atomic_write_metric,
+            atomic_read_write = %self.atomic_read_write_metric,
+            batch_semaphore_acq = %self.batch_semaphore_acq_metric,
+            batch_semaphore_rel = %self.batch_semaphore_rel_metric,
+            barrier_wait = %self.barrier_wait_metric,
+            condvar_wait = %self.condvar_wait_metric,
+            condvar_notify = %self.condvar_notify_metric,
+            park = %self.park_metric,
+            unpark = %self.unpark_metric,
+            channel_send = %self.channel_send_metric,
+            channel_recv = %self.channel_recv_metric,
+            spawn = %self.spawn_metric,
+            yield_event = %self.yield_event_metric,
+            sleep = %self.sleep_metric,
+            exit = %self.exit_metric,
+            join = %self.join_metric,
+            unknown = %self.unknown_metric,
             "run finished"
         );
     }

--- a/shuttle-engine/src/scheduler/mod.rs
+++ b/shuttle-engine/src/scheduler/mod.rs
@@ -89,12 +89,12 @@ pub trait Scheduler {
     ///
     /// The list of runnable tasks is guaranteed to be non-empty. If `current_task` is `None`, the
     /// execution has not yet begun.
-    fn next_task(
+    fn next_task<'a>(
         &mut self,
-        runnable_tasks: &[&Task],
+        runnable_tasks: &'a [&'a Task],
         current_task: Option<TaskId>,
         is_yielding: bool,
-    ) -> Option<TaskId>;
+    ) -> Option<&'a Task>;
 
     /// Choose the next u64 value to return to the currently running task.
     fn next_u64(&mut self) -> u64;
@@ -105,12 +105,12 @@ impl Scheduler for Box<dyn Scheduler + Send> {
         self.as_mut().new_execution()
     }
 
-    fn next_task(
+    fn next_task<'a>(
         &mut self,
-        runnable_tasks: &[&Task],
+        runnable_tasks: &'a [&'a Task],
         current_task: Option<TaskId>,
         is_yielding: bool,
-    ) -> Option<TaskId> {
+    ) -> Option<&'a Task> {
         self.as_mut().next_task(runnable_tasks, current_task, is_yielding)
     }
 

--- a/shuttle-engine/src/thread_support.rs
+++ b/shuttle-engine/src/thread_support.rs
@@ -1,13 +1,15 @@
 use crate::runtime::execution::ExecutionState;
+use crate::runtime::task::Event;
 use crate::runtime::thread;
 use std::marker::PhantomData;
 
 /// Cooperatively gives up a timeslice to the Shuttle scheduler.
+#[track_caller]
 pub fn yield_now() {
     let waker = ExecutionState::with(|state| state.current().waker());
     waker.wake_by_ref();
     ExecutionState::request_yield();
-    thread::switch();
+    thread::switch(Event::yield_now());
 }
 
 /// The body of a spawned thread. Runs `f`, drops thread locals, publishes result.
@@ -21,7 +23,7 @@ pub fn thread_fn<F, T>(
     let ret = f();
 
     if switch_before_exit && ExecutionState::with(|s| s.exit_current_truncates_execution()) {
-        thread::switch();
+        thread::switch(Event::Exit);
     }
 
     tracing::trace!("thread finished, dropping thread locals");

--- a/shuttle-schedulers/src/annotation.rs
+++ b/shuttle-schedulers/src/annotation.rs
@@ -23,14 +23,14 @@ impl<S: Scheduler> Scheduler for AnnotationScheduler<S> {
         self.0.new_execution()
     }
 
-    fn next_task(
+    fn next_task<'a>(
         &mut self,
-        runnable_tasks: &[&Task],
+        runnable_tasks: &'a [&'a Task],
         current_task: Option<TaskId>,
         is_yielding: bool,
-    ) -> Option<TaskId> {
+    ) -> Option<&'a Task> {
         let choice = self.0.next_task(runnable_tasks, current_task, is_yielding)?;
-        record_schedule(choice, runnable_tasks);
+        record_schedule(choice.id(), runnable_tasks);
         Some(choice)
     }
 

--- a/shuttle-schedulers/src/pct.rs
+++ b/shuttle-schedulers/src/pct.rs
@@ -110,7 +110,12 @@ impl Scheduler for PctScheduler {
         Some(Schedule::new(self.data_source.reinitialize()))
     }
 
-    fn next_task(&mut self, runnable: &[&Task], current: Option<TaskId>, is_yielding: bool) -> Option<TaskId> {
+    fn next_task<'a>(
+        &mut self,
+        runnable: &'a [&'a Task],
+        current: Option<TaskId>,
+        is_yielding: bool,
+    ) -> Option<&'a Task> {
         // If any new tasks were created, assign them priorities by randomly swapping them with an
         // existing task's priority, so we maintain the invariant that every priority is distinct
         let max_known_task = self.priorities.len();
@@ -155,11 +160,10 @@ impl Scheduler for PctScheduler {
 
         // Choose the highest-priority (== lowest priority value) runnable task
         Some(
-            runnable
+            *runnable
                 .iter()
                 .min_by_key(|t| self.priorities.get(&t.id()))
-                .expect("priority queue invariant")
-                .id(),
+                .expect("priority queue invariant"),
         )
     }
 

--- a/shuttle-schedulers/src/random.rs
+++ b/shuttle-schedulers/src/random.rs
@@ -91,8 +91,13 @@ impl Scheduler for RandomScheduler {
         }
     }
 
-    fn next_task(&mut self, runnable: &[&Task], _current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
-        Some(runnable.choose(&mut self.rng).unwrap().id())
+    fn next_task<'a>(
+        &mut self,
+        runnable: &'a [&'a Task],
+        _current: Option<TaskId>,
+        _is_yielding: bool,
+    ) -> Option<&'a Task> {
+        Some(*runnable.choose(&mut self.rng).unwrap())
     }
 
     fn next_u64(&mut self) -> u64 {

--- a/shuttle-schedulers/src/replay.rs
+++ b/shuttle-schedulers/src/replay.rs
@@ -76,7 +76,12 @@ impl Scheduler for ReplayScheduler {
         }
     }
 
-    fn next_task(&mut self, runnable: &[&Task], _current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
+    fn next_task<'a>(
+        &mut self,
+        runnable: &'a [&'a Task],
+        _current: Option<TaskId>,
+        _is_yielding: bool,
+    ) -> Option<&'a Task> {
         loop {
             if self.steps >= self.schedule.steps.len() {
                 assert!(self.allow_incomplete, "schedule ended early");
@@ -93,7 +98,7 @@ impl Scheduler for ReplayScheduler {
                             if task.clock <= *target_clock {
                                 // The target event causally depends on this
                                 // event, so we schedule it.
-                                return Some(next);
+                                return Some(*task);
                             } else {
                                 // The target event is concurrent with this
                                 // event, so it is irrelevant to the replay.
@@ -114,7 +119,7 @@ impl Scheduler for ReplayScheduler {
                                 continue;
                             }
                         } else {
-                            return Some(next);
+                            return Some(*task);
                         }
                     } else {
                         assert!(

--- a/shuttle-schedulers/src/round_robin.rs
+++ b/shuttle-schedulers/src/round_robin.rs
@@ -33,9 +33,14 @@ impl Scheduler for RoundRobinScheduler {
         }
     }
 
-    fn next_task(&mut self, runnable: &[&Task], current: Option<TaskId>, _is_yielding: bool) -> Option<TaskId> {
+    fn next_task<'a>(
+        &mut self,
+        runnable: &'a [&'a Task],
+        current: Option<TaskId>,
+        _is_yielding: bool,
+    ) -> Option<&'a Task> {
         if current.is_none() {
-            return Some(runnable.first().unwrap().id());
+            return Some(runnable.first().unwrap());
         }
         let current = current.unwrap();
 
@@ -43,8 +48,7 @@ impl Scheduler for RoundRobinScheduler {
             runnable
                 .iter()
                 .find(|t| t.id() > current)
-                .unwrap_or_else(|| runnable.first().unwrap())
-                .id(),
+                .unwrap_or_else(|| runnable.first().unwrap()),
         )
     }
 

--- a/shuttle-std/src/future.rs
+++ b/shuttle-std/src/future.rs
@@ -6,7 +6,7 @@
 //! [`futures::executor`]: https://docs.rs/futures/0.3.13/futures/executor/index.html
 
 use shuttle_engine::runtime::execution::ExecutionState;
-use shuttle_engine::runtime::task::TaskId;
+use shuttle_engine::runtime::task::{Event, TaskId};
 use shuttle_engine::runtime::thread;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -79,7 +79,8 @@ impl AbortHandle {
         // Scheduling point: the scheduler may run other tasks (including the target)
         // before the abort flag is set, creating interleavings where the task completes
         // normally despite an abort() call.
-        thread::switch();
+        // There is no `Event` variant for aborts, so this scheduling point is unlabelled.
+        thread::switch(Event::Unknown);
 
         // Signal the Wrapper to skip the inner future on the next poll.
         // If already aborted, skip the redundant wake.
@@ -145,7 +146,8 @@ impl<T> JoinHandle<T> {
         // Scheduling point: the scheduler may run other tasks (including the target)
         // before the abort flag is set, creating interleavings where the task completes
         // normally despite an abort() call.
-        thread::switch();
+        // There is no `Event` variant for aborts, so this scheduling point is unlabelled.
+        thread::switch(Event::Unknown);
 
         // Signal the Wrapper to skip the inner future on the next poll.
         // If already aborted, skip the redundant wake.
@@ -342,7 +344,7 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
             Poll::Ready(result) => break result,
             Poll::Pending => {
                 ExecutionState::with(|state| state.current_mut().sleep_unless_woken());
-                thread::switch();
+                thread::switch_keeping_current_event();
             }
         }
     }

--- a/shuttle-std/src/sync/atomic/bool.rs
+++ b/shuttle-std/src/sync/atomic/bool.rs
@@ -44,16 +44,19 @@ impl AtomicBool {
     }
 
     /// Loads a value from the atomic boolean.
+    #[track_caller]
     pub fn load(&self, order: Ordering) -> bool {
         self.inner.load(order)
     }
 
     /// Stores a value into the atomic boolean.
+    #[track_caller]
     pub fn store(&self, val: bool, order: Ordering) {
         self.inner.store(val, order)
     }
 
     /// Stores a value into the atomic boolean, returning the previous value.
+    #[track_caller]
     pub fn swap(&self, val: bool, order: Ordering) -> bool {
         self.inner.swap(val, order)
     }
@@ -61,6 +64,7 @@ impl AtomicBool {
     /// Fetches the value, and applies a function to it that returns an optional new value.
     /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some(_)`, else
     /// `Err(previous_value)`.
+    #[track_caller]
     pub fn fetch_update<F>(&self, set_order: Ordering, fetch_order: Ordering, f: F) -> Result<bool, bool>
     where
         F: FnMut(bool) -> Option<bool>,
@@ -71,6 +75,7 @@ impl AtomicBool {
     /// Stores a value into the atomic boolean if the current value is the same as the
     /// `current` value.
     #[deprecated(since = "0.0.6", note = "Use `compare_exchange` or `compare_exchange_weak` instead")]
+    #[track_caller]
     pub fn compare_and_swap(&self, current: bool, new: bool, order: Ordering) -> bool {
         match self.compare_exchange(current, new, order, order) {
             Ok(v) => v,
@@ -84,6 +89,7 @@ impl AtomicBool {
     /// The return value is a result indicating whether the new value was written and
     /// containing the previous value. On success this value is guaranteed to be equal to
     /// `current`.
+    #[track_caller]
     pub fn compare_exchange(
         &self,
         current: bool,
@@ -102,6 +108,7 @@ impl AtomicBool {
     /// platforms. The return value is a result indicating whether the new value was written
     /// and containing the previous value.
     // TODO actually produce spurious failures
+    #[track_caller]
     pub fn compare_exchange_weak(
         &self,
         current: bool,
@@ -113,21 +120,25 @@ impl AtomicBool {
     }
 
     /// Logical "and" with the current value. Returns the previous value.
+    #[track_caller]
     pub fn fetch_and(&self, val: bool, order: Ordering) -> bool {
         self.fetch_update(order, order, |old| Some(old & val)).unwrap()
     }
 
     /// Logical "nand" with the current value. Returns the previous value.
+    #[track_caller]
     pub fn fetch_nand(&self, val: bool, order: Ordering) -> bool {
         self.fetch_update(order, order, |old| Some(!(old & val))).unwrap()
     }
 
     /// Logical "or" with the current value. Returns the previous value.
+    #[track_caller]
     pub fn fetch_or(&self, val: bool, order: Ordering) -> bool {
         self.fetch_update(order, order, |old| Some(old | val)).unwrap()
     }
 
     /// Logical "xor" with the current value. Returns the previous value.
+    #[track_caller]
     pub fn fetch_xor(&self, val: bool, order: Ordering) -> bool {
         self.fetch_update(order, order, |old| Some(old ^ val)).unwrap()
     }

--- a/shuttle-std/src/sync/atomic/int.rs
+++ b/shuttle-std/src/sync/atomic/int.rs
@@ -46,16 +46,19 @@ macro_rules! atomic_int {
             }
 
             /// Loads a value from the atomic integer.
+            #[track_caller]
             pub fn load(&self, order: Ordering) -> $int_type {
                 self.inner.load(order)
             }
 
             /// Stores a value into the atomic integer.
+            #[track_caller]
             pub fn store(&self, val: $int_type, order: Ordering) {
                 self.inner.store(val, order)
             }
 
             /// Stores a value into the atomic integer, returning the previous value.
+            #[track_caller]
             pub fn swap(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.inner.swap(val, order)
             }
@@ -63,6 +66,7 @@ macro_rules! atomic_int {
             /// Fetches the value, and applies a function to it that returns an optional new value.
             /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some(_)`, else
             /// `Err(previous_value)`.
+            #[track_caller]
             pub fn fetch_update<F>(
                 &self,
                 set_order: Ordering,
@@ -81,6 +85,7 @@ macro_rules! atomic_int {
                 since = "0.0.6",
                 note = "Use `compare_exchange` or `compare_exchange_weak` instead"
             )]
+            #[track_caller]
             pub fn compare_and_swap(&self, current: $int_type, new: $int_type, order: Ordering) -> $int_type {
                 match self.compare_exchange(current, new, order, order) {
                     Ok(v) => v,
@@ -94,6 +99,7 @@ macro_rules! atomic_int {
             /// The return value is a result indicating whether the new value was written and
             /// containing the previous value. On success this value is guaranteed to be equal to
             /// `current`.
+            #[track_caller]
             pub fn compare_exchange(
                 &self,
                 current: $int_type,
@@ -112,6 +118,7 @@ macro_rules! atomic_int {
             /// The return value is a result indicating whether the new value was written and
             /// containing the previous value.
             // TODO actually produce spurious failures
+            #[track_caller]
             pub fn compare_exchange_weak(
                 &self,
                 current: $int_type,
@@ -125,6 +132,7 @@ macro_rules! atomic_int {
             /// Adds to the current value, returning the previous value.
             ///
             /// This operation wraps around on overflow.
+            #[track_caller]
             pub fn fetch_add(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old.wrapping_add(val)))
                     .unwrap()
@@ -133,37 +141,44 @@ macro_rules! atomic_int {
             /// Subtracts from the current value, returning the previous value.
             ///
             /// This operation wraps around on overflow.
+            #[track_caller]
             pub fn fetch_sub(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old.wrapping_sub(val)))
                     .unwrap()
             }
 
             /// Bitwise "and" with the current value. Returns the previous value.
+            #[track_caller]
             pub fn fetch_and(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old & val)).unwrap()
             }
 
             /// Bitwise "nand" with the current value. Returns the previous value.
+            #[track_caller]
             pub fn fetch_nand(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(!(old & val))).unwrap()
             }
 
             /// Bitwise "or" with the current value. Returns the previous value.
+            #[track_caller]
             pub fn fetch_or(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old | val)).unwrap()
             }
 
             /// Bitwise "xor" with the current value. Returns the previous value.
+            #[track_caller]
             pub fn fetch_xor(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old ^ val)).unwrap()
             }
 
             /// Maximum with the current value. Returns the previous value.
+            #[track_caller]
             pub fn fetch_max(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old.max(val))).unwrap()
             }
 
             /// Minimum with the current value. Returns the previous value.
+            #[track_caller]
             pub fn fetch_min(&self, val: $int_type, order: Ordering) -> $int_type {
                 self.fetch_update(order, order, |old| Some(old.min(val))).unwrap()
             }

--- a/shuttle-std/src/sync/atomic/mod.rs
+++ b/shuttle-std/src/sync/atomic/mod.rs
@@ -62,6 +62,7 @@ pub use std::sync::atomic::Ordering;
 use crate::sync::{ResourceSignature, ResourceType};
 use shuttle_engine::runtime::execution::ExecutionState;
 use shuttle_engine::runtime::task::clock::VectorClock;
+use shuttle_engine::runtime::task::Event;
 use shuttle_engine::runtime::thread;
 use shuttle_engine::silence_warnings;
 use std::cell::RefCell;
@@ -121,7 +122,6 @@ pub use std::sync::atomic::compiler_fence;
 struct Atomic<T> {
     inner: RefCell<T>,
     clock: RefCell<Option<VectorClock>>, // wrapped in option to support the const new()
-    #[allow(unused)]
     signature: ResourceSignature,
 }
 
@@ -159,34 +159,38 @@ impl<T: Copy + Eq> Atomic<T> {
         self.inner.into_inner()
     }
 
+    #[track_caller]
     fn load(&self, order: Ordering) -> T {
         maybe_warn_about_ordering(order);
 
-        thread::switch();
+        thread::switch(Event::atomic_read(&self.signature));
         self.exhale_clock();
         let value = *self.inner.borrow();
         value
     }
 
+    #[track_caller]
     fn store(&self, val: T, order: Ordering) {
         maybe_warn_about_ordering(order);
 
-        thread::switch();
+        thread::switch(Event::atomic_write(&self.signature));
         self.inhale_clock();
         *self.inner.borrow_mut() = val;
     }
 
+    #[track_caller]
     fn swap(&self, mut val: T, order: Ordering) -> T {
         maybe_warn_about_ordering(order);
 
         // swap behaves like { let x = load() ; store(val) ; x }
-        thread::switch();
+        thread::switch(Event::atomic_read_write(&self.signature));
         self.exhale_clock(); // for the load
         self.inhale_clock(); // for the store
         std::mem::swap(&mut *self.inner.borrow_mut(), &mut val);
         val
     }
 
+    #[track_caller]
     fn fetch_update<F>(&self, set_order: Ordering, fetch_order: Ordering, mut f: F) -> Result<T, T>
     where
         F: FnMut(T) -> Option<T>,
@@ -196,7 +200,7 @@ impl<T: Copy + Eq> Atomic<T> {
 
         // fetch_update behaves like (ignoring error): { let x = load() ; store(f(x)); x }
         // in the error case, there is no store, so the register does not inherit the clock of the caller
-        thread::switch();
+        thread::switch(Event::atomic_read_write(&self.signature));
         self.exhale_clock(); // for the load()
         let current = *self.inner.borrow();
         let ret = if let Some(new) = f(current) {

--- a/shuttle-std/src/sync/atomic/ptr.rs
+++ b/shuttle-std/src/sync/atomic/ptr.rs
@@ -49,16 +49,19 @@ impl<T> AtomicPtr<T> {
     }
 
     /// Loads a value from the pointer.
+    #[track_caller]
     pub fn load(&self, order: Ordering) -> *mut T {
         self.inner.load(order)
     }
 
     /// Stores a value into the pointer.
+    #[track_caller]
     pub fn store(&self, val: *mut T, order: Ordering) {
         self.inner.store(val, order)
     }
 
     /// Stores a value into the atomic pointer, returning the previous value.
+    #[track_caller]
     pub fn swap(&self, val: *mut T, order: Ordering) -> *mut T {
         self.inner.swap(val, order)
     }
@@ -66,6 +69,7 @@ impl<T> AtomicPtr<T> {
     /// Fetches the value, and applies a function to it that returns an optional new value.
     /// Returns a `Result` of `Ok(previous_value)` if the function returned `Some(_)`, else
     /// `Err(previous_value)`.
+    #[track_caller]
     pub fn fetch_update<F>(&self, set_order: Ordering, fetch_order: Ordering, f: F) -> Result<*mut T, *mut T>
     where
         F: FnMut(*mut T) -> Option<*mut T>,
@@ -76,6 +80,7 @@ impl<T> AtomicPtr<T> {
     /// Stores a value into the atomic pointer if the current value is the same as the
     /// `current` value.
     #[deprecated(since = "0.0.6", note = "Use `compare_exchange` or `compare_exchange_weak` instead")]
+    #[track_caller]
     pub fn compare_and_swap(&self, current: *mut T, new: *mut T, order: Ordering) -> *mut T {
         match self.compare_exchange(current, new, order, order) {
             Ok(v) => v,
@@ -89,6 +94,7 @@ impl<T> AtomicPtr<T> {
     /// The return value is a result indicating whether the new value was written and
     /// containing the previous value. On success this value is guaranteed to be equal to
     /// `current`.
+    #[track_caller]
     pub fn compare_exchange(
         &self,
         current: *mut T,
@@ -107,6 +113,7 @@ impl<T> AtomicPtr<T> {
     /// platforms. The return value is a result indicating whether the new value was written
     /// and containing the previous value.
     // TODO actually produce spurious failures
+    #[track_caller]
     pub fn compare_exchange_weak(
         &self,
         current: *mut T,

--- a/shuttle-std/src/sync/barrier.rs
+++ b/shuttle-std/src/sync/barrier.rs
@@ -1,7 +1,7 @@
 use crate::sync::{ResourceSignature, ResourceType};
 use shuttle_engine::runtime::execution::ExecutionState;
 use shuttle_engine::runtime::task::clock::VectorClock;
-use shuttle_engine::runtime::task::TaskId;
+use shuttle_engine::runtime::task::{Event, TaskId};
 use shuttle_engine::runtime::thread;
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -72,7 +72,6 @@ impl fmt::Debug for BarrierState {
 /// A barrier enables multiple threads to synchronize the beginning of some computation.
 pub struct Barrier {
     state: Rc<RefCell<BarrierState>>,
-    #[allow(unused)]
     signature: ResourceSignature,
 }
 
@@ -97,6 +96,7 @@ impl Barrier {
     }
 
     /// Blocks the current thread until all threads have rendezvoused here.
+    #[track_caller]
     pub fn wait(&self) -> BarrierWaitResult {
         let state = self.state.borrow_mut();
         // The barrier will block if the number of current waiters *plus* an additional waiter
@@ -114,7 +114,7 @@ impl Barrier {
         // `Y1 Z` and `Z Y1`, the state of the barrier is {T1, T2}. As a result, we never need to
         // switch before blocking on a barrier wait.
         if !will_block {
-            thread::switch();
+            thread::switch(Event::barrier_wait(&self.signature));
         }
         let mut state = self.state.borrow_mut();
         let my_epoch = state.epoch;
@@ -134,7 +134,7 @@ impl Barrier {
             trace!(waiters=?state.waiters, epoch=my_epoch, "blocked on barrier {:?}", self);
             drop(state);
             ExecutionState::with(|s| s.current_mut().block(false));
-            thread::switch();
+            thread::switch(Event::barrier_wait(&self.signature));
         } else {
             trace!(waiters=?state.waiters, epoch=my_epoch, "releasing waiters on barrier {:?}", self);
 

--- a/shuttle-std/src/sync/condvar.rs
+++ b/shuttle-std/src/sync/condvar.rs
@@ -3,7 +3,7 @@ use assoc::AssocExt;
 use shuttle_engine::current;
 use shuttle_engine::runtime::execution::ExecutionState;
 use shuttle_engine::runtime::task::clock::VectorClock;
-use shuttle_engine::runtime::task::TaskId;
+use shuttle_engine::runtime::task::{Event, TaskId};
 use shuttle_engine::runtime::thread;
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -16,7 +16,6 @@ use tracing::trace;
 #[derive(Debug)]
 pub struct Condvar {
     state: RefCell<CondvarState>,
-    #[allow(unused)]
     signature: ResourceSignature,
 }
 
@@ -131,6 +130,7 @@ impl Condvar {
     }
 
     /// Blocks the current thread until this condition variable receives a notification.
+    #[track_caller]
     pub fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> LockResult<MutexGuard<'a, T>> {
         let me = ExecutionState::me();
 
@@ -152,7 +152,7 @@ impl Condvar {
 
         // TODO: Condvar::wait should allow for spurious wakeups.
         ExecutionState::with(|s| s.current_mut().block(false));
-        thread::switch();
+        thread::switch(Event::condvar_wait(&self.signature));
 
         // After the context switch, consume whichever signal that woke this thread
         let mut state = self.state.borrow_mut();
@@ -240,8 +240,9 @@ impl Condvar {
     ///
     /// If there is a blocked thread on this condition variable, then it will be woken up from its
     /// call to wait or wait_timeout. Calls to notify_one are not buffered in any way.
+    #[track_caller]
     pub fn notify_one(&self) {
-        thread::switch();
+        thread::switch(Event::condvar_notify());
 
         let me = ExecutionState::me();
 
@@ -277,8 +278,9 @@ impl Condvar {
     }
 
     /// Wakes up all blocked threads on this condvar.
+    #[track_caller]
     pub fn notify_all(&self) {
-        thread::switch();
+        thread::switch(Event::condvar_notify());
 
         let me = ExecutionState::me();
 

--- a/shuttle-std/src/sync/mpsc.rs
+++ b/shuttle-std/src/sync/mpsc.rs
@@ -3,7 +3,7 @@
 use crate::sync::{ResourceSignature, ResourceType};
 use shuttle_engine::runtime::execution::ExecutionState;
 use shuttle_engine::runtime::task::clock::VectorClock;
-use shuttle_engine::runtime::task::{TaskId, DEFAULT_INLINE_TASKS};
+use shuttle_engine::runtime::task::{Event, TaskId, DEFAULT_INLINE_TASKS};
 use shuttle_engine::runtime::thread;
 use smallvec::SmallVec;
 use std::cell::RefCell;
@@ -47,7 +47,6 @@ pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
 struct Channel<T> {
     bound: Option<usize>, // None for an unbounded channel, Some(k) for a bounded channel of size k
     state: Rc<RefCell<ChannelState<T>>>,
-    #[allow(unused)]
     signature: ResourceSignature,
 }
 
@@ -134,10 +133,12 @@ impl<T> Channel<T> {
         }
     }
 
+    #[track_caller]
     fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
         self.send_internal(message, false)
     }
 
+    #[track_caller]
     fn send(&self, message: T) -> Result<(), SendError<T>> {
         self.send_internal(message, true).map_err(|e| match e {
             TrySendError::Full(_) => unreachable!(),
@@ -166,10 +167,11 @@ impl<T> Channel<T> {
         is_full || !state.waiting_senders.is_empty() || (is_rendezvous && state.waiting_receivers.is_empty())
     }
 
+    #[track_caller]
     fn send_internal(&self, message: T, can_block: bool) -> Result<(), TrySendError<T>> {
         // Because channels are always fair wrt. waiting senders (waiting senders is an *ordered* list),
         // blocking sends do not commute thus must always provide a switch before blocking
-        thread::switch();
+        thread::switch(Event::channel_send(&self.signature));
 
         let me = ExecutionState::me();
         let mut state = self.state.borrow_mut();
@@ -201,7 +203,7 @@ impl<T> Channel<T> {
             ExecutionState::with(|s| s.current_mut().block(false));
             drop(state);
 
-            thread::switch();
+            thread::switch(Event::channel_send(&self.signature));
 
             state = self.state.borrow_mut();
             trace!(
@@ -259,6 +261,7 @@ impl<T> Channel<T> {
         Ok(())
     }
 
+    #[track_caller]
     fn recv(&self) -> Result<T, RecvError> {
         self.recv_internal(true).map_err(|e| match e {
             TryRecvError::Disconnected => RecvError,
@@ -266,6 +269,7 @@ impl<T> Channel<T> {
         })
     }
 
+    #[track_caller]
     fn try_recv(&self) -> Result<T, TryRecvError> {
         self.recv_internal(false)
     }
@@ -277,10 +281,11 @@ impl<T> Channel<T> {
         state.messages.is_empty() || !state.waiting_receivers.is_empty()
     }
 
+    #[track_caller]
     fn recv_internal(&self, can_block: bool) -> Result<T, TryRecvError> {
         // Because channels are always fair wrt. waiting receivers (waiting receivers is an *ordered* list),
         // blocking receives do not commute thus must always provide a switch before blocking
-        thread::switch();
+        thread::switch(Event::channel_recv(&self.signature));
 
         let me = ExecutionState::me();
         let mut state = self.state.borrow_mut();
@@ -339,7 +344,7 @@ impl<T> Channel<T> {
             ExecutionState::with(|s| s.current_mut().block(false));
             drop(state);
 
-            thread::switch();
+            thread::switch(Event::channel_recv(&self.signature));
 
             state = self.state.borrow_mut();
             trace!(

--- a/shuttle-std/src/sync/mutex.rs
+++ b/shuttle-std/src/sync/mutex.rs
@@ -2,7 +2,7 @@ use crate::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
 use crate::sync::{ResourceSignature, ResourceType};
 use shuttle_engine::current;
 use shuttle_engine::future::batch_semaphore::{BatchSemaphore, Fairness};
-use shuttle_engine::runtime::task::TaskId;
+use shuttle_engine::runtime::task::{Event, TaskId};
 use shuttle_engine::runtime::thread;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
@@ -69,7 +69,7 @@ impl<T: ?Sized> Mutex<T> {
             self.semaphore.acquire_blocking(1).unwrap();
         } else {
             // we always need to allow for a context switch to make the previous event visible for completeness
-            thread::switch();
+            thread::switch(Event::Unknown);
         }
 
         state = self.state.borrow_mut();

--- a/shuttle-std/src/sync/rwlock.rs
+++ b/shuttle-std/src/sync/rwlock.rs
@@ -1,7 +1,7 @@
 use crate::sync::{ResourceSignature, ResourceType};
 use shuttle_engine::future::batch_semaphore::{BatchSemaphore, Fairness};
 use shuttle_engine::runtime::execution::ExecutionState;
-use shuttle_engine::runtime::task::{TaskId, TaskSet};
+use shuttle_engine::runtime::task::{Event, TaskId, TaskSet};
 use shuttle_engine::runtime::thread;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
@@ -218,7 +218,7 @@ impl<T: ?Sized> RwLock<T> {
             self.semaphore.acquire_blocking(typ.num_permits()).unwrap();
         } else {
             // we always need to allow for a context switch to make the previous event visible for completeness
-            thread::switch();
+            thread::switch(Event::Unknown);
         }
 
         state = self.state.borrow_mut();

--- a/shuttle-std/src/thread.rs
+++ b/shuttle-std/src/thread.rs
@@ -1,7 +1,7 @@
 //! Shuttle's implementation of [`std::thread`].
 
 use shuttle_engine::runtime::execution::ExecutionState;
-use shuttle_engine::runtime::task::TaskId;
+use shuttle_engine::runtime::task::{Event, TaskId};
 use shuttle_engine::runtime::thread;
 use std::marker::PhantomData;
 use std::panic::Location;
@@ -42,8 +42,10 @@ impl Thread {
     }
 
     /// Atomically makes the handle's token available if it is not already.
+    #[track_caller]
     pub fn unpark(&self) {
-        thread::switch();
+        let target_task_signature = ExecutionState::with(|s| s.get(self.id.task_id).signature.clone());
+        thread::switch(Event::unpark(&target_task_signature));
 
         ExecutionState::with(|s| {
             s.get_mut(self.id.task_id).unpark();
@@ -91,7 +93,7 @@ impl<'scope> Scope<'scope, '_> {
                 let ret = f();
 
                 if ExecutionState::with(|s| s.exit_current_truncates_execution()) {
-                    thread::switch();
+                    thread::switch(Event::Exit);
                 }
 
                 finished.store(true, Ordering::Relaxed);
@@ -121,6 +123,7 @@ impl<'scope> Scope<'scope, '_> {
 ///
 /// The function passed to `scope` will be provided a [`Scope`] object,
 /// through which scoped threads can be [spawned][`Scope::spawn`].
+#[track_caller]
 pub fn scope<'env, F, T>(f: F) -> T
 where
     F: for<'scope> FnOnce(&'scope Scope<'scope, 'env>) -> T,
@@ -137,7 +140,7 @@ where
     if scope.num_running_threads.load(Ordering::Relaxed) != 0 {
         tracing::info!("thread blocked, waiting for completion of scoped threads");
         ExecutionState::with(|s| s.current_mut().block(false));
-        thread::switch();
+        thread::switch(Event::park());
     }
 
     ret
@@ -257,11 +260,13 @@ unsafe impl<T> Sync for JoinHandle<T> {}
 
 impl<T> JoinHandle<T> {
     /// Waits for the associated thread to finish.
+    #[track_caller]
     pub fn join(self) -> Result<T> {
+        let target_task_signature = ExecutionState::with(|s| s.get(self.task_id).signature.clone());
         let is_finished = ExecutionState::with(|state| state.get(self.task_id).finished());
         // If the joinee task is finished then the joiner will not block
         if is_finished {
-            thread::switch();
+            thread::switch(Event::join(&target_task_signature));
         }
 
         let should_block = ExecutionState::with(|state| {
@@ -276,7 +281,7 @@ impl<T> JoinHandle<T> {
         });
 
         if should_block {
-            thread::switch();
+            thread::switch(Event::join(&target_task_signature));
         }
 
         // Waiting thread inherits the clock of the finished thread
@@ -299,17 +304,19 @@ impl<T> JoinHandle<T> {
 ///
 /// Some Shuttle schedulers use this as a hint to deprioritize the current thread in order for other
 /// threads to make progress (e.g., in a spin loop).
+#[track_caller]
 pub fn yield_now() {
     let waker = ExecutionState::with(|state| state.current().waker());
     waker.wake_by_ref();
     ExecutionState::request_yield();
-    thread::switch();
+    thread::switch(Event::yield_now());
 }
 
 /// Puts the current thread to sleep for at least the specified amount of time.
 // Note that Shuttle does not model time, so this behaves just like a context switch.
+#[track_caller]
 pub fn sleep(_dur: Duration) {
-    thread::switch();
+    thread::switch(Event::sleep());
 }
 
 /// Get a handle to the thread that invokes it
@@ -326,6 +333,7 @@ pub fn current() -> Thread {
 }
 
 /// Blocks unless or until the current thread's token is made available (may wake spuriously).
+#[track_caller]
 pub fn park() {
     let switch = ExecutionState::with(|s| s.current_mut().park());
 
@@ -337,7 +345,7 @@ pub fn park() {
     // context would result in spurious wakeups triggering nearly every time.
     if switch {
         ExecutionState::request_yield();
-        thread::switch();
+        thread::switch(Event::park());
     }
 }
 

--- a/shuttle/tests/basic/execution.rs
+++ b/shuttle/tests/basic/execution.rs
@@ -125,17 +125,17 @@ fn max_steps_early_exit_scheduler() {
             }
         }
 
-        fn next_task(
+        fn next_task<'a>(
             &mut self,
-            runnable_tasks: &[&Task],
+            runnable_tasks: &'a [&'a Task],
             _current_task: Option<TaskId>,
             _is_yielding: bool,
-        ) -> Option<TaskId> {
+        ) -> Option<&'a Task> {
             if self.steps >= self.max_steps {
                 None
             } else {
                 self.steps += 1;
-                Some(runnable_tasks.first().unwrap().id())
+                Some(runnable_tasks.first().unwrap())
             }
         }
 

--- a/shuttle/tests/basic/timeout.rs
+++ b/shuttle/tests/basic/timeout.rs
@@ -25,12 +25,12 @@ impl<S: Scheduler> Scheduler for SleepableScheduler<S> {
         self.scheduler.new_execution()
     }
 
-    fn next_task(
+    fn next_task<'a>(
         &mut self,
-        runnable_tasks: &[&Task],
+        runnable_tasks: &'a [&'a Task],
         current_task: Option<TaskId>,
         is_yielding: bool,
-    ) -> Option<TaskId> {
+    ) -> Option<&'a Task> {
         self.scheduler.next_task(runnable_tasks, current_task, is_yielding)
     }
 


### PR DESCRIPTION
Currently, Shuttle schedulers have no visibility into the system under test. The algorithms only see which tasks are enabled at a given time, not what those tasks are actually doing. This lack of semantic information greatly limits what we can do with Shuttle schedulers. Many algorithms, such as Partial Order Sampling (POS) and Selective Uniform Random Walk (SURW) leverage information about the events being executed to make better scheduling decisions (e.g. make a different decision if two events conflict, or if a particular task is accessing a resource “of interest”). Such information is also useful for developing a general notion of behavioral coverage — for example, tracking new reads-from edges.

This PR adds a `next_event` field to the Task struct, which is accessible to scheduling algorithms. The Event enum gives the schedulers access to the signature of the resource being accessed, as well as the source location of the access (via `track_caller`).

As a small "demo" application, I also modified the Metrics scheduler to count the number and kind of events observed during a Shuttle test. As part of this demo, I did make some light changes to the Scheduler API so that it returns a &Task instead of a TaskId. This change allows nested schedulers such as the Metrics scheduler to directly lookup information about the task chosen by inner schedulers without iterating over the runnable tasks.

Note: this PR does use some unsafe lifetime casting to allow Task to hold a reference to the Task/Resource signatures. Just outright cloning the signatures is maybe  ~5-8% slower in the worst case. I'm open to discussion/suggestions here, but I think the other approaches to avoid cloning without unsafe might end up being significantly more complicated than the unsafe code without much real benefit. In particular, using `Rc<_>` for signatures requires heap allocations on initialization, while many resource constructors are `const`. Note that this is similar to the unsafe added for the runnable tasks slice, and, as in that case, we are providing a safe API to the scheduling algorithms.

I am marking this as a draft for now because it depends on ~~two other open PRs (#207 and #210)~~ #216.

~~It currently includes the changes from these other PRs. To look at the changes unique to this PR, see 4778a31461c74077ea6ab49ebec82bbd69393dfd~~

I've rebased this on #216, will mark as ready for review as soon as that is merged

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.