### PR TITLE
Add tokio-retry wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "wrappers/tokio/impls/tokio-util",
     "wrappers/tokio/wrappers/shuttle-tokio",
     "wrappers/tokio/wrappers/shuttle-tokio-stream",
+    "wrappers/tokio/wrappers/shuttle-tokio-retry",
+    "wrappers/tokio/impls/tokio-retry",
     "wrappers/parking_lot",
 ]
 

--- a/wrappers/tokio/impls/tokio-retry/Cargo.toml
+++ b/wrappers/tokio/impls/tokio-retry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shuttle-tokio-retry-impl"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Shuttle's internal implementation of the `tokio-retry` crate. Do not depend on this crate directly; use `shuttle-tokio-retry`."
+
+[dependencies]
+rand = { package = "shuttle-rand", version = "0.8", path = "../../../shuttle_rand_0.8", features = ["shuttle"] }
+tokio = { package = "shuttle-tokio-impl", version = "0.1", path = "../tokio", features = ["time"] }
+pin-project = "1.0.5"
+
+[dev-dependencies]
+tokio = { package = "shuttle-tokio-impl", version = "0.1", path = "../tokio", features = ["full"] }

--- a/wrappers/tokio/impls/tokio-retry/LICENSE
+++ b/wrappers/tokio/impls/tokio-retry/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Sam Rijs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wrappers/tokio/impls/tokio-retry/README.md
+++ b/wrappers/tokio/impls/tokio-retry/README.md
@@ -1,0 +1,7 @@
+# Shuttle support for `tokio-retry`
+
+This crate contains the implementation that enables testing of applications that use [tokio-retry](https://crates.io/crates/tokio-retry) with Shuttle. It should not be depended on directly, depend on `shuttle-tokio-retry` instead.
+
+## Limitations
+
+The implementation replaces `rand` and `tokio` with their Shuttle-compatible equivalents. The retry strategies and API surface match upstream `tokio-retry` 0.3.

--- a/wrappers/tokio/impls/tokio-retry/src/action.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/action.rs
@@ -1,0 +1,23 @@
+use std::future::Future;
+
+/// An action can be run multiple times and produces a future.
+pub trait Action {
+    /// The future that this action produces.
+    type Future: Future<Output = Result<Self::Item, Self::Error>>;
+    /// The item that the future may resolve with.
+    type Item;
+    /// The error that the future may resolve with.
+    type Error;
+
+    fn run(&mut self) -> Self::Future;
+}
+
+impl<R, E, T: Future<Output = Result<R, E>>, F: FnMut() -> T> Action for F {
+    type Item = R;
+    type Error = E;
+    type Future = T;
+
+    fn run(&mut self) -> Self::Future {
+        self()
+    }
+}

--- a/wrappers/tokio/impls/tokio-retry/src/condition.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/condition.rs
@@ -1,0 +1,10 @@
+/// Specifies under which conditions a retry is attempted.
+pub trait Condition<E> {
+    fn should_retry(&mut self, error: &E) -> bool;
+}
+
+impl<E, F: FnMut(&E) -> bool> Condition<E> for F {
+    fn should_retry(&mut self, error: &E) -> bool {
+        self(error)
+    }
+}

--- a/wrappers/tokio/impls/tokio-retry/src/future.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/future.rs
@@ -1,0 +1,170 @@
+use std::cmp;
+use std::error;
+use std::fmt;
+use std::future::Future;
+use std::iter::{IntoIterator, Iterator};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use pin_project::pin_project;
+use tokio::time::{sleep_until, Duration, Instant, Sleep};
+
+use super::action::Action;
+use super::condition::Condition;
+
+#[pin_project(project = RetryStateProj)]
+enum RetryState<A>
+where
+    A: Action,
+{
+    Running(#[pin] A::Future),
+    Sleeping(#[pin] Sleep),
+}
+
+impl<A: Action> RetryState<A> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> RetryFuturePoll<A> {
+        match self.project() {
+            RetryStateProj::Running(future) => RetryFuturePoll::Running(future.poll(cx)),
+            RetryStateProj::Sleeping(future) => RetryFuturePoll::Sleeping(future.poll(cx)),
+        }
+    }
+}
+
+enum RetryFuturePoll<A>
+where
+    A: Action,
+{
+    Running(Poll<Result<A::Item, A::Error>>),
+    Sleeping(Poll<()>),
+}
+
+/// Future that drives multiple attempts at an action via a retry strategy.
+#[allow(clippy::type_complexity)]
+#[pin_project]
+pub struct Retry<I, A>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+{
+    #[pin]
+    retry_if: RetryIf<I, A, fn(&A::Error) -> bool>,
+}
+
+impl<I, A> Retry<I, A>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+{
+    pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(strategy: T, action: A) -> Retry<I, A> {
+        Retry {
+            retry_if: RetryIf::spawn(strategy, action, (|_| true) as fn(&A::Error) -> bool),
+        }
+    }
+}
+
+impl<I, A> Future for Retry<I, A>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+{
+    type Output = Result<A::Item, A::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.project();
+        this.retry_if.poll(cx)
+    }
+}
+
+/// Future that drives multiple attempts at an action via a retry strategy. Retries are only attempted if
+/// the `Error` returned by the future satisfies a given condition.
+#[pin_project]
+pub struct RetryIf<I, A, C>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+    C: Condition<A::Error>,
+{
+    strategy: I,
+    #[pin]
+    state: RetryState<A>,
+    action: A,
+    condition: C,
+}
+
+impl<I, A, C> RetryIf<I, A, C>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+    C: Condition<A::Error>,
+{
+    pub fn spawn<T: IntoIterator<IntoIter = I, Item = Duration>>(
+        strategy: T,
+        mut action: A,
+        condition: C,
+    ) -> RetryIf<I, A, C> {
+        RetryIf {
+            strategy: strategy.into_iter(),
+            state: RetryState::Running(action.run()),
+            action,
+            condition,
+        }
+    }
+
+    fn attempt(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<A::Item, A::Error>> {
+        let future = {
+            let mut this = self.as_mut().project();
+            this.action.run()
+        };
+        self.as_mut().project().state.set(RetryState::Running(future));
+        self.poll(cx)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn retry(
+        mut self: Pin<&mut Self>,
+        err: A::Error,
+        cx: &mut Context,
+    ) -> Result<Poll<Result<A::Item, A::Error>>, A::Error> {
+        match self.as_mut().project().strategy.next() {
+            None => Err(err),
+            Some(duration) => {
+                let deadline = Instant::now() + duration;
+                let future = sleep_until(deadline);
+                self.as_mut().project().state.set(RetryState::Sleeping(future));
+                Ok(self.poll(cx))
+            }
+        }
+    }
+}
+
+impl<I, A, C> Future for RetryIf<I, A, C>
+where
+    I: Iterator<Item = Duration>,
+    A: Action,
+    C: Condition<A::Error>,
+{
+    type Output = Result<A::Item, A::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.as_mut().project().state.poll(cx) {
+            RetryFuturePoll::Running(poll_result) => match poll_result {
+                Poll::Ready(Ok(ok)) => Poll::Ready(Ok(ok)),
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(Err(err)) => {
+                    if self.as_mut().project().condition.should_retry(&err) {
+                        match self.retry(err, cx) {
+                            Ok(poll) => poll,
+                            Err(err) => Poll::Ready(Err(err)),
+                        }
+                    } else {
+                        Poll::Ready(Err(err))
+                    }
+                }
+            },
+            RetryFuturePoll::Sleeping(poll_result) => match poll_result {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(_) => self.attempt(cx),
+            },
+        }
+    }
+}

--- a/wrappers/tokio/impls/tokio-retry/src/lib.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/lib.rs
@@ -1,0 +1,19 @@
+//! This crate contains Shuttle's internal implementation of the `tokio-retry` crate.
+//! Do not depend on this crate directly. Use the `shuttle-tokio-retry` crate, which conditionally
+//! exposes this implementation with the `shuttle` feature or the original crate without it.
+//!
+//! [`Shuttle`]: <https://crates.io/crates/shuttle>
+//!
+//! [`tokio-retry`]: <https://crates.io/crates/tokio-retry>
+
+#![allow(warnings)]
+
+mod action;
+mod condition;
+mod future;
+/// Assorted retry strategies including fixed interval and exponential back-off.
+pub mod strategy;
+
+pub use action::Action;
+pub use condition::Condition;
+pub use future::{Retry, RetryIf};

--- a/wrappers/tokio/impls/tokio-retry/src/strategy/exponential_backoff.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/strategy/exponential_backoff.rs
@@ -1,0 +1,127 @@
+use std::iter::Iterator;
+use std::time::Duration;
+
+/// A retry strategy driven by exponential back-off.
+///
+/// The power corresponds to the number of past attempts.
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoff {
+    current: u64,
+    base: u64,
+    factor: u64,
+    max_delay: Option<Duration>,
+}
+
+impl ExponentialBackoff {
+    /// Constructs a new exponential back-off strategy,
+    /// given a base duration in milliseconds.
+    ///
+    /// The resulting duration is calculated by taking the base to the `n`-th power,
+    /// where `n` denotes the number of past attempts.
+    pub fn from_millis(base: u64) -> ExponentialBackoff {
+        ExponentialBackoff {
+            current: base,
+            base,
+            factor: 1u64,
+            max_delay: None,
+        }
+    }
+
+    /// A multiplicative factor that will be applied to the retry delay.
+    ///
+    /// For example, using a factor of `1000` will make each delay in units of seconds.
+    ///
+    /// Default factor is `1`.
+    pub fn factor(mut self, factor: u64) -> ExponentialBackoff {
+        self.factor = factor;
+        self
+    }
+
+    /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
+    pub fn max_delay(mut self, duration: Duration) -> ExponentialBackoff {
+        self.max_delay = Some(duration);
+        self
+    }
+}
+
+impl Iterator for ExponentialBackoff {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        // set delay duration by applying factor
+        let duration = if let Some(duration) = self.current.checked_mul(self.factor) {
+            Duration::from_millis(duration)
+        } else {
+            Duration::from_millis(u64::MAX)
+        };
+
+        // check if we reached max delay
+        if let Some(ref max_delay) = self.max_delay {
+            if duration > *max_delay {
+                return Some(*max_delay);
+            }
+        }
+
+        if let Some(next) = self.current.checked_mul(self.base) {
+            self.current = next;
+        } else {
+            self.current = u64::MAX;
+        }
+
+        Some(duration)
+    }
+}
+
+#[test]
+fn returns_some_exponential_base_10() {
+    let mut s = ExponentialBackoff::from_millis(10);
+
+    assert_eq!(s.next(), Some(Duration::from_millis(10)));
+    assert_eq!(s.next(), Some(Duration::from_millis(100)));
+    assert_eq!(s.next(), Some(Duration::from_millis(1000)));
+}
+
+#[test]
+fn returns_some_exponential_base_2() {
+    let mut s = ExponentialBackoff::from_millis(2);
+
+    assert_eq!(s.next(), Some(Duration::from_millis(2)));
+    assert_eq!(s.next(), Some(Duration::from_millis(4)));
+    assert_eq!(s.next(), Some(Duration::from_millis(8)));
+}
+
+#[test]
+fn saturates_at_maximum_value() {
+    let mut s = ExponentialBackoff::from_millis(u64::MAX - 1);
+
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX - 1)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX)));
+    assert_eq!(s.next(), Some(Duration::from_millis(u64::MAX)));
+}
+
+#[test]
+fn can_use_factor_to_get_seconds() {
+    let factor = 1000;
+    let mut s = ExponentialBackoff::from_millis(2).factor(factor);
+
+    assert_eq!(s.next(), Some(Duration::from_secs(2)));
+    assert_eq!(s.next(), Some(Duration::from_secs(4)));
+    assert_eq!(s.next(), Some(Duration::from_secs(8)));
+}
+
+#[test]
+fn stops_increasing_at_max_delay() {
+    let mut s = ExponentialBackoff::from_millis(2).max_delay(Duration::from_millis(4));
+
+    assert_eq!(s.next(), Some(Duration::from_millis(2)));
+    assert_eq!(s.next(), Some(Duration::from_millis(4)));
+    assert_eq!(s.next(), Some(Duration::from_millis(4)));
+}
+
+#[test]
+fn returns_max_when_max_less_than_base() {
+    let mut s = ExponentialBackoff::from_millis(20).max_delay(Duration::from_millis(10));
+
+    assert_eq!(s.next(), Some(Duration::from_millis(10)));
+    assert_eq!(s.next(), Some(Duration::from_millis(10)));
+}

--- a/wrappers/tokio/impls/tokio-retry/src/strategy/fibonacci_backoff.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/strategy/fibonacci_backoff.rs
@@ -1,0 +1,126 @@
+use std::iter::Iterator;
+use std::time::Duration;
+
+/// A retry strategy driven by the fibonacci series.
+///
+/// Each retry uses a delay which is the sum of the two previous delays.
+///
+/// Depending on the problem at hand, a fibonacci retry strategy might
+/// perform better and lead to better throughput than the `ExponentialBackoff`
+/// strategy.
+///
+/// See ["A Performance Comparison of Different Backoff Algorithms under Different Rebroadcast Probabilities for MANETs."](http://www.comp.leeds.ac.uk/ukpew09/papers/12.pdf)
+/// for more details.
+#[derive(Debug, Clone)]
+pub struct FibonacciBackoff {
+    curr: u64,
+    next: u64,
+    factor: u64,
+    max_delay: Option<Duration>,
+}
+
+impl FibonacciBackoff {
+    /// Constructs a new fibonacci back-off strategy,
+    /// given a base duration in milliseconds.
+    pub fn from_millis(millis: u64) -> FibonacciBackoff {
+        FibonacciBackoff {
+            curr: millis,
+            next: millis,
+            factor: 1u64,
+            max_delay: None,
+        }
+    }
+
+    /// A multiplicative factor that will be applied to the retry delay.
+    ///
+    /// For example, using a factor of `1000` will make each delay in units of seconds.
+    ///
+    /// Default factor is `1`.
+    pub fn factor(mut self, factor: u64) -> FibonacciBackoff {
+        self.factor = factor;
+        self
+    }
+
+    /// Apply a maximum delay. No retry delay will be longer than this `Duration`.
+    pub fn max_delay(mut self, duration: Duration) -> FibonacciBackoff {
+        self.max_delay = Some(duration);
+        self
+    }
+}
+
+impl Iterator for FibonacciBackoff {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        // set delay duration by applying factor
+        let duration = if let Some(duration) = self.curr.checked_mul(self.factor) {
+            Duration::from_millis(duration)
+        } else {
+            Duration::from_millis(u64::MAX)
+        };
+
+        // check if we reached max delay
+        if let Some(ref max_delay) = self.max_delay {
+            if duration > *max_delay {
+                return Some(*max_delay);
+            }
+        }
+
+        if let Some(next_next) = self.curr.checked_add(self.next) {
+            self.curr = self.next;
+            self.next = next_next;
+        } else {
+            self.curr = self.next;
+            self.next = u64::MAX;
+        }
+
+        Some(duration)
+    }
+}
+
+#[test]
+fn returns_the_fibonacci_series_starting_at_10() {
+    let mut iter = FibonacciBackoff::from_millis(10);
+    assert_eq!(iter.next(), Some(Duration::from_millis(10)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(10)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(20)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(30)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(50)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(80)));
+}
+
+#[test]
+fn saturates_at_maximum_value() {
+    let mut iter = FibonacciBackoff::from_millis(u64::MAX);
+    assert_eq!(iter.next(), Some(Duration::from_millis(u64::MAX)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(u64::MAX)));
+}
+
+#[test]
+fn stops_increasing_at_max_delay() {
+    let mut iter = FibonacciBackoff::from_millis(10).max_delay(Duration::from_millis(50));
+    assert_eq!(iter.next(), Some(Duration::from_millis(10)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(10)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(20)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(30)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(50)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(50)));
+}
+
+#[test]
+fn returns_max_when_max_less_than_base() {
+    let mut iter = FibonacciBackoff::from_millis(20).max_delay(Duration::from_millis(10));
+
+    assert_eq!(iter.next(), Some(Duration::from_millis(10)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(10)));
+}
+
+#[test]
+fn can_use_factor_to_get_seconds() {
+    let factor = 1000;
+    let mut s = FibonacciBackoff::from_millis(1).factor(factor);
+
+    assert_eq!(s.next(), Some(Duration::from_secs(1)));
+    assert_eq!(s.next(), Some(Duration::from_secs(1)));
+    assert_eq!(s.next(), Some(Duration::from_secs(2)));
+}

--- a/wrappers/tokio/impls/tokio-retry/src/strategy/fixed_interval.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/strategy/fixed_interval.rs
@@ -1,0 +1,40 @@
+use std::iter::Iterator;
+use std::time::Duration;
+
+/// A retry strategy driven by a fixed interval.
+#[derive(Debug, Clone)]
+pub struct FixedInterval {
+    duration: Duration,
+}
+
+impl FixedInterval {
+    /// Constructs a new fixed interval strategy.
+    pub fn new(duration: Duration) -> FixedInterval {
+        FixedInterval { duration }
+    }
+
+    /// Constructs a new fixed interval strategy,
+    /// given a duration in milliseconds.
+    pub fn from_millis(millis: u64) -> FixedInterval {
+        FixedInterval {
+            duration: Duration::from_millis(millis),
+        }
+    }
+}
+
+impl Iterator for FixedInterval {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        Some(self.duration)
+    }
+}
+
+#[test]
+fn returns_some_fixed() {
+    let mut s = FixedInterval::new(Duration::from_millis(123));
+
+    assert_eq!(s.next(), Some(Duration::from_millis(123)));
+    assert_eq!(s.next(), Some(Duration::from_millis(123)));
+    assert_eq!(s.next(), Some(Duration::from_millis(123)));
+}

--- a/wrappers/tokio/impls/tokio-retry/src/strategy/jitter.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/strategy/jitter.rs
@@ -1,0 +1,5 @@
+use std::time::Duration;
+
+pub fn jitter(duration: Duration) -> Duration {
+    duration.mul_f64(rand::random::<f64>())
+}

--- a/wrappers/tokio/impls/tokio-retry/src/strategy/mod.rs
+++ b/wrappers/tokio/impls/tokio-retry/src/strategy/mod.rs
@@ -1,0 +1,9 @@
+mod exponential_backoff;
+mod fibonacci_backoff;
+mod fixed_interval;
+mod jitter;
+
+pub use self::exponential_backoff::ExponentialBackoff;
+pub use self::fibonacci_backoff::FibonacciBackoff;
+pub use self::fixed_interval::FixedInterval;
+pub use self::jitter::jitter;

--- a/wrappers/tokio/impls/tokio-retry/tests/future.rs
+++ b/wrappers/tokio/impls/tokio-retry/tests/future.rs
@@ -1,0 +1,97 @@
+use std::future;
+use std::iter::Take;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use shuttle_tokio_retry_impl::{Retry, RetryIf};
+
+#[tokio::test]
+async fn attempts_just_once() {
+    use std::iter::empty;
+    let counter = Arc::new(AtomicUsize::new(0));
+    let cloned_counter = counter.clone();
+    let future = Retry::spawn(empty(), move || {
+        cloned_counter.fetch_add(1, Ordering::SeqCst);
+        future::ready(Err::<(), u64>(42))
+    });
+    let res = future.await;
+
+    assert_eq!(res, Err(42));
+    assert_eq!(counter.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn attempts_until_max_retries_exceeded() {
+    use shuttle_tokio_retry_impl::strategy::FixedInterval;
+    let s = FixedInterval::from_millis(100).take(2);
+    let counter = Arc::new(AtomicUsize::new(0));
+    let cloned_counter = counter.clone();
+    let future = Retry::spawn(s, move || {
+        cloned_counter.fetch_add(1, Ordering::SeqCst);
+        future::ready(Err::<(), u64>(42))
+    });
+    let res = future.await;
+
+    assert_eq!(res, Err(42));
+    assert_eq!(counter.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn attempts_until_success() {
+    use shuttle_tokio_retry_impl::strategy::FixedInterval;
+    let s = FixedInterval::from_millis(100);
+    let counter = Arc::new(AtomicUsize::new(0));
+    let cloned_counter = counter.clone();
+    let future = Retry::spawn(s, move || {
+        let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
+        if previous < 3 {
+            future::ready(Err::<(), u64>(42))
+        } else {
+            future::ready(Ok::<(), u64>(()))
+        }
+    });
+    let res = future.await;
+
+    assert_eq!(res, Ok(()));
+    assert_eq!(counter.load(Ordering::SeqCst), 4);
+}
+
+#[tokio::test]
+async fn compatible_with_tokio_core() {
+    use shuttle_tokio_retry_impl::strategy::FixedInterval;
+    let s = FixedInterval::from_millis(100);
+    let counter = Arc::new(AtomicUsize::new(0));
+    let cloned_counter = counter.clone();
+    let future = Retry::spawn(s, move || {
+        let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
+        if previous < 3 {
+            future::ready(Err::<(), u64>(42))
+        } else {
+            future::ready(Ok::<(), u64>(()))
+        }
+    });
+    let res = future.await;
+
+    assert_eq!(res, Ok(()));
+    assert_eq!(counter.load(Ordering::SeqCst), 4);
+}
+
+#[tokio::test]
+async fn attempts_retry_only_if_given_condition_is_true() {
+    use shuttle_tokio_retry_impl::strategy::FixedInterval;
+    let s = FixedInterval::from_millis(100).take(5);
+    let counter = Arc::new(AtomicUsize::new(0));
+    let cloned_counter = counter.clone();
+    let future: RetryIf<Take<FixedInterval>, _, fn(&usize) -> _> = RetryIf::spawn(
+        s,
+        move || {
+            let previous = cloned_counter.fetch_add(1, Ordering::SeqCst);
+            future::ready(Err::<(), usize>(previous + 1))
+        },
+        |e: &usize| *e < 3,
+    );
+    let res = future.await;
+
+    assert_eq!(res, Err(3));
+    assert_eq!(counter.load(Ordering::SeqCst), 3);
+}

--- a/wrappers/tokio/wrappers/shuttle-tokio-retry/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio-retry/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "shuttle-tokio-retry"
+version = "0.3.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "tokio-retry wrapper for the Shuttle concurrency testing tool."
+
+[lib]
+name = "shuttle_tokio_retry"
+path = "src/lib.rs"
+doctest = false
+
+[features]
+shuttle = [ "dep:shuttle-tokio-retry-impl" ]
+
+[dependencies]
+cfg-if = "1.0"
+tokio-retry-orig = { package = "tokio-retry", version = "0.3" }
+shuttle-tokio-retry-impl = { path = "../../impls/tokio-retry", version = "0.1", optional = true }

--- a/wrappers/tokio/wrappers/shuttle-tokio-retry/README.md
+++ b/wrappers/tokio/wrappers/shuttle-tokio-retry/README.md
@@ -1,0 +1,23 @@
+# Shuttle support for `tokio-retry`
+
+This crate contains the wrapper that enables testing of applications that use [tokio-retry](https://crates.io/crates/tokio-retry) with Shuttle.
+
+## How to use
+
+To use it, add the following in your Cargo.toml:
+
+```
+[features]
+shuttle = [
+   "tokio-retry/shuttle",
+]
+
+[dependencies]
+tokio-retry = { package = "shuttle-tokio-retry", version = "VERSION_NUMBER" }
+```
+
+The code will then behave as before when the `shuttle` feature flag is not provided, and will run with Shuttle-compatible primitives when the `shuttle` feature flag is provided.
+
+## Limitations
+
+For the list of current limitations, see the [tokio-retry](https://crates.io/crates/shuttle-tokio-retry-impl) inner crate.

--- a/wrappers/tokio/wrappers/shuttle-tokio-retry/src/lib.rs
+++ b/wrappers/tokio/wrappers/shuttle-tokio-retry/src/lib.rs
@@ -1,0 +1,27 @@
+//! This crate provides a Shuttle-compatible implementation and wrapper for [`tokio-retry`] in order to make it
+//! more ergonomic to run a codebase using [`tokio-retry`] under Shuttle.
+//!
+//! [`tokio-retry`]: <https://crates.io/crates/tokio-retry>
+//!
+//! To use this crate, add something akin to the following to your Cargo.toml:
+//!
+//! ```ignore
+//! [features]
+//! shuttle = [
+//!    "tokio-retry/shuttle",
+//! ]
+//!
+//! [dependencies]
+//! tokio-retry = { package = "shuttle-tokio-retry", version = "0.3" }
+//! ```
+//!
+//! The rest of the codebase then remains unchanged, and running with Shuttle-compatible `tokio-retry`
+//! can be done via the "shuttle" feature flag.
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "shuttle")] {
+        pub use shuttle_tokio_retry_impl::*;
+    } else {
+        pub use tokio_retry_orig::*;
+    }
+}


### PR DESCRIPTION
Adds a tokio-retry wrapper for 0.3.0.

Just discovered 0.3.1. was released 6 days ago. Should add support for that, don't think it's needed to block merging this PR on porting that over

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.