### PR TITLE
Adding global config for Shuttle

### DIFF
--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -27,6 +27,7 @@ regex = { version = "1.10.6", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 const-siphasher = "1.0.2"
+config = { version = "0.15.18", default-features = false, features = ["toml"] }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }

--- a/shuttle/shuttle_config_example.toml
+++ b/shuttle/shuttle_config_example.toml
@@ -1,0 +1,62 @@
+# Shuttle Configuration Example
+# This file demonstrates available configuration options for Shuttle
+
+# Stack size for each thread (in bytes)
+stack_size = 32768
+
+# How to persist failing schedules: "none", "print", or "file"
+failure_persistence = "print"
+
+# Optional: Directory path for file persistence (only used when failure_persistence = "file")
+# failure_persistence_path = "./shuttle_failures"
+
+# Maximum number of steps before taking action (0 means no limit when max_steps_behavior = "none")
+max_steps = 1000000
+
+# What to do when max_steps is reached: "fail", "continue", or "none"
+max_steps_behavior = "fail"
+
+# Optional: Maximum time in seconds for a single test iteration
+# max_time_secs = 60
+
+# Suppress warning messages
+silence_warnings = false
+
+# Record execution steps in tracing spans
+record_steps_in_span = false
+
+# Return immediately when a panic occurs (vs continuing to explore other schedules)
+immediately_return_on_panic = false
+
+# Enable metrics collection
+enable_metrics = false
+
+# Check for uncontrolled nondeterminism
+check_uncontrolled_nondeterminism = false
+
+# Scheduler configuration
+[scheduler]
+# Scheduler type: "random", "pct", "dfs", "replay", "round_robin", or "urw"
+# Additional schedulers can be registered using the scheduler registry
+type = "random"
+
+# Number of iterations to run
+iterations = 100
+
+# Optional: Random seed for reproducible runs
+seed = 42
+
+# PCT-specific: Number of priority change points
+depth = 3
+
+# DFS-specific: Maximum iterations before stopping
+max_iterations = 10000
+
+# DFS-specific: Allow random data generation
+allow_random_data = false
+
+# Replay-specific: Path to schedule file
+schedule_file = "./schedule.json"
+
+# Replay-specific: Inline schedule string
+schedule = "..."

--- a/shuttle/src/scheduler/dfs.rs
+++ b/shuttle/src/scheduler/dfs.rs
@@ -38,6 +38,13 @@ impl DfsScheduler {
         }
     }
 
+    /// Construct a new DfsScheduler from configuration.
+    pub fn from_config(config: &config::Config) -> Self {
+        let max_iterations = config.get_int("scheduler.max_iterations").ok().map(|i| i as usize);
+        let allow_random_data = config.get_bool("scheduler.allow_random_data").unwrap_or(false);
+        Self::new(max_iterations, allow_random_data)
+    }
+
     /// Check if there are any scheduling points at or below the `index`th level that have remaining
     /// schedulable tasks to explore.
     // TODO probably should memoize this -- at each iteration, just need to know the largest i

--- a/shuttle/src/scheduler/mod.rs
+++ b/shuttle/src/scheduler/mod.rs
@@ -6,6 +6,8 @@ mod data;
 mod dfs;
 mod pct;
 mod random;
+/// Global registry for custom schedulers
+pub mod registry;
 mod replay;
 mod round_robin;
 mod uncontrolled_nondeterminism;

--- a/shuttle/src/scheduler/pct.rs
+++ b/shuttle/src/scheduler/pct.rs
@@ -38,6 +38,17 @@ impl PctScheduler {
         Self::new_from_seed(OsRng.next_u64(), max_depth, max_iterations)
     }
 
+    /// Construct a new PctScheduler from configuration.
+    pub fn from_config(config: &config::Config) -> Self {
+        let depth = config.get_int("scheduler.depth").unwrap_or(3) as usize;
+        let iterations = config.get_int("scheduler.iterations").unwrap_or(100) as usize;
+        if let Ok(seed) = config.get_int("scheduler.seed") {
+            Self::new_from_seed(seed as u64, depth, iterations)
+        } else {
+            Self::new(depth, iterations)
+        }
+    }
+
     /// Construct a new PCTScheduler with a given seed.
     ///
     /// If the `SHUTTLE_RANDOM_SEED` environment variable is set, then that seed will be used instead.

--- a/shuttle/src/scheduler/random.rs
+++ b/shuttle/src/scheduler/random.rs
@@ -52,6 +52,16 @@ impl RandomScheduler {
         Self::new_from_seed(OsRng.next_u64(), max_iterations)
     }
 
+    /// Construct a new RandomScheduler from configuration.
+    pub fn from_config(config: &config::Config) -> Self {
+        let iterations = config.get_int("scheduler.iterations").unwrap_or(100) as usize;
+        if let Ok(seed) = config.get_int("scheduler.seed") {
+            Self::new_from_seed(seed as u64, iterations)
+        } else {
+            Self::new(iterations)
+        }
+    }
+
     /// Construct a new RandomScheduler with a given seed.
     ///
     /// Two RandomSchedulers initialized with the same seed will make the same scheduling decisions

--- a/shuttle/src/scheduler/registry.rs
+++ b/shuttle/src/scheduler/registry.rs
@@ -1,0 +1,98 @@
+use crate::scheduler::{
+    DfsScheduler, PctScheduler, RandomScheduler, ReplayScheduler, RoundRobinScheduler, Scheduler, UrwRandomScheduler,
+};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Factory function type for creating schedulers from configuration
+pub type SchedulerFactory = Arc<dyn Fn(&config::Config) -> Box<dyn Scheduler + Send> + Send + Sync>;
+
+static REGISTRY: OnceLock<Mutex<HashMap<String, SchedulerFactory>>> = OnceLock::new();
+
+fn get_registry() -> &'static Mutex<HashMap<String, SchedulerFactory>> {
+    REGISTRY.get_or_init(|| {
+        let mut map = HashMap::new();
+
+        // Register built-in schedulers
+        map.insert(
+            "random".to_string(),
+            Arc::new(|config: &config::Config| {
+                Box::new(RandomScheduler::from_config(config)) as Box<dyn Scheduler + Send>
+            }) as SchedulerFactory,
+        );
+
+        map.insert(
+            "dfs".to_string(),
+            Arc::new(|config: &config::Config| Box::new(DfsScheduler::from_config(config)) as Box<dyn Scheduler + Send>)
+                as SchedulerFactory,
+        );
+
+        map.insert(
+            "roundrobin".to_string(),
+            Arc::new(|config: &config::Config| {
+                Box::new(RoundRobinScheduler::from_config(config)) as Box<dyn Scheduler + Send>
+            }) as SchedulerFactory,
+        );
+
+        map.insert(
+            "urw".to_string(),
+            Arc::new(|config: &config::Config| {
+                Box::new(UrwRandomScheduler::from_config(config)) as Box<dyn Scheduler + Send>
+            }) as SchedulerFactory,
+        );
+
+        map.insert(
+            "pct".to_string(),
+            Arc::new(|config: &config::Config| Box::new(PctScheduler::from_config(config)) as Box<dyn Scheduler + Send>)
+                as SchedulerFactory,
+        );
+
+        map.insert(
+            "replay".to_string(),
+            Arc::new(|config: &config::Config| {
+                Box::new(ReplayScheduler::from_config(config)) as Box<dyn Scheduler + Send>
+            }) as SchedulerFactory,
+        );
+
+        Mutex::new(map)
+    })
+}
+
+/// Register a custom scheduler factory with the global registry
+///
+/// # Example
+///
+/// ```no_run
+/// use shuttle::{register_scheduler, scheduler::Scheduler};
+/// use config::Config;
+///
+/// struct MyScheduler;
+/// impl Scheduler for MyScheduler {
+///     // ... implementation
+/// #   fn new_execution(&mut self) -> Option<shuttle::scheduler::Schedule> { None }
+/// #   fn next_task(&mut self, _: &[&shuttle::scheduler::Task], _: Option<shuttle::scheduler::TaskId>, _: bool) -> Option<shuttle::scheduler::TaskId> { None }
+/// #   fn next_u64(&mut self) -> u64 { 0 }
+/// }
+///
+/// register_scheduler("my_scheduler", |config| {
+///     let iterations = config.get_int("scheduler.iterations").unwrap_or(100) as usize;
+///     Box::new(MyScheduler)
+/// });
+/// ```
+pub fn register_scheduler<F>(name: &str, factory: F)
+where
+    F: Fn(&config::Config) -> Box<dyn Scheduler + Send> + Send + Sync + 'static,
+{
+    let registry = get_registry();
+    let mut map = registry.lock().unwrap();
+    map.insert(name.to_string(), Arc::new(factory));
+}
+
+/// Create a scheduler from the registry
+pub(crate) fn create_scheduler(name: &str, config: &config::Config) -> Box<dyn Scheduler + Send> {
+    let registry = get_registry();
+    let map = registry.lock().unwrap();
+    map.get(name)
+        .map(|factory| factory(config))
+        .expect("Could not create scheduler")
+}

--- a/shuttle/src/scheduler/replay.rs
+++ b/shuttle/src/scheduler/replay.rs
@@ -21,6 +21,18 @@ pub struct ReplayScheduler {
 }
 
 impl ReplayScheduler {
+    /// Construct a new ReplayScheduler from configuration.
+    pub fn from_config(config: &config::Config) -> Self {
+        if let Ok(path) = config.get_string("scheduler.schedule_file") {
+            Self::new_from_file(path).expect("failed to load schedule from file")
+        } else {
+            let schedule = config
+                .get_string("scheduler.schedule")
+                .expect("replay scheduler requires 'scheduler.schedule' or 'scheduler.schedule_file' config");
+            Self::new_from_encoded(&schedule)
+        }
+    }
+
     /// Given an encoded schedule, construct a new [`ReplayScheduler`] that will execute threads in
     /// the order specified in the schedule.
     pub fn new_from_encoded(encoded_schedule: &str) -> Self {

--- a/shuttle/src/scheduler/round_robin.rs
+++ b/shuttle/src/scheduler/round_robin.rs
@@ -21,6 +21,12 @@ impl RoundRobinScheduler {
             data_source: RandomDataSource::initialize(0),
         }
     }
+
+    /// Construct a new RoundRobinScheduler from configuration.
+    pub fn from_config(config: &config::Config) -> Self {
+        let iterations = config.get_int("scheduler.iterations").unwrap_or(1) as usize;
+        Self::new(iterations)
+    }
 }
 
 impl Scheduler for RoundRobinScheduler {

--- a/shuttle/src/scheduler/urw.rs
+++ b/shuttle/src/scheduler/urw.rs
@@ -60,6 +60,16 @@ impl UrwRandomScheduler {
         Self::new_from_seed(OsRng.next_u64(), max_iterations)
     }
 
+    /// Construct a new UrwRandomScheduler from configuration.
+    pub fn from_config(config: &config::Config) -> Self {
+        let iterations = config.get_int("scheduler.iterations").unwrap_or(100) as usize;
+        if let Ok(seed) = config.get_int("scheduler.seed") {
+            Self::new_from_seed(seed as u64, iterations)
+        } else {
+            Self::new(iterations)
+        }
+    }
+
     /// Construct a UniformRandomScheduler with a given seed.
     /// Two UniformRandomSchedulers initialized with the same seed will make the same scheduling decisions when executing the same workloads.
     /// If the `SHUTTLE_RANDOM_SEED` environment variable is set, then that seed will be used instead.

--- a/shuttle/tests/basic/execution.rs
+++ b/shuttle/tests/basic/execution.rs
@@ -1,6 +1,6 @@
 use shuttle::{
-    check, check_dfs, current,
-    scheduler::{DfsScheduler, RandomScheduler},
+    check_dfs, current,
+    scheduler::{DfsScheduler, RandomScheduler, RoundRobinScheduler},
     thread, Config, MaxSteps, Runner,
 };
 use std::panic::{catch_unwind, AssertUnwindSafe};
@@ -15,7 +15,9 @@ fn basic_scheduler_test() {
     let counter = Arc::new(AtomicUsize::new(0));
     let counter_clone = Arc::clone(&counter);
 
-    check(move || {
+    let runner = Runner::new(RoundRobinScheduler::new(1), Default::default());
+
+    runner.run(move || {
         counter.fetch_add(1, Ordering::SeqCst);
         let counter_clone = Arc::clone(&counter);
         thread::spawn(move || {

--- a/shuttle/tests/basic/rwlock.rs
+++ b/shuttle/tests/basic/rwlock.rs
@@ -1,6 +1,6 @@
-use shuttle::scheduler::PctScheduler;
+use shuttle::scheduler::{PctScheduler, RoundRobinScheduler};
 use shuttle::sync::{mpsc::channel, RwLock};
-use shuttle::{check, check_dfs, check_random, thread, Runner};
+use shuttle::{check_dfs, check_random, thread, Runner};
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, TryLockError};
@@ -77,8 +77,10 @@ fn deadlock() {
 #[test]
 #[should_panic(expected = "deadlock")]
 fn deadlock_default() {
+    let runner = Runner::new(RoundRobinScheduler::new(1), Default::default());
+
     // Round-robin should always fail this deadlock test
-    check(deadlock);
+    runner.run(deadlock);
 }
 
 #[test]

--- a/shuttle/tests/config/mod.rs
+++ b/shuttle/tests/config/mod.rs
@@ -1,0 +1,204 @@
+use shuttle::scheduler::{DfsScheduler, PctScheduler, RandomScheduler, UrwRandomScheduler};
+use shuttle::{load_global_config, load_global_config_from};
+use std::env;
+use std::sync::{Arc, RwLock};
+
+static ENV_LOCK: RwLock<()> = RwLock::new(());
+
+#[test]
+fn test_config_from_env() {
+    let settings = {
+        let _guard = ENV_LOCK.write().unwrap();
+        env::set_var("SHUTTLE.STACK_SIZE", "0");
+        let settings = load_global_config();
+        env::remove_var("SHUTTLE.STACK_SIZE");
+        settings
+    };
+
+    let config = shuttle::Config::from_global_config(&settings);
+
+    assert_eq!(config.stack_size, 0);
+}
+
+#[test]
+fn test_config_from_file() {
+    let settings = {
+        let _guard = ENV_LOCK.read().unwrap();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/config/shuttle_dfs.toml");
+        load_global_config_from(Some(path))
+    };
+    assert_eq!(settings.get_string("scheduler.type").unwrap(), "dfs");
+}
+
+#[test]
+fn test_custom_scheduler_custom_config_field() {
+    use shuttle::register_scheduler;
+    use shuttle::scheduler::{Schedule, Scheduler, Task, TaskId};
+
+    struct FooScheduler {
+        _foo: String,
+    }
+
+    impl Scheduler for FooScheduler {
+        fn new_execution(&mut self) -> Option<Schedule> {
+            Some(Schedule::new(0))
+        }
+
+        fn next_task(&mut self, runnable: &[&Task], _: Option<TaskId>, _: bool) -> Option<TaskId> {
+            runnable.first().map(|t| t.id())
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            0
+        }
+    }
+
+    register_scheduler("foo_scheduler", |config| {
+        let foo = config.get_string("scheduler.foo").unwrap();
+        Box::new(FooScheduler { _foo: foo })
+    });
+    let settings = {
+        let _guard = ENV_LOCK.write().unwrap();
+        env::set_var("SHUTTLE.SCHEDULER.TYPE", "foo_scheduler");
+        env::set_var("SHUTTLE.SCHEDULER.FOO", "bar");
+
+        let settings = load_global_config();
+        env::remove_var("SHUTTLE.SCHEDULER.TYPE");
+        env::remove_var("SHUTTLE.SCHEDULER.FOO");
+        settings
+    };
+    assert_eq!(settings.get_string("scheduler.type").unwrap(), "foo_scheduler");
+    assert_eq!(settings.get_string("scheduler.foo").unwrap(), "bar");
+}
+
+mod main_task_only_scheduler {
+    use shuttle::scheduler::{Schedule, Scheduler, Task, TaskId};
+    use std::sync::Once;
+
+    static REGISTER: Once = Once::new();
+
+    pub struct MainTaskOnlyScheduler {
+        iterations: usize,
+        current: usize,
+    }
+
+    impl Scheduler for MainTaskOnlyScheduler {
+        fn new_execution(&mut self) -> Option<Schedule> {
+            if self.current < self.iterations {
+                self.current += 1;
+                Some(Schedule::new(0))
+            } else {
+                None
+            }
+        }
+
+        fn next_task(&mut self, runnable: &[&Task], current: Option<TaskId>, _: bool) -> Option<TaskId> {
+            if current.is_none() {
+                Some(runnable[0].id())
+            } else {
+                None
+            }
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            0
+        }
+    }
+
+    pub fn register() {
+        REGISTER.call_once(|| {
+            shuttle::register_scheduler("main_task_only", |config| {
+                let iterations = config.get_int("scheduler.iterations").unwrap_or(1) as usize;
+                Box::new(MainTaskOnlyScheduler { iterations, current: 0 })
+            });
+        });
+    }
+}
+
+#[test]
+fn test_run_custom_scheduler() {
+    main_task_only_scheduler::register();
+
+    let thread1_ran_outer = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let thread1_ran_inner = thread1_ran_outer.clone();
+    {
+        let _guard = ENV_LOCK.write().unwrap();
+        env::set_var("SHUTTLE.SCHEDULER.TYPE", "main_task_only");
+        env::set_var("SHUTTLE.SCHEDULER.ITERATIONS", "1");
+
+        shuttle::check(move || {
+            use shuttle::sync::atomic::{AtomicBool, Ordering};
+            use shuttle::sync::Arc;
+
+            let thread1_ran = Arc::new(AtomicBool::new(false));
+            let t1 = thread1_ran.clone();
+
+            shuttle::thread::spawn(move || {
+                t1.store(true, Ordering::SeqCst);
+            });
+
+            shuttle::thread::yield_now();
+
+            _ = thread1_ran_inner.fetch_or(thread1_ran.load(Ordering::SeqCst), Ordering::SeqCst);
+        });
+
+        env::remove_var("SHUTTLE.SCHEDULER.TYPE");
+        env::remove_var("SHUTTLE.SCHEDULER.ITERATIONS");
+    }
+    assert!(!thread1_ran_outer.load(std::sync::atomic::Ordering::SeqCst));
+}
+
+#[test]
+fn test_config_example_file() {
+    let settings = {
+        let _guard = ENV_LOCK.read().unwrap();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("shuttle_config_example.toml");
+        load_global_config_from(Some(path))
+    };
+
+    let expected = crate::Config::default();
+    let actual = crate::Config::from_global_config(&settings);
+
+    assert_eq!(expected, actual);
+
+    RandomScheduler::from_config(&settings);
+}
+
+#[test]
+fn test_config_example_scheduler_dfs() {
+    let settings = {
+        let _guard = ENV_LOCK.write().unwrap();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("shuttle_config_example.toml");
+        env::set_var("SHUTTLE.SCHEDULER.TYPE", "dfs");
+        let settings = load_global_config_from(Some(path));
+        env::remove_var("SHUTTLE.SCHEDULER.TYPE");
+        settings
+    };
+    DfsScheduler::from_config(&settings);
+}
+
+#[test]
+fn test_config_example_scheduler_urw() {
+    let settings = {
+        let _guard = ENV_LOCK.write().unwrap();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("shuttle_config_example.toml");
+        env::set_var("SHUTTLE.SCHEDULER.TYPE", "urw");
+        let settings = load_global_config_from(Some(path));
+        env::remove_var("SHUTTLE.SCHEDULER.TYPE");
+        settings
+    };
+    UrwRandomScheduler::from_config(&settings);
+}
+
+#[test]
+fn test_config_example_scheduler_pct() {
+    let settings = {
+        let _guard = ENV_LOCK.write().unwrap();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("shuttle_config_example.toml");
+        env::set_var("SHUTTLE.SCHEDULER.TYPE", "pct");
+        let settings = load_global_config_from(Some(path));
+        env::remove_var("SHUTTLE.SCHEDULER.TYPE");
+        settings
+    };
+    PctScheduler::from_config(&settings);
+}

--- a/shuttle/tests/config/shuttle_dfs.toml
+++ b/shuttle/tests/config/shuttle_dfs.toml
@@ -1,0 +1,5 @@
+# DFS scheduler configuration
+[scheduler]
+type = "dfs"
+max_iterations = 100
+allow_random_data = false

--- a/shuttle/tests/mod.rs
+++ b/shuttle/tests/mod.rs
@@ -2,6 +2,7 @@
 
 mod advanced;
 mod basic;
+mod config;
 mod data;
 mod demo;
 mod future;


### PR DESCRIPTION
This PR adds a global config for Shuttle, utilizing the [config](https://crates.io/crates/config) crate to make Shuttle tests configurable via a TOML file and/or environment variables. This allows users to swap scheduling algorithms, configuration parameters, or (in the future #217) time models declaratively without editing or recompiling their test code.

The public `check` function now uses this global config when running Shuttle tests. All other entrypoints to Shuttle (`check_random`, building a `Runner` manually, etc.) are unchanged.

Currently, the global config is the same for all tests using `check`, but it is easy to extend this in a future PR to store "sub-configs" in the global config objects, which can be accessed in subsets of tests via a key `check(fn, key)` API.

To run a scheduler via the global config, that scheduler must register a "factory" function that can create instances of that scheduler with the scheduler "registry". The scheduler "registry" is a global static that maps the name of the scheduler used in the config (`scheduler.type`) to the factory function. All basic schedulers in the Shuttle repository are registered by default, but additional custom schedulers can also be registered dynamically so that they can be run via the global config / check function.

#### Documentation

`shuttle/shuttle_config_example.toml` -- provides an example config with most configuration options for the included Shuttle schedulers
`fn check` -- the doc comment explains the configuration precedence and environment variable naming convention

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.