### PR TITLE
Clippy: mem::take instead of mem::replace

### DIFF
--- a/shuttle/src/runtime/execution.rs
+++ b/shuttle/src/runtime/execution.rs
@@ -647,7 +647,7 @@ impl ExecutionState {
         let (mut tasks, final_state) = Self::with(|state| {
             state.in_cleanup = true;
             assert!(state.current_task == ScheduledTask::Stopped || state.current_task == ScheduledTask::Finished);
-            (std::mem::replace(&mut state.tasks, SmallVec::new()), state.current_task)
+            (std::mem::take(&mut state.tasks), state.current_task)
         });
 
         for task in tasks.drain(..) {


### PR DESCRIPTION
Clippy ref https://github.com/awslabs/shuttle/actions/runs/19842771142/job/56854541216?pr=238

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.