### PR TITLE
Optimize schedule() to skip finished task early

### DIFF
--- a/shuttle/src/runtime/execution.rs
+++ b/shuttle/src/runtime/execution.rs
@@ -868,7 +868,10 @@ impl ExecutionState {
         let mut any_runnable = false;
 
         for task in &self.tasks {
-            unfinished_attached |= !task.finished() && !task.detached;
+            if task.finished() {
+                continue;
+            }
+            unfinished_attached |= !task.detached;
             let is_runnable = task.runnable();
             any_runnable |= is_runnable;
 


### PR DESCRIPTION
Our longbake test based on shuttle started to experience timeouts during transaction execution after one merge from live bumping Rust version from 1.92 to 1.93, and the problem sustains when rust bump to 1.94. After some investigations, we were able to discover the following: 
```
Look at the inner loop (the task iteration):

OLD (1.92) — the loop body at 0x15e2750:
asm
ldrb w8, [x21, #0x11c]    // load task state
cmp  w8, #0x5              // check if Finished
b.eq 0x15e2744             // if finished, skip (just advance pointer)
ldrb w9, [x21, #0x11a]    // load detached flag
cmp  w8, #0x2              // check if Runnable
...


NEW (1.94) — the loop body at 0x154df40:
asm
ldrb w8, [x21, #0x11c]    // load task state
cmp  w8, #0x5              // check if Finished
b.ne 0x154df90             // if NOT finished, go to complex path
mov  w28, wzr              // extra work
sub  w9, w8, #0x2          // extra computation
cmp  w8, #0x1
csinc w9, w9, wzr, hi     // conditional select
cmp  w9, #0x1
b.eq ...                   // more branches
```

The new compiler restructured the branch logic. The old code had a fast path: if task.finished() (state == 5), immediately skip. The new code does more work even for finished tasks — it
falls through into additional comparisons before skipping.

With ~500 tasks and ~12M calls to schedule(), and most tasks being finished, this means billions of extra instructions on the "finished task" fast path.

This is a classic LLVM codegen regression — the optimizer restructured the branch conditions in a way that's worse for the common case (most tasks are finished).
So this change is essentially adding the optimization back in rust code. And proved the longbake run succeeded after this change


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.