### PR TITLE
Better error messages for usages of ExecutionState::with

### DIFF
--- a/shuttle/src/current.rs
+++ b/shuttle/src/current.rs
@@ -87,12 +87,15 @@ pub fn set_name_for_task(task_id: TaskId, task_name: impl Into<TaskName>) -> Opt
     // when running with something like the `tracing_subscriber::fmt` subscriber.
     // This either has to be lived with, or the task name should be set via the `ChildLabelFn` mechanism, or a different subscriber should be used
     // (if this is done, then `record_steps_in_span` should be set to true as well), or Shuttle will have to be chanegd to recreate the Span
-    ExecutionState::try_with(|state| {
+    let res = ExecutionState::try_with(|state| {
         state
             .get_mut(task_id)
             .step_span
             .record("task", format!("{task_name:?}"));
     });
+    if let Err(e) = res {
+        tracing::error!("`set_name_for_task` failed with error: {e:?}");
+    }
     set_label_for_task::<TaskName>(task_id, task_name)
 }
 

--- a/shuttle/src/future/mod.rs
+++ b/shuttle/src/future/mod.rs
@@ -63,12 +63,15 @@ pub struct AbortHandle {
 impl AbortHandle {
     /// Abort the task associated with the handle.
     pub fn abort(&self) {
-        ExecutionState::try_with(|state| {
+        let res = ExecutionState::try_with(|state| {
             if !state.is_finished() {
                 let task = state.get_mut(self.task_id);
                 task.abort();
             }
         });
+        if let Err(e) = res {
+            tracing::error!("`AbortHandle::abort` failed with error: {e:?}");
+        }
     }
 
     /// Returns `true` if this task is finished, otherwise returns `false`.
@@ -111,12 +114,15 @@ impl<T> Default for JoinHandleInner<T> {
 impl<T> JoinHandle<T> {
     /// Abort the task associated with the handle.
     pub fn abort(&self) {
-        ExecutionState::try_with(|state| {
+        let res = ExecutionState::try_with(|state| {
             if !state.is_finished() {
                 let task = state.get_mut(self.task_id);
                 task.abort();
             }
         });
+        if let Err(e) = res {
+            tracing::error!("`JoinHandle::abort` failed with error: {e:?}");
+        }
     }
 
     /// Returns `true` if this task is finished, otherwise returns `false`.

--- a/shuttle/src/scheduler/metrics.rs
+++ b/shuttle/src/scheduler/metrics.rs
@@ -70,7 +70,7 @@ impl<S: Scheduler> Scheduler for MetricsScheduler<S> {
         if self.iterations > 0 {
             self.record_and_reset_metrics();
 
-            if self.iterations % self.iteration_divisor == 0 {
+            if self.iterations.is_multiple_of(self.iteration_divisor) {
                 info!(iterations = self.iterations);
 
                 if self.iterations == self.iteration_divisor * 10 {

--- a/shuttle/tests/basic/execution.rs
+++ b/shuttle/tests/basic/execution.rs
@@ -242,7 +242,9 @@ fn context_switches_mutex() {
 /// Check that we get a good failure message if accessing a Shuttle primitive from outside an
 /// execution.
 #[test]
-#[should_panic(expected = "are you trying to access a Shuttle primitive from outside a Shuttle test?")]
+#[should_panic(
+    expected = "`ExecutionState::with` panicked because `ExecutionState` is not set. Are you accessing a Shuttle primitive outside of a Shuttle test?"
+)]
 fn failure_outside_execution() {
     let lock = shuttle::sync::Mutex::new(0u64);
     let _ = lock.lock().unwrap();

--- a/shuttle/tests/basic/tracing.rs
+++ b/shuttle/tests/basic/tracing.rs
@@ -60,7 +60,7 @@ fn tracing_nested_spans_panic_mod_5(number: usize) {
                     warn!("incrementing from {}", *locked);
                     *locked += 1;
                 }
-                if number % 5 == 0 {
+                if number.is_multiple_of(5) {
                     panic!();
                 }
             })

--- a/shuttle/tests/ui/spawn_not_send.stderr
+++ b/shuttle/tests/ui/spawn_not_send.stderr
@@ -1,8 +1,8 @@
 error: future cannot be sent between threads safely
- --> tests/ui/spawn_not_send.rs:9:53
+ --> tests/ui/spawn_not_send.rs:9:39
   |
 9 |             shuttle::future::block_on(future::spawn(async { drop(rc) })).unwrap()
-  |                                                     ^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+  |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
   |
   = help: within `{async block@$DIR/tests/ui/spawn_not_send.rs:9:53: 9:58}`, the trait `Send` is not implemented for `Rc<i32>`
 note: captured value is not `Send`


### PR DESCRIPTION
I've repeatedly added more logging on usages of `ExecutionState::with` when debugging stuff, so figured that might as well be there by default.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.