### PR TITLE
Better instrument backtraces for blocked futures

### DIFF
--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -1,9 +1,9 @@
 //! A counting semaphore supporting both async and sync operations.
-use crate::current;
 use crate::runtime::execution::ExecutionState;
 use crate::runtime::task::{clock::VectorClock, TaskId};
 use crate::runtime::thread;
 use crate::sync_types::{ResourceSignature, ResourceType};
+use crate::{backtrace_enabled, current};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt;
@@ -790,7 +790,7 @@ impl Future for Acquire<'_> {
         }
         self.never_polled = false;
 
-        if self.waiter.has_permits.load(Ordering::SeqCst) {
+        let out = if self.waiter.has_permits.load(Ordering::SeqCst) {
             assert!(!self.waiter.is_queued.load(Ordering::SeqCst));
             self.completed = true;
             trace!("Acquire::poll for waiter {:?} with permits", self.waiter);
@@ -894,7 +894,18 @@ impl Future for Acquire<'_> {
                 self.waiter.set_task_id(ExecutionState::me());
                 Poll::Pending
             }
+        };
+        if matches!(out, Poll::Pending) {
+            // `Backtrace::capture()` is a noop (it returns the constant `disabled()`) if `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE` is not set.
+            ExecutionState::with(|state| {
+                state.current_mut().backtrace = if backtrace_enabled() {
+                    Some(std::backtrace::Backtrace::force_capture())
+                } else {
+                    None
+                }
+            })
         }
+        out
     }
 }
 

--- a/shuttle-engine/src/runtime/task/mod.rs
+++ b/shuttle-engine/src/runtime/task/mod.rs
@@ -508,12 +508,6 @@ impl Task {
     }
 
     pub fn sleep(&mut self) {
-        self.backtrace = if backtrace_enabled() {
-            Some(Backtrace::force_capture())
-        } else {
-            None
-        };
-
         assert!(self.state != TaskState::Finished);
         self.state = TaskState::Sleeping;
     }

--- a/shuttle-std/src/future.rs
+++ b/shuttle-std/src/future.rs
@@ -5,6 +5,7 @@
 //!
 //! [`futures::executor`]: https://docs.rs/futures/0.3.13/futures/executor/index.html
 
+use shuttle_engine::backtrace_enabled;
 use shuttle_engine::runtime::execution::ExecutionState;
 use shuttle_engine::runtime::task::TaskId;
 use shuttle_engine::runtime::thread;
@@ -225,6 +226,15 @@ impl<T> Future for JoinHandle<T> {
             Poll::Ready(result)
         } else {
             lock.waker = Some(cx.waker().clone());
+
+            ExecutionState::with(|state| {
+                state.current_mut().backtrace = if backtrace_enabled() {
+                    Some(std::backtrace::Backtrace::force_capture())
+                } else {
+                    None
+                }
+            });
+
             Poll::Pending
         }
     }


### PR DESCRIPTION
Improves the backtrace output for blocked futures by instrumenting `JoinHandle` and `Acquire` instead of `sleep`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.