### PR TITLE
`bench` action doesn't fail build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,7 @@ jobs:
   bench:
     name: Benchmarks 
     runs-on: ubuntu-latest
+    continue-on-error: true # This step will not fail the job if it errors
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust


### PR DESCRIPTION
This makes it so that the flaky GH action for commenting with benchmarking results won't fail the build

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.