### PR TITLE
Make workflow not break on merge

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,27 @@
+name: Bench
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    name: Benchmarks 
+    runs-on: ubuntu-latest
+    continue-on-error: true # This step will not fail the job if it errors
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - uses: boa-dev/criterion-compare-action@v3
+        with:
+          cwd: "shuttle"
+          features: "bench-no-vector-clocks"
+          branchName: ${{ github.base_ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:
@@ -58,16 +60,3 @@ jobs:
       - name: cargo doc
         run: cargo doc --no-deps
 
-  bench:
-    name: Benchmarks 
-    runs-on: ubuntu-latest
-    continue-on-error: true # This step will not fail the job if it errors
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Rust
-        run: rustup update stable
-      - uses: boa-dev/criterion-compare-action@v3
-        with:
-          cwd: "shuttle"
-          features: "bench-no-vector-clocks"
-          branchName: ${{ github.base_ref }}


### PR DESCRIPTION
Currently on merge to main we get the following output for benchmarks:

```
Run boa-dev/criterion-compare-action@v3
Error: Input required and not supplied: branchName
    at Object.getInput (/home/runner/work/_actions/boa-dev/criterion-compare-action/v3/dist/index.js:1:3790)
    at main (/home/runner/work/_actions/boa-dev/criterion-compare-action/v3/dist/index.js:7:331417)
    at /home/runner/work/_actions/boa-dev/criterion-compare-action/v3/dist/index.js:7:334502
    at /home/runner/work/_actions/boa-dev/criterion-compare-action/v3/dist/index.js:7:334578
    at /home/runner/work/_actions/boa-dev/criterion-compare-action/v3/dist/index.js:7:334582
    at Object.<anonymous> (/home/runner/work/_actions/boa-dev/criterion-compare-action/v3/dist/index.js:7:334621)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
Error: Unhanded error:
Error: Input required and not supplied: branchName
```
(ref: https://github.com/awslabs/shuttle/actions/runs/20906721819/job/60061562154)

This PR splits up tests and benchmarking, so that benchmarking is only run in PRs, but not on the merge (while tests are ran for both). This means we shouldn't see the error above.

There is a case to be made for adding benchmarking on merge against the previous HEAD, but the results kind of have nowhere to live; if they live in the job summary which becomes a green checkmark or a red x then we should define thresholds to make them a red x on breach. That is more effort than I think it is worth, especially since we already do the same benchmarking in the PR, and this would only add it in the cases where the PR is not rebased before merge.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.