### PR TITLE
Remove wildcard contraint lazy_static

### DIFF
--- a/wrappers/lazy_static/lazy_static_impl/Cargo.toml
+++ b/wrappers/lazy_static/lazy_static_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-lazy_static-impl"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "The implementation for the Shutte-compatible wrapper for the lazy_static crate."
@@ -9,4 +9,4 @@ description = "The implementation for the Shutte-compatible wrapper for the lazy
 spin_no_std = []
 
 [dependencies]
-shuttle = { path = "../../../shuttle", version = "*" }
+shuttle = { path = "../../../shuttle", version = "<0.10" }


### PR DESCRIPTION
Wildcard imports are disallowed when publishing. I considered doing `<1`, but then realized we are probably going to move stuff around (ie. shuttle-core + shuttle), meaning the safer thing is to limit it to all versions below 0.10. This does create a footgun though, as we may bump Shuttle to 0.10 and forget to update all the wrappers, breaking all the wrappers in the process.

The PR also bumps version because I released 0.1.0

I also realize now that we'll have to SemVer trick (https://github.com/dtolnay/semver-trick) when/if the crate is restructured to a core and a shuttle

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.