### PR TITLE
Add wrapper for async_stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "wrappers/tokio/wrappers/shuttle-tokio",
     "wrappers/tokio/wrappers/shuttle-tokio-stream",
     "wrappers/parking_lot",
+    "wrappers/async_stream",
 ]
 
 resolver = "2"

--- a/wrappers/async_stream/Cargo.toml
+++ b/wrappers/async_stream/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shuttle-async-stream"
+version = "0.3.6"
+edition = "2021"
+license = "MIT"
+description = "A Shuttle-compatible wrapper for the `async-stream` crate"
+
+[features]
+shuttle = [ "dep:shuttle-async-stream-impl" ]
+
+[dependencies]
+cfg-if = "1.0"
+async-stream-orig = { package = "async-stream", version = "0.3" }
+shuttle-async-stream-impl = { path = "./async_stream_impl", version = "0.1.0", optional = true }

--- a/wrappers/async_stream/README.md
+++ b/wrappers/async_stream/README.md
@@ -1,0 +1,23 @@
+# Shuttle support for `async-stream`
+
+This folder contains the implementation and wrapper that enables testing of [async-stream](https://crates.io/crates/async-stream) applications with Shuttle.
+
+## How to use
+
+To use it, add the following in your Cargo.toml:
+
+```
+[features]
+shuttle = [
+   "async-stream/shuttle",
+]
+
+[dependencies]
+async-stream = { package = "shuttle-async-stream", version = "VERSION_NUMBER" }
+```
+
+The code will then behave as before when the `shuttle` feature flag is not provided, and will run with Shuttle-compatible primitives when the `shuttle` feature flag is provided.
+
+## Limitations
+
+There should be no limitations compared to [async-stream](https://crates.io/crates/async-stream). The version here is a fork of the 0.3.6 version, where the only change from the original is that the thread-local in `yielder.rs` has been made Shuttle-compatible.

--- a/wrappers/async_stream/async_stream_impl/Cargo.toml
+++ b/wrappers/async_stream/async_stream_impl/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "shuttle-async-stream-impl"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.65"
+license = "MIT"
+description = "Shuttle's internal implementation of the `async-stream` crate. Do not depend on this crate directly; use `shuttle-async-stream`."
+
+[dependencies]
+async-stream-impl = { version = "0.3" }
+futures-core = "0.3"
+pin-project-lite = "0.2"
+shuttle = { path = "../../../shuttle", version = "<0.10" }
+
+[dev-dependencies]
+futures-util = "0.3"
+rustversion = "1"
+trybuild = "1"
+tokio = { package = "shuttle-tokio-impl", path = "../../tokio/impls/tokio", version = "*", features = ["full"] }
+tokio-test = { package = "shuttle-tokio-test-impl", path = "../../tokio/impls/tokio-test", version = "*" }

--- a/wrappers/async_stream/async_stream_impl/LICENSE
+++ b/wrappers/async_stream/async_stream_impl/LICENSE
@@ -1,0 +1,51 @@
+Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Copyright (c) 2018 David Tolnay
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/wrappers/async_stream/async_stream_impl/src/async_stream.rs
+++ b/wrappers/async_stream/async_stream_impl/src/async_stream.rs
@@ -1,0 +1,79 @@
+use crate::yielder::Receiver;
+
+use futures_core::{FusedStream, Stream};
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub struct AsyncStream<T, U> {
+        rx: Receiver<T>,
+        done: bool,
+        #[pin]
+        generator: U,
+    }
+}
+
+impl<T, U> AsyncStream<T, U> {
+    #[doc(hidden)]
+    pub fn new(rx: Receiver<T>, generator: U) -> AsyncStream<T, U> {
+        AsyncStream {
+            rx,
+            done: false,
+            generator,
+        }
+    }
+}
+
+impl<T, U> FusedStream for AsyncStream<T, U>
+where
+    U: Future<Output = ()>,
+{
+    fn is_terminated(&self) -> bool {
+        self.done
+    }
+}
+
+impl<T, U> Stream for AsyncStream<T, U>
+where
+    U: Future<Output = ()>,
+{
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let me = self.project();
+
+        if *me.done {
+            return Poll::Ready(None);
+        }
+
+        let mut dst = None;
+        let res = {
+            let _enter = me.rx.enter(&mut dst);
+            me.generator.poll(cx)
+        };
+
+        *me.done = res.is_ready();
+
+        if dst.is_some() {
+            return Poll::Ready(dst.take());
+        }
+
+        if *me.done {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.done {
+            (0, Some(0))
+        } else {
+            (0, None)
+        }
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/src/lib.rs
+++ b/wrappers/async_stream/async_stream_impl/src/lib.rs
@@ -1,0 +1,45 @@
+//! This crate contains Shuttle's internal implementation of the `async-stream` crate.
+//! Do not depend on this crate directly. Use the `shuttle-async-stream` crate, which conditionally
+//! exposes this implementation with the `shuttle` feature or the original crate without it.
+//!
+//! [`Shuttle`]: <https://crates.io/crates/shuttle>
+//!
+//! [`async-stream`]: <https://crates.io/crates/async-stream>
+
+#![warn(missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+
+// SHUTTLE_CHANGES:
+// The only change that has been made with regards to `async-stream` is that the `thread-local` in `yielder.rs` has been made Shuttle-compatible,
+// and the [ui](https://github.com/tokio-rs/async-stream/tree/master/async-stream/tests/ui) tests have been removed, as they relied on `tokio::main`.
+
+mod async_stream;
+mod next;
+mod yielder;
+
+/// Asynchronous stream
+#[macro_export]
+macro_rules! stream {
+    ($($tt:tt)*) => {
+        $crate::__private::stream_inner!(($crate) $($tt)*)
+    }
+}
+
+/// Asynchronous fallible stream
+#[macro_export]
+macro_rules! try_stream {
+    ($($tt:tt)*) => {
+        $crate::__private::try_stream_inner!(($crate) $($tt)*)
+    }
+}
+
+// Not public API.
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::async_stream::AsyncStream;
+    pub use crate::next::next;
+    pub use async_stream_impl::{stream_inner, try_stream_inner};
+    pub mod yielder {
+        pub use crate::yielder::pair;
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/src/next.rs
+++ b/wrappers/async_stream/async_stream_impl/src/next.rs
@@ -1,0 +1,32 @@
+use futures_core::Stream;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+// This is equivalent to the `futures::StreamExt::next` method.
+// But we want to make this crate dependency as small as possible, so we define our `next` function.
+#[doc(hidden)]
+pub fn next<S>(stream: &mut S) -> impl Future<Output = Option<S::Item>> + '_
+where
+    S: Stream + Unpin,
+{
+    Next { stream }
+}
+
+#[derive(Debug)]
+struct Next<'a, S> {
+    stream: &'a mut S,
+}
+
+impl<S> Unpin for Next<'_, S> where S: Unpin {}
+
+impl<S> Future for Next<'_, S>
+where
+    S: Stream + Unpin,
+{
+    type Output = Option<S::Item>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.stream).poll_next(cx)
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/src/yielder.rs
+++ b/wrappers/async_stream/async_stream_impl/src/yielder.rs
@@ -1,0 +1,95 @@
+use std::cell::Cell;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::ptr;
+use std::task::{Context, Poll};
+
+#[derive(Debug)]
+pub struct Sender<T> {
+    _p: PhantomData<fn(T) -> T>,
+}
+
+#[derive(Debug)]
+pub struct Receiver<T> {
+    _p: PhantomData<T>,
+}
+
+pub(crate) struct Enter<'a, T> {
+    _rx: &'a mut Receiver<T>,
+    prev: *mut (),
+}
+
+// Note: It is considered unsound for anyone other than our macros to call
+// this function. This is a private API intended only for calls from our
+// macros, and users should never call it, but some people tend to
+// misinterpret it as fine to call unless it is marked unsafe.
+#[doc(hidden)]
+pub unsafe fn pair<T>() -> (Sender<T>, Receiver<T>) {
+    let tx = Sender { _p: PhantomData };
+    let rx = Receiver { _p: PhantomData };
+    (tx, rx)
+}
+
+// Tracks the pointer to `Option<T>`.
+//
+// TODO: Ensure wakers match?
+// SHUTTLE_CHANGES: Importing the thread local from `shuttle` is the only change from `async-stream`.
+shuttle::thread_local!(static STORE: Cell<*mut ()> = const { Cell::new(ptr::null_mut()) });
+
+// ===== impl Sender =====
+
+impl<T> Sender<T> {
+    pub fn send(&mut self, value: T) -> impl Future<Output = ()> {
+        Send { value: Some(value) }
+    }
+}
+
+struct Send<T> {
+    value: Option<T>,
+}
+
+impl<T> Unpin for Send<T> {}
+
+impl<T> Future for Send<T> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+        if self.value.is_none() {
+            return Poll::Ready(());
+        }
+
+        STORE.with(|cell| {
+            let ptr = cell.get() as *mut Option<T>;
+            let option_ref = unsafe { ptr.as_mut() }.expect("invalid usage");
+
+            if option_ref.is_none() {
+                *option_ref = self.value.take();
+            }
+
+            Poll::Pending
+        })
+    }
+}
+
+// ===== impl Receiver =====
+
+impl<T> Receiver<T> {
+    pub(crate) fn enter<'a>(&'a mut self, dst: &'a mut Option<T>) -> Enter<'a, T> {
+        let prev = STORE.with(|cell| {
+            let prev = cell.get();
+            cell.set(dst as *mut _ as *mut ());
+            prev
+        });
+
+        Enter { _rx: self, prev }
+    }
+}
+
+// ===== impl Enter =====
+
+impl<T> Drop for Enter<'_, T> {
+    fn drop(&mut self) {
+        STORE.with(|cell| cell.set(self.prev));
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/tests/for_await.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/for_await.rs
@@ -1,0 +1,25 @@
+use shuttle_async_stream_impl::stream;
+
+use futures_util::stream::StreamExt;
+
+#[tokio::test]
+async fn test() {
+    {
+        let s = stream! {
+            yield "hello";
+            yield "world";
+        };
+
+        let s = stream! {
+            for await x in s {
+                yield x.to_owned() + "!";
+            }
+        };
+
+        let values: Vec<_> = s.collect().await;
+
+        assert_eq!(2, values.len());
+        assert_eq!("hello!", values[0]);
+        assert_eq!("world!", values[1]);
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/tests/for_await.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/for_await.rs
@@ -4,22 +4,20 @@ use futures_util::stream::StreamExt;
 
 #[tokio::test]
 async fn test() {
-    {
-        let s = stream! {
-            yield "hello";
-            yield "world";
-        };
+    let s = stream! {
+        yield "hello";
+        yield "world";
+    };
 
-        let s = stream! {
-            for await x in s {
-                yield x.to_owned() + "!";
-            }
-        };
+    let s = stream! {
+        for await x in s {
+            yield x.to_owned() + "!";
+        }
+    };
 
-        let values: Vec<_> = s.collect().await;
+    let values: Vec<_> = s.collect().await;
 
-        assert_eq!(2, values.len());
-        assert_eq!("hello!", values[0]);
-        assert_eq!("world!", values[1]);
-    }
+    assert_eq!(2, values.len());
+    assert_eq!("hello!", values[0]);
+    assert_eq!("world!", values[1]);
 }

--- a/wrappers/async_stream/async_stream_impl/tests/reexporter/Cargo.toml
+++ b/wrappers/async_stream/async_stream_impl/tests/reexporter/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "reexporter"
+version = "0.0.0"
+authors = []
+edition = "2021"
+publish = false
+
+[dependencies]
+async-stream = { package = "shuttle-async-stream-impl", path = "../.." }

--- a/wrappers/async_stream/async_stream_impl/tests/reexporter/src/lib.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/reexporter/src/lib.rs
@@ -1,0 +1,3 @@
+//! A crate to test reexporting the `stream!` and `try_stream!` macros.
+
+pub use shuttle_async_stream_impl::{stream, try_stream};

--- a/wrappers/async_stream/async_stream_impl/tests/spans_preserved.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/spans_preserved.rs
@@ -1,0 +1,16 @@
+use futures_util::pin_mut;
+use futures_util::stream::StreamExt;
+use shuttle_async_stream_impl::stream;
+
+#[tokio::test]
+async fn spans_preserved() {
+    let s = stream! {
+     assert_eq!(line!(), 8);
+    };
+    pin_mut!(s);
+
+    #[allow(clippy::never_loop)]
+    while s.next().await.is_some() {
+        unreachable!();
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/tests/stream.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/stream.rs
@@ -1,0 +1,232 @@
+use shuttle_async_stream_impl::stream;
+
+use futures_core::stream::{FusedStream, Stream};
+use futures_util::pin_mut;
+use futures_util::stream::StreamExt;
+use tokio::sync::mpsc;
+use tokio_test::assert_ok;
+
+#[tokio::test]
+async fn noop_stream() {
+    let s = stream! {};
+    pin_mut!(s);
+
+    #[allow(clippy::never_loop)]
+    while s.next().await.is_some() {
+        unreachable!();
+    }
+}
+
+#[tokio::test]
+async fn empty_stream() {
+    let mut ran = false;
+
+    {
+        let r = &mut ran;
+        let s = stream! {
+            *r = true;
+            println!("hello world!");
+        };
+        pin_mut!(s);
+
+        #[allow(clippy::never_loop)]
+        while s.next().await.is_some() {
+            unreachable!();
+        }
+    }
+
+    assert!(ran);
+}
+
+#[tokio::test]
+async fn yield_single_value() {
+    let s = stream! {
+        yield "hello";
+    };
+
+    let values: Vec<_> = s.collect().await;
+
+    assert_eq!(1, values.len());
+    assert_eq!("hello", values[0]);
+}
+
+#[tokio::test]
+async fn fused() {
+    let s = stream! {
+        yield "hello";
+    };
+    pin_mut!(s);
+
+    assert!(!s.is_terminated());
+    assert_eq!(s.next().await, Some("hello"));
+    assert_eq!(s.next().await, None);
+
+    assert!(s.is_terminated());
+    // This should return None from now on
+    assert_eq!(s.next().await, None);
+}
+
+#[tokio::test]
+async fn yield_multi_value() {
+    let s = stream! {
+        yield "hello";
+        yield "world";
+        yield "dizzy";
+    };
+
+    let values: Vec<_> = s.collect().await;
+
+    assert_eq!(3, values.len());
+    assert_eq!("hello", values[0]);
+    assert_eq!("world", values[1]);
+    assert_eq!("dizzy", values[2]);
+}
+
+#[tokio::test]
+async fn unit_yield_in_select() {
+    use tokio::select;
+
+    async fn do_stuff_async() {}
+
+    let s = stream! {
+        select! {
+            _ = do_stuff_async() => yield,
+            else => yield,
+        }
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(values.len(), 1);
+}
+
+#[tokio::test]
+async fn yield_with_select() {
+    use tokio::select;
+
+    async fn do_stuff_async() {}
+    async fn more_async_work() {}
+
+    let s = stream! {
+        select! {
+            _ = do_stuff_async() => yield "hey",
+            _ = more_async_work() => yield "hey",
+            else => yield "hey",
+        }
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(values, vec!["hey"]);
+}
+
+#[tokio::test]
+async fn return_stream() {
+    fn build_stream() -> impl Stream<Item = u32> {
+        stream! {
+            yield 1;
+            yield 2;
+            yield 3;
+        }
+    }
+
+    let s = build_stream();
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(3, values.len());
+    assert_eq!(1, values[0]);
+    assert_eq!(2, values[1]);
+    assert_eq!(3, values[2]);
+}
+
+#[tokio::test]
+async fn consume_channel() {
+    let (tx, mut rx) = mpsc::channel(10);
+
+    let s = stream! {
+        while let Some(v) = rx.recv().await {
+            yield v;
+        }
+    };
+
+    pin_mut!(s);
+
+    for i in 0..3 {
+        assert_ok!(tx.send(i).await);
+        assert_eq!(Some(i), s.next().await);
+    }
+
+    drop(tx);
+    assert_eq!(None, s.next().await);
+}
+
+#[tokio::test]
+async fn borrow_self() {
+    struct Data(String);
+
+    impl Data {
+        fn stream(&self) -> impl Stream<Item = &str> + '_ {
+            stream! {
+                yield &self.0[..];
+            }
+        }
+    }
+
+    let data = Data("hello".to_string());
+    let s = data.stream();
+    pin_mut!(s);
+
+    assert_eq!(Some("hello"), s.next().await);
+}
+
+#[tokio::test]
+async fn stream_in_stream() {
+    let s = stream! {
+        let s = stream! {
+            for i in 0..3 {
+                yield i;
+            }
+        };
+
+        pin_mut!(s);
+        while let Some(v) = s.next().await {
+            yield v;
+        }
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(3, values.len());
+}
+
+#[tokio::test]
+async fn yield_non_unpin_value() {
+    let s: Vec<_> = stream! {
+        for i in 0..3 {
+            yield async move { i };
+        }
+    }
+    .buffered(1)
+    .collect()
+    .await;
+
+    assert_eq!(s, vec![0, 1, 2]);
+}
+
+#[test]
+fn inner_try_stream() {
+    use shuttle_async_stream_impl::try_stream;
+    use tokio::select;
+
+    async fn do_stuff_async() {}
+
+    let _ = stream! {
+        select! {
+            _ = do_stuff_async() => {
+                let another_s = try_stream! {
+                    yield;
+                };
+                let _: Result<(), ()> = Box::pin(another_s).next().await.unwrap();
+            },
+            else => {},
+        }
+        yield
+    };
+}

--- a/wrappers/async_stream/async_stream_impl/tests/test-reexport/Cargo.toml
+++ b/wrappers/async_stream/async_stream_impl/tests/test-reexport/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-reexport"
+version = "0.0.0"
+authors = []
+edition = "2021"
+publish = false
+
+[dependencies]
+reexporter = { path = "../reexporter" }
+futures-core = "0.3.8"

--- a/wrappers/async_stream/async_stream_impl/tests/test-reexport/src/lib.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/test-reexport/src/lib.rs
@@ -1,0 +1,17 @@
+use futures_core::stream::Stream;
+
+pub fn create_stream() -> impl Stream<Item = u8> {
+    reexporter::stream! {
+        for x in 0..10_u8 {
+            yield x;
+        }
+    }
+}
+
+pub fn create_try_stream() -> impl Stream<Item = Result<u8, u8>> {
+    reexporter::try_stream! {
+        for x in 0..10_u8 {
+            yield x;
+        }
+    }
+}

--- a/wrappers/async_stream/async_stream_impl/tests/try_stream.rs
+++ b/wrappers/async_stream/async_stream_impl/tests/try_stream.rs
@@ -1,0 +1,84 @@
+use shuttle_async_stream_impl::try_stream;
+
+use futures_core::stream::Stream;
+use futures_util::stream::StreamExt;
+
+#[tokio::test]
+async fn single_err() {
+    let s = try_stream! {
+        if true {
+            Err("hello")?;
+        } else {
+            yield "world";
+        }
+
+        unreachable!();
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(1, values.len());
+    assert_eq!(Err("hello"), values[0]);
+}
+
+#[tokio::test]
+async fn yield_then_err() {
+    let s = try_stream! {
+        yield "hello";
+        Err("world")?;
+        unreachable!();
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(2, values.len());
+    assert_eq!(Ok("hello"), values[0]);
+    assert_eq!(Err("world"), values[1]);
+}
+
+#[tokio::test]
+async fn convert_err() {
+    struct ErrorA(u8);
+    #[derive(PartialEq, Debug)]
+    struct ErrorB(u8);
+    impl From<ErrorA> for ErrorB {
+        fn from(a: ErrorA) -> ErrorB {
+            ErrorB(a.0)
+        }
+    }
+
+    fn test() -> impl Stream<Item = Result<&'static str, ErrorB>> {
+        try_stream! {
+            if true {
+                Err(ErrorA(1))?;
+            } else {
+                Err(ErrorB(2))?;
+            }
+            yield "unreachable";
+        }
+    }
+
+    let values: Vec<_> = test().collect().await;
+    assert_eq!(1, values.len());
+    assert_eq!(Err(ErrorB(1)), values[0]);
+}
+
+#[tokio::test]
+async fn multi_try() {
+    fn test() -> impl Stream<Item = Result<i32, String>> {
+        try_stream! {
+            let a = Ok::<_,  String>(Ok::<_,  String>(123))??;
+            for _ in 1..10 {
+                yield a;
+            }
+        }
+    }
+    let values: Vec<_> = test().collect().await;
+    assert_eq!(9, values.len());
+    assert_eq!(std::iter::repeat(123).take(9).map(Ok).collect::<Vec<_>>(), values);
+}
+
+#[allow(unused)]
+fn issue_65() -> impl Stream<Item = Result<u32, ()>> {
+    try_stream! {
+        yield Err(())?;
+    }
+}

--- a/wrappers/async_stream/src/lib.rs
+++ b/wrappers/async_stream/src/lib.rs
@@ -1,0 +1,34 @@
+//! This crate provides a Shuttle-compatible implementation and wrapper for [`async-stream`] in order to make it
+//! more ergonomic to run a codebase under Shuttle.
+//!
+//! [`async-stream`]: <https://crates.io/crates/async-stream>
+//!
+//! To use this crate, add something akin to the following to your Cargo.toml:
+//!
+//! ```ignore
+//! [features]
+//! shuttle = [
+//!    "async-stream/shuttle",
+//! ]
+//!
+//! [dependencies]
+//! async-stream = { package = "shuttle-async-stream", version = "0.3" }
+//! ```
+//!
+//! The rest of the codebase then remains unchanged, and running with Shuttle-compatible `async-stream` can be done via the "shuttle" feature flag.
+//!
+//! By default the version of `async-stream` exported is the latest `0.3` version (the same as if you had written `async-stream = "0.3"` in your Cargo.toml).
+//! If you need to constrain the version of `async-stream` that you depend on (eg. to pin the version), then this can be done by adding an entry like:
+//!
+//! ```ignore
+//! [dependencies]
+//! async-stream-version-import-dont-use = { package = "async-stream", version = "=0.3.6" }
+//! ```
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "shuttle")] {
+        pub use shuttle_async_stream_impl::*;
+    } else {
+        pub use async_stream_orig::*;
+    }
+}


### PR DESCRIPTION
Adds a wrapper for async stream. Followed the scheme from https://github.com/awslabs/shuttle/pull/232.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.