### PR TITLE
Add shuttle-lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "shuttle",
     "wrappers/shuttle_rand_0.8",
     "wrappers/shuttle_sync",
+    "wrappers/lazy_static",
 ]
 
 resolver = "2"

--- a/wrappers/lazy_static/Cargo.toml
+++ b/wrappers/lazy_static/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shuttle-lazy_static"
+version = "1.5.0"
+edition = "2024"
+
+[features]
+shuttle = ["dep:shuttle-lazy_static-impl"]
+
+spin_no_std = [ "lazy_static/spin_no_std", "shuttle-lazy_static-impl?/spin_no_std"  ]
+
+[dependencies]
+cfg-if = "1.0"
+lazy_static = "1"
+shuttle-lazy_static-impl = { path = "./lazy_static_impl", version = "0.1.0", optional = true }

--- a/wrappers/lazy_static/lazy_static_impl/Cargo.toml
+++ b/wrappers/lazy_static/lazy_static_impl/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shuttle-lazy_static-impl"
+version = "0.1.0"
+edition = "2024"
+
+[features]
+spin_no_std = []
+
+[dependencies]
+shuttle = { path = "../../../shuttle", version = "*" }

--- a/wrappers/lazy_static/lazy_static_impl/src/lib.rs
+++ b/wrappers/lazy_static/lazy_static_impl/src/lib.rs
@@ -1,0 +1,13 @@
+//! This crate contains Shuttle's internal implementations of the `lazy_static` crate.
+//! Do not depend on this crate directly. Use the `shuttle-lazy_static` crate, which conditionally
+//! exposes these implementations with the `shuttle` feature or the original crate without it.
+//!
+//! [`Shuttle`]: <https://crates.io/crates/shuttle>
+//!
+//! [`lazy_static`]: <https://crates.io/crates/lazy_static>
+
+// The reason this crate exists and we don't just import directly from shuttle in the wrapper is
+// that by doing it like this we can change where the implementation is sourced from without changing
+// the wrapper, which is a property needed if one wants the wrapper version to match the version of
+// `lazy_static`
+pub use shuttle::lazy_static::*;

--- a/wrappers/lazy_static/src/lib.rs
+++ b/wrappers/lazy_static/src/lib.rs
@@ -1,0 +1,34 @@
+//! This crate provides a Shuttle-compatible implementation and wrapper for [`lazy_static`] in order to make it
+//! more ergonomic to run a codebase under Shuttle.
+//!
+//! [`lazy_static`]: <https://crates.io/crates/lazy_static>
+//!
+//! To use this crate, add something akin to the following to your Cargo.toml:
+//!
+//! ```ignore
+//! [features]
+//! shuttle = [
+//!    "lazy_static/shuttle",
+//! ]
+//!
+//! [dependencies]
+//! lazy_static = { package = "shuttle-lazy_static", version = "1.5" }
+//! ```
+//!
+//! The rest of the codebase then remains unchanged, and running with Shuttle-compatible `lazy_static` can be done via the "shuttle" feature flag.
+//!
+//! By default the version of `lazy_static` exported is the latest `1.x` version (the same as if you had written `lazy_static = "1"` in your Cargo.toml).
+//! If you need to constrain the version of `lazy_static` that you depend on (eg. to pin the version), then this can be done by adding an entry like:
+//!
+//! ```ignore
+//! [dependencies]
+//! lazy_static-version-import-dont-use = { package = "lazy_static", version = "=1.5.0" }
+//! ```
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "shuttle")] {
+        pub use shuttle_lazy_static_impl::*;
+    } else {
+        pub use lazy_static::*;
+    }
+}


### PR DESCRIPTION
Adds a wrapper for [lazy_static](https://crates.io/crates/lazy_static)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.