### PR TITLE
Fix: Initialized Continuations Not Reusable and `maybe_yield` Can be Called after Execution is Finished

### DIFF
--- a/shuttle/src/runtime/execution.rs
+++ b/shuttle/src/runtime/execution.rs
@@ -658,8 +658,10 @@ impl ExecutionState {
             if std::thread::panicking() && !state.in_cleanup {
                 return true;
             }
+
             debug_assert!(
-                matches!(state.current_task, ScheduledTask::Some(_)) && state.next_task == ScheduledTask::None,
+                matches!(state.current_task, ScheduledTask::Some(_) | ScheduledTask::Finished)
+                    && state.next_task == ScheduledTask::None,
                 "we're inside a task and scheduler should not yet have run"
             );
 

--- a/shuttle/src/runtime/thread/continuation.rs
+++ b/shuttle/src/runtime/thread/continuation.rs
@@ -164,9 +164,7 @@ impl Continuation {
     /// have Exited, are not reusable as they have broken out of the loop where their inner functions
     /// can be replaced.
     fn reusable(&self) -> bool {
-        self.state == ContinuationState::NotReady
-            || self.state == ContinuationState::FinishedIteration
-            || self.state == ContinuationState::Initialized
+        self.state == ContinuationState::NotReady || self.state == ContinuationState::FinishedIteration
     }
 }
 


### PR DESCRIPTION
This fixes two issues that emerged when combining #204 and #216.

1. Continuations which are initialized cannot be naively reused. This is because resources *moved* to the inner function of the continuation (as arguments or closure captures) must be dropped before the next execution begins, even if the function itself has not started to execute

2. Because of the scheduling point changes, it is now possible to be in the `ScheduledTask::Finished` state for the current task when drop handlers are run (which can include scheduling points). This PR weakens the debug assertion to allow this 
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.