### PR TITLE
Add BatchSemaphore::close_no_scheduling_point

### DIFF
--- a/shuttle/src/future/batch_semaphore.rs
+++ b/shuttle/src/future/batch_semaphore.rs
@@ -394,7 +394,11 @@ impl BatchSemaphore {
     /// permits and notifies all pending waiters.
     pub fn close(&self) {
         thread::switch();
+        self.close_no_scheduling_point();
+    }
 
+    /// Closes the semaphore without invoking `thread::switch`
+    pub fn close_no_scheduling_point(&self) {
         self.init_object_id();
         let mut state = self.state.borrow_mut();
         if state.closed {


### PR DESCRIPTION
Adds `BatchSemaphore::close_no_scheduling_point`.

The reason for adding this is that primitives which utilize multiple semaphores (in my case: `mpsc`) need to be able to close more than one semaphore without having more than one scheduling point. This is both for efficiency, and for not leaving a system which is partially closed.

The latter could have been solved with an atomic field as the source of truth on whether the system is closed or not, but I prefer exposing this method as this approach is more efficient than having needless scheduling points.

There is however one con of this, which is that after #212 gets merged, a `switch` becomes both a scheduling point and an "indicator of interest". If this PR gets merged, then any users of `BatchSemaphore::close_no_scheduling_point` will not indicate any interest on those `BatchSemaphore`s. There's a couple potential solutions to this that come to mind:

1. Ignore it
2. Add a new `Event` which takes multiple `Event`s. The code would then never use `close`, and instead do a single `switch` before calling `close_no_scheduling_point` on whichever `BatchSemaphore`s it wants to close.
	- Rumor has it this would also be useful to solve the issue I point out in my comment in this comment: https://github.com/awslabs/shuttle/pull/212#issuecomment-3466069944

There might be a case to expose multiple `_no_scheduling_point` functions. My stance is that we'll add those once we need them. If it becomes the case that we want multiple `_no_scheduling_point` functions, then I will probably suggest to refactor the code such that `switch(Event)` returns a `Switched(Event)` which would be passed by ownership to the `_no_scheduling_point` functions in order to make sure that a scheduling point has occurred and that a corresponding `Event` has been created. Again, that bridge is to be burned if that river is ever to be crossed.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.