### PR TITLE
Fix: remove unneccessary call to init_object_id

### DIFF
--- a/shuttle/src/future/batch_semaphore.rs
+++ b/shuttle/src/future/batch_semaphore.rs
@@ -550,8 +550,6 @@ impl BatchSemaphore {
 
     /// Acquire the specified number of permits (blocking API)
     pub fn acquire_blocking(&self, num_permits: usize) -> Result<(), AcquireError> {
-        // No switch here; switch should be triggered on polling future
-        self.init_object_id();
         crate::future::block_on(self.acquire(num_permits))
     }
 


### PR DESCRIPTION
We already call `self.init_object_id();` in `acquire`.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.