### PR TITLE
Add support for task abort

### DIFF
--- a/shuttle/src/future/mod.rs
+++ b/shuttle/src/future/mod.rs
@@ -14,6 +14,7 @@ use std::future::Future;
 use std::panic::Location;
 use std::pin::Pin;
 use std::result::Result;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 
@@ -26,9 +27,19 @@ where
 {
     let stack_size = ExecutionState::with(|s| s.config.stack_size);
     let inner = Arc::new(std::sync::Mutex::new(JoinHandleInner::default()));
-    let task_id = ExecutionState::spawn_future(Wrapper::new(fut, inner.clone()), stack_size, None, caller);
+    let aborted = Arc::new(AtomicBool::new(false));
+    let task_id = ExecutionState::spawn_future(
+        Wrapper::new(fut, inner.clone(), aborted.clone()),
+        stack_size,
+        None,
+        caller,
+    );
 
-    JoinHandle { task_id, inner }
+    JoinHandle {
+        task_id,
+        inner,
+        aborted,
+    }
 }
 
 /// Spawn a new async task that the executor will run to completion.
@@ -56,11 +67,26 @@ where
 #[derive(Debug, Clone)]
 pub struct AbortHandle {
     task_id: TaskId,
+    aborted: Arc<AtomicBool>,
 }
 
 impl AbortHandle {
     /// Abort the task associated with the handle.
+    ///
+    /// The task will be cancelled at the next await point. If the task has already
+    /// completed, this is a no-op.
     pub fn abort(&self) {
+        // Scheduling point: the scheduler may run other tasks (including the target)
+        // before the abort flag is set, creating interleavings where the task completes
+        // normally despite an abort() call.
+        thread::switch();
+
+        // Signal the Wrapper to skip the inner future on the next poll.
+        // If already aborted, skip the redundant wake.
+        if self.aborted.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        // Wake the task so Wrapper::poll() runs and performs cleanup.
         let res = ExecutionState::try_with(|state| {
             if !state.is_finished() {
                 state.get_mut(self.task_id).abort();
@@ -90,7 +116,8 @@ unsafe impl Sync for AbortHandle {}
 #[derive(Debug)]
 pub struct JoinHandle<T> {
     task_id: TaskId,
-    inner: std::sync::Arc<std::sync::Mutex<JoinHandleInner<T>>>,
+    inner: Arc<std::sync::Mutex<JoinHandleInner<T>>>,
+    aborted: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]
@@ -110,7 +137,22 @@ impl<T> Default for JoinHandleInner<T> {
 
 impl<T> JoinHandle<T> {
     /// Abort the task associated with the handle.
+    ///
+    /// The task will be cancelled at the next await point. Awaiting the `JoinHandle` after
+    /// calling `abort` will return `Err(JoinError::Cancelled)`, unless the task completed
+    /// before the abort took effect.
     pub fn abort(&self) {
+        // Scheduling point: the scheduler may run other tasks (including the target)
+        // before the abort flag is set, creating interleavings where the task completes
+        // normally despite an abort() call.
+        thread::switch();
+
+        // Signal the Wrapper to skip the inner future on the next poll.
+        // If already aborted, skip the redundant wake.
+        if self.aborted.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        // Wake the task so Wrapper::poll() runs and performs cleanup.
         let res = ExecutionState::try_with(|state| {
             if !state.is_finished() {
                 state.get_mut(self.task_id).abort();
@@ -134,7 +176,10 @@ impl<T> JoinHandle<T> {
 
     /// Returns a new `AbortHandle` that can be used to remotely abort this task.
     pub fn abort_handle(&self) -> AbortHandle {
-        AbortHandle { task_id: self.task_id }
+        AbortHandle {
+            task_id: self.task_id,
+            aborted: self.aborted.clone(),
+        }
     }
 }
 
@@ -158,7 +203,16 @@ impl Error for JoinError {}
 
 impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {
-        self.abort();
+        // Detach the task so it keeps running but we don't wait for it.
+        // Dropping a JoinHandle does NOT cancel the task (unlike abort()).
+        let res = ExecutionState::try_with(|state| {
+            if !state.is_finished() {
+                state.get_mut(self.task_id).detach();
+            }
+        });
+        if let Err(e) = res {
+            tracing::error!("`JoinHandle::drop` failed with error: {e:?}");
+        }
     }
 }
 
@@ -180,9 +234,17 @@ impl<T> Future for JoinHandle<T> {
 // contains a mutex-wrapped field that stores the value and the waker for the task
 // waiting on the join handle. When `poll` returns `Poll::Ready`, the `Wrapper` stores
 // the result in the `result` field and wakes the `waker`.
+//
+// The `aborted` flag is set by `JoinHandle::abort()` / `AbortHandle::abort()`. On the
+// next poll, `Wrapper` detects the flag, drops the inner future (running its destructors),
+// cleans up thread-local storage, publishes `Err(JoinError::Cancelled)` to any awaiting
+// join handle, and returns `Poll::Ready(())`.
 struct Wrapper<F: Future> {
-    future: Pin<Box<F>>,
-    inner: std::sync::Arc<std::sync::Mutex<JoinHandleInner<F::Output>>>,
+    /// The inner future. Wrapped in `Option` so we can drop it explicitly in the
+    /// abort path (before running thread-local destructors).
+    future: Option<Pin<Box<F>>>,
+    inner: Arc<std::sync::Mutex<JoinHandleInner<F::Output>>>,
+    aborted: Arc<AtomicBool>,
 }
 
 impl<F> Wrapper<F>
@@ -190,10 +252,33 @@ where
     F: Future + 'static,
     F::Output: 'static,
 {
-    fn new(future: F, inner: std::sync::Arc<std::sync::Mutex<JoinHandleInner<F::Output>>>) -> Self {
+    fn new(future: F, inner: Arc<std::sync::Mutex<JoinHandleInner<F::Output>>>, aborted: Arc<AtomicBool>) -> Self {
         Self {
-            future: Box::pin(future),
+            future: Some(Box::pin(future)),
             inner,
+            aborted,
+        }
+    }
+}
+
+impl<F> Wrapper<F>
+where
+    F: Future + 'static,
+    F::Output: 'static,
+{
+    /// Clean up thread-local storage, publish the result to the JoinHandle, and wake
+    /// any task waiting on the result.
+    fn finish(&self, result: Result<F::Output, JoinError>) {
+        // Run thread-local destructors.
+        // See `pop_local` for details on why this loop looks slightly funky.
+        while let Some(local) = ExecutionState::with(|state| state.current_mut().pop_local()) {
+            drop(local);
+        }
+
+        let mut lock = self.inner.lock().unwrap();
+        lock.result = Some(result);
+        if let Some(waker) = lock.waker.take() {
+            waker.wake();
         }
     }
 }
@@ -205,8 +290,25 @@ where
 {
     type Output = ();
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.future.as_mut().poll(cx) {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        // If abort() was called, skip polling the inner future.
+        if this.aborted.load(Ordering::Relaxed) {
+            // If the execution is already finished (e.g., the runtime is shutting down),
+            // we can't access task state for cleanup. Just return Ready to let the task
+            // be cleaned up by the runtime.
+            if ExecutionState::try_with(|state| state.is_finished()).unwrap_or(true) {
+                return Poll::Ready(());
+            }
+
+            // Drop the inner future first so its destructors can still access TLS.
+            this.future.take();
+            this.finish(Err(JoinError::Cancelled));
+            return Poll::Ready(());
+        }
+
+        match this.future.as_mut().unwrap().as_mut().poll(cx) {
             Poll::Ready(result) => {
                 // If we've finished execution already (this task was detached), don't clean up. We
                 // can't access the state any more to destroy thread locals, and don't want to run
@@ -215,22 +317,7 @@ where
                     return Poll::Ready(());
                 }
 
-                // Run thread-local destructors before publishing the result.
-                // See `pop_local` for details on why this loop looks this slightly funky way.
-                // TODO: thread locals and futures don't mix well right now. each task gets its own
-                //       thread local storage, but real async code might know that its executor is
-                //       single-threaded and so use TLS to share objects across all tasks.
-                while let Some(local) = ExecutionState::with(|state| state.current_mut().pop_local()) {
-                    drop(local);
-                }
-
-                let mut lock = self.inner.lock().unwrap();
-                lock.result = Some(Ok(result));
-
-                if let Some(waker) = lock.waker.take() {
-                    waker.wake();
-                }
-
+                this.finish(Ok(result));
                 Poll::Ready(())
             }
             Poll::Pending => Poll::Pending,

--- a/shuttle/src/runtime/task/mod.rs
+++ b/shuttle/src/runtime/task/mod.rs
@@ -481,9 +481,12 @@ impl Task {
         self.detached = true;
     }
 
+    /// Wake this task so the Wrapper future can observe the abort flag on its next poll.
     pub(crate) fn abort(&mut self) {
-        // TODO: Change into actually aborting
-        self.detach();
+        if self.finished() {
+            return;
+        }
+        self.wake();
     }
 
     pub(crate) fn waker(&self) -> Waker {

--- a/shuttle/tests/future/basic.rs
+++ b/shuttle/tests/future/basic.rs
@@ -1,3 +1,4 @@
+use futures::channel::oneshot;
 use futures::task::{FutureObj, Spawn, SpawnError, SpawnExt as _};
 use futures::{try_join, Future};
 use shuttle::sync::{Barrier, Mutex};
@@ -410,4 +411,485 @@ fn clean_up_detached_task() {
         },
         None,
     )
+}
+
+// --- Task abort tests ---
+
+/// Local mirror of JoinError variants that implements Hash/Eq for use in HashSets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Outcome {
+    Cancelled,
+    #[allow(dead_code)]
+    Other,
+}
+
+impl From<shuttle::future::JoinError> for Outcome {
+    fn from(e: shuttle::future::JoinError) -> Self {
+        match e {
+            shuttle::future::JoinError::Cancelled => Outcome::Cancelled,
+        }
+    }
+}
+
+/// Abort a task that has just been spawned. Because abort() is a scheduling
+/// point, DFS can explore interleavings where the task completes before the
+/// abort flag is set, so both Ok and Cancelled are valid outcomes.
+#[test]
+fn abort_before_first_poll() {
+    use std::collections::HashSet;
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<Result<i32, Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let t = future::spawn(async move { 42 });
+            t.abort();
+            let result = future::block_on(t);
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<Result<i32, Outcome>> = [Ok(42), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
+}
+
+/// Abort a task that has already completed. The JoinHandle should return the
+/// normal Ok result, not Cancelled.
+#[test]
+fn abort_already_finished_task() {
+    check_dfs(
+        || {
+            let (tx, rx) = oneshot::channel();
+            let t = future::spawn(async move {
+                tx.send(()).unwrap();
+                42
+            });
+            // Wait until the task has sent its signal (i.e., it's about to return 42).
+            future::block_on(async { rx.await.unwrap() });
+            // Task has finished by now. Aborting a finished task should be a no-op.
+            t.abort();
+            let result = future::block_on(t);
+            assert_eq!(result.unwrap(), 42);
+        },
+        None,
+    );
+}
+
+/// Abort a task that has started and is holding a Mutex. The abort should cancel the
+/// task (returning JoinError::Cancelled), drop the future's locals (releasing the lock),
+/// and not execute any code after the await point.
+#[test]
+fn abort_frees_mutex() {
+    check_dfs(
+        || {
+            let mutex = Arc::new(Mutex::new(()));
+            let mutex2 = mutex.clone();
+            let after_await = Arc::new(AtomicUsize::new(0));
+            let after_clone = after_await.clone();
+            let (tx_ready, rx_ready) = oneshot::channel();
+            let (tx_proceed, rx_proceed) = oneshot::channel::<()>();
+
+            // Use spawn_local because MutexGuard is !Send across await
+            let t = future::spawn_local(async move {
+                let _guard = mutex2.lock().unwrap();
+                // Signal that we're holding the lock, then sleep forever.
+                tx_ready.send(()).unwrap();
+                let _ = rx_proceed.await;
+                after_clone.fetch_add(1, Ordering::SeqCst);
+            });
+
+            // Wait until the task is holding the lock and sleeping.
+            future::block_on(async { rx_ready.await.unwrap() });
+
+            // Abort the task that holds the lock
+            t.abort();
+            let result = future::block_on(t);
+            assert!(matches!(result, Err(shuttle::future::JoinError::Cancelled)));
+            assert_eq!(after_await.load(Ordering::SeqCst), 0);
+
+            // The lock should have been released by the abort
+            let _guard = mutex.lock().unwrap();
+            drop(tx_proceed);
+        },
+        None,
+    );
+}
+
+/// Abort a future task while it's blocked on a Shuttle sync primitive (Mutex).
+/// The abort should not take effect until the sync operation completes and the
+/// task reaches an await point. This was a known problem in awslabs/shuttle#150
+/// where immediately destroying the task caused Mutex internals to assert-fail.
+#[test]
+fn abort_while_blocked_on_sync() {
+    check_dfs(
+        || {
+            let lock = Arc::new(Mutex::new(0i32));
+            let lock2 = lock.clone();
+            let t1 = thread::spawn(move || {
+                let mut guard = lock2.lock().unwrap();
+                *guard += 1;
+            });
+            let t2 = future::spawn(async move {
+                let _l = lock.lock().unwrap();
+            });
+            t2.abort();
+            t1.join().unwrap();
+            let _ = future::block_on(t2);
+        },
+        None,
+    );
+}
+
+/// Reproduction case from https://github.com/awslabs/shuttle/issues/91.
+/// An aborted task must not run its body even when the future it was awaiting
+/// resolves successfully after abort.
+#[test]
+fn abort_woken_task_does_not_run() {
+    check_dfs(
+        || {
+            let (sender, receiver) = oneshot::channel();
+            let t = future::spawn(async move {
+                receiver.await.unwrap();
+                panic!("should not get here");
+            });
+            t.abort();
+            sender.send(()).unwrap();
+            thread::yield_now();
+        },
+        None,
+    );
+}
+
+/// Dropping a JoinHandle detaches the task (it keeps running), it does NOT abort.
+/// This matches tokio semantics.
+#[test]
+fn drop_join_handle_detaches_not_aborts() {
+    check_dfs(
+        || {
+            let ran = Arc::new(AtomicUsize::new(0));
+            let ran_clone = ran.clone();
+            let (tx, rx) = oneshot::channel();
+
+            let t = future::spawn(async move {
+                ran_clone.fetch_add(1, Ordering::SeqCst);
+                tx.send(()).unwrap();
+            });
+            drop(t); // detach, not abort
+            future::block_on(async { rx.await.unwrap() }); // wait for the task
+            assert_eq!(ran.load(Ordering::SeqCst), 1);
+        },
+        None,
+    );
+}
+
+/// Abort via AbortHandle works the same as via JoinHandle.
+/// Also checks that is_finished() returns true after the aborted task completes.
+#[test]
+fn abort_via_abort_handle() {
+    use std::collections::HashSet;
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<Result<i32, Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let t = future::spawn(async move { 42 });
+            let ah = t.abort_handle();
+            ah.abort();
+            let result = future::block_on(t);
+            // Task is finished regardless of outcome.
+            assert!(ah.is_finished());
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<Result<i32, Outcome>> = [Ok(42), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
+}
+
+/// Aborting a task twice is a no-op the second time.
+#[test]
+fn double_abort_is_idempotent() {
+    use std::collections::HashSet;
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<Result<i32, Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let t = future::spawn(async { 42 });
+            t.abort();
+            t.abort(); // second abort should be harmless
+            let result = future::block_on(t);
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<Result<i32, Outcome>> = [Ok(42), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
+}
+
+/// Abort a task that has multiple await points. check_dfs explores all orderings,
+/// and we collect (steps_completed, result) pairs across iterations. The only
+/// valid outcomes are:
+///   (1, Cancelled) — aborted after step 1, before step 2
+///   (2, Cancelled) — aborted after step 2, before step 3
+///   (3, Ok)        — task completed before abort took effect
+/// Note: (0, Cancelled) is impossible because the ready signal and step 1 are in
+/// the same synchronous block (no await between them).
+#[test]
+fn abort_at_second_await_point() {
+    use std::collections::HashSet;
+    type StepOutcome = (usize, Result<(), Outcome>);
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<StepOutcome>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let steps = Arc::new(AtomicUsize::new(0));
+            let steps_clone = steps.clone();
+            let (tx_ready, rx_ready) = oneshot::channel();
+
+            let t = future::spawn(async move {
+                tx_ready.send(()).unwrap();
+                steps_clone.fetch_add(1, Ordering::SeqCst); // step 1
+                future::yield_now().await;
+                steps_clone.fetch_add(1, Ordering::SeqCst); // step 2
+                future::yield_now().await;
+                steps_clone.fetch_add(1, Ordering::SeqCst); // step 3
+            });
+
+            // Ensure the task has started.
+            future::block_on(async { rx_ready.await.unwrap() });
+
+            // Yield to create a scheduling point. check_dfs explores orderings
+            // where the task makes different amounts of progress before abort.
+            thread::yield_now();
+
+            t.abort();
+            let result = future::block_on(t);
+
+            let s = steps.load(Ordering::SeqCst);
+            outcomes.lock().unwrap().insert((s, result.map_err(Outcome::from)));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<StepOutcome> =
+        [(1, Err(Outcome::Cancelled)), (2, Err(Outcome::Cancelled)), (3, Ok(()))].into();
+    assert_eq!(*seen, expected, "expected all three outcomes, saw: {:?}", *seen);
+}
+
+/// Abort a detached task via AbortHandle. When the JoinHandle is dropped (detaching
+/// the task), the AbortHandle should still be able to abort it.
+#[test]
+fn abort_detached_task_via_abort_handle() {
+    check_dfs(
+        || {
+            let ran = Arc::new(AtomicUsize::new(0));
+            let ran_clone = ran.clone();
+            let (tx_ready, rx_ready) = oneshot::channel();
+            let (tx_proceed, rx_proceed) = oneshot::channel::<()>();
+
+            let t = future::spawn(async move {
+                tx_ready.send(()).unwrap();
+                let _ = rx_proceed.await;
+                ran_clone.fetch_add(1, Ordering::SeqCst);
+            });
+            let ah = t.abort_handle();
+            drop(t); // detach the task
+
+            // Wait until the task is sleeping at the rx_proceed await point.
+            future::block_on(async { rx_ready.await.unwrap() });
+
+            ah.abort(); // abort via the AbortHandle
+
+            // Yield so the scheduler can run the aborted (detached) task's cleanup.
+            thread::yield_now();
+
+            assert_eq!(ran.load(Ordering::SeqCst), 0);
+            drop(tx_proceed);
+        },
+        None,
+    );
+}
+
+/// Test that forgetting a JoinHandle (std::mem::forget) doesn't cause issues.
+/// The task continues running as if detached.
+#[test]
+fn forget_join_handle_task_continues() {
+    check_dfs(
+        || {
+            let ran = Arc::new(AtomicUsize::new(0));
+            let ran_clone = ran.clone();
+            let (tx, rx) = oneshot::channel();
+
+            let t = future::spawn(async move {
+                ran_clone.fetch_add(1, Ordering::SeqCst);
+                tx.send(()).unwrap();
+            });
+            std::mem::forget(t); // no Drop runs, task is not detached or aborted
+            future::block_on(async { rx.await.unwrap() }); // wait for the task
+            assert_eq!(ran.load(Ordering::SeqCst), 1);
+        },
+        None,
+    );
+}
+
+/// Destructors of the inner future run when the task is aborted.
+/// The DropCounter is dropped exactly once whether the task completes or is cancelled.
+#[test]
+fn abort_runs_inner_future_drop() {
+    use std::collections::HashSet;
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Clone)]
+    struct DropCounter(Arc<StdMutex<usize>>);
+
+    impl Drop for DropCounter {
+        fn drop(&mut self) {
+            *self.0.lock().unwrap() += 1;
+        }
+    }
+
+    let outcomes: Arc<StdMutex<HashSet<Result<(), Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let drop_count = Arc::new(StdMutex::new(0usize));
+            let dc = DropCounter(drop_count.clone());
+            let t = future::spawn(async move {
+                let _guard = dc;
+                future::yield_now().await;
+            });
+            t.abort();
+            let result = future::block_on(t);
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+            // The DropCounter should have been dropped exactly once,
+            // whether the task completed normally or was cancelled.
+            assert_eq!(1, *drop_count.lock().unwrap());
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<Result<(), Outcome>> = [Ok(()), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
+}
+
+/// When an aborted task's inner future is dropped, its destructor must still be
+/// able to access thread-local storage. This would fail if TLS were destroyed
+/// (via pop_local) before the inner future is dropped.
+#[test]
+fn abort_drop_can_access_thread_local() {
+    use std::collections::HashSet;
+
+    shuttle::thread_local! {
+        static TLS_COUNTER: std::cell::Cell<usize> = std::cell::Cell::new(0);
+    }
+
+    struct AccessTlsOnDrop;
+
+    impl Drop for AccessTlsOnDrop {
+        fn drop(&mut self) {
+            // This would panic with "cannot access a Thread Local Storage value
+            // during or after destruction" if TLS were already destroyed.
+            TLS_COUNTER.with(|c| c.set(c.get() + 1));
+        }
+    }
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<Result<(), Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let (tx, rx) = oneshot::channel();
+            let t = future::spawn(async move {
+                // Initialize the TLS slot and hold a guard that accesses it on drop.
+                TLS_COUNTER.with(|c| c.set(42));
+                let _guard = AccessTlsOnDrop;
+                // Signal that TLS is initialized and the guard is held.
+                tx.send(()).unwrap();
+                future::yield_now().await;
+            });
+            // Wait until the task has initialized TLS and is holding the guard.
+            future::block_on(async { rx.await.unwrap() });
+            t.abort();
+            let result = future::block_on(t);
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    // DFS must explore both: task cancelled and task completed before abort.
+    let expected: HashSet<Result<(), Outcome>> = [Ok(()), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
+}
+
+/// Aborting with AbortHandle while another task is awaiting the JoinHandle.
+#[test]
+fn abort_while_joined() {
+    use std::collections::HashSet;
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<Result<u32, Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let t = future::spawn(async move {
+                future::yield_now().await;
+                42u32
+            });
+            let abort = t.abort_handle();
+            // Spawn a task that awaits t's JoinHandle.
+            let joiner = future::spawn(t);
+            abort.abort();
+            let result = future::block_on(joiner).unwrap();
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<Result<u32, Outcome>> = [Ok(42u32), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
+}
+
+/// AbortHandle clone works the same as the original.
+#[test]
+fn abort_handle_clone() {
+    use std::collections::HashSet;
+
+    let outcomes: Arc<std::sync::Mutex<HashSet<Result<(), Outcome>>>> = Default::default();
+    let outcomes_clone = outcomes.clone();
+
+    check_dfs(
+        move || {
+            let t = future::spawn(async move {
+                future::yield_now().await;
+            });
+            let abort1 = t.abort_handle();
+            let abort2 = abort1.clone();
+            drop(abort1);
+            abort2.abort();
+            let result = future::block_on(t);
+            outcomes.lock().unwrap().insert(result.map_err(Outcome::from));
+        },
+        None,
+    );
+
+    let seen = outcomes_clone.lock().unwrap();
+    let expected: HashSet<Result<(), Outcome>> = [Ok(()), Err(Outcome::Cancelled)].into();
+    assert_eq!(*seen, expected, "expected both outcomes, saw: {:?}", *seen);
 }

--- a/wrappers/tokio/impls/tokio/inner/tests/task_abort.rs
+++ b/wrappers/tokio/impls/tokio/inner/tests/task_abort.rs
@@ -1,0 +1,221 @@
+use shuttle::check_dfs;
+use shuttle_tokio_impl_inner::task::{self, AbortHandle, JoinHandle};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use test_log::test;
+
+// ---- Basic abort via JoinHandle ----
+
+// Aborting before the task runs. abort() is a scheduling point, so DFS
+// explores interleavings where the task completes before the abort flag is set.
+#[test]
+fn tokio_abort_before_task_runs() {
+    check_dfs(
+        || {
+            let counter = Arc::new(AtomicUsize::new(0));
+            let t1: JoinHandle<()> = task::spawn({
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+            t1.abort();
+            let result = shuttle::future::block_on(t1);
+            match result {
+                Ok(()) => assert_eq!(1, counter.load(Ordering::SeqCst)),
+                Err(e) => {
+                    assert!(e.is_cancelled());
+                    assert_eq!(0, counter.load(Ordering::SeqCst));
+                }
+            }
+        },
+        None,
+    );
+}
+
+// Aborting a task mid-flight (after one yield): join resolves to Err or Ok depending on ordering.
+#[test]
+fn tokio_abort_mid_flight() {
+    check_dfs(
+        || {
+            let counter = Arc::new(AtomicUsize::new(0));
+            let t1: JoinHandle<()> = task::spawn({
+                let counter = counter.clone();
+                async move {
+                    shuttle::future::yield_now().await;
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+            let abort = t1.abort_handle();
+            let joiner: JoinHandle<Result<(), _>> = task::spawn(t1);
+            abort.abort();
+            let result = shuttle::future::block_on(joiner).unwrap();
+            // Either the task completed before abort, or it was cancelled.
+            match result {
+                Ok(()) => assert_eq!(1, counter.load(Ordering::SeqCst)),
+                Err(e) => {
+                    assert!(e.is_cancelled());
+                    assert_eq!(
+                        0,
+                        counter.load(Ordering::SeqCst),
+                        "aborted task must not increment counter"
+                    );
+                }
+            }
+        },
+        None,
+    );
+}
+
+// Aborting via AbortHandle after JoinHandle is consumed.
+#[test]
+fn tokio_abort_handle_works_after_join_consumed() {
+    check_dfs(
+        || {
+            let t1: JoinHandle<()> = task::spawn(async {
+                shuttle::future::yield_now().await;
+            });
+            let abort: AbortHandle = t1.abort_handle();
+            abort.abort();
+            let result = shuttle::future::block_on(t1);
+            // With scheduling point in abort(), both outcomes are possible.
+            match result {
+                Ok(()) => {}
+                Err(e) => assert!(e.is_cancelled()),
+            }
+        },
+        None,
+    );
+}
+
+// Calling abort() multiple times is idempotent.
+#[test]
+fn tokio_abort_idempotent() {
+    check_dfs(
+        || {
+            let t1: JoinHandle<i32> = task::spawn(async { 42 });
+            t1.abort();
+            t1.abort();
+            t1.abort();
+            let result = shuttle::future::block_on(t1);
+            match result {
+                Ok(42) => {}
+                Err(e) => assert!(e.is_cancelled()),
+                _ => panic!("unexpected result"),
+            }
+        },
+        None,
+    );
+}
+
+// Aborting a finished task returns Ok with the task's output.
+#[test]
+fn tokio_abort_finished_task_returns_ok() {
+    check_dfs(
+        || {
+            let t1: JoinHandle<u32> = task::spawn(async { 99u32 });
+            let result = shuttle::future::block_on(async move {
+                let v = t1.await.unwrap();
+                v
+            });
+            assert_eq!(99, result);
+        },
+        None,
+    );
+}
+
+// JoinError::is_cancelled() is true for aborted tasks.
+#[test]
+fn tokio_join_error_is_cancelled() {
+    check_dfs(
+        || {
+            let t1: JoinHandle<()> = task::spawn(async {
+                shuttle::future::yield_now().await;
+            });
+            t1.abort();
+            let result = shuttle::future::block_on(t1);
+            match result {
+                Ok(()) => {} // task completed before abort took effect
+                Err(e) => assert!(e.is_cancelled()),
+            }
+        },
+        None,
+    );
+}
+
+// Dropping a JoinHandle does NOT abort the task; the task runs to completion.
+#[test]
+fn tokio_drop_join_handle_detaches_not_aborts() {
+    let ran = Arc::new(AtomicUsize::new(0));
+    let ran_clone = ran.clone();
+    check_dfs(
+        move || {
+            let ran = ran.clone();
+            let t1: JoinHandle<()> = task::spawn(async move {
+                ran.fetch_add(1, Ordering::SeqCst);
+            });
+            drop(t1);
+            // Yield so the detached task gets a chance to run.
+            shuttle::future::block_on(shuttle::future::yield_now());
+        },
+        None,
+    );
+    // Across all DFS orderings, the detached task ran in at least some.
+    assert!(ran_clone.load(Ordering::SeqCst) > 0);
+}
+
+// AbortHandle clone produces a functional handle.
+#[test]
+fn tokio_abort_handle_clone() {
+    check_dfs(
+        || {
+            let t1: JoinHandle<()> = task::spawn(async {
+                shuttle::future::yield_now().await;
+            });
+            let abort1 = t1.abort_handle();
+            let abort2 = abort1.clone();
+            drop(abort1);
+            abort2.abort();
+            let result = shuttle::future::block_on(t1);
+            match result {
+                Ok(()) => {}
+                Err(e) => assert!(e.is_cancelled()),
+            }
+        },
+        None,
+    );
+}
+
+// Aborting one task does not affect a sibling task.
+#[test]
+fn tokio_abort_one_task_sibling_unaffected() {
+    check_dfs(
+        || {
+            let c1 = Arc::new(AtomicUsize::new(0));
+            let c2 = Arc::new(AtomicUsize::new(0));
+
+            let t1: JoinHandle<()> = task::spawn({
+                let c1 = c1.clone();
+                async move {
+                    shuttle::future::yield_now().await;
+                    c1.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+            let t2: JoinHandle<u32> = task::spawn({
+                let c2 = c2.clone();
+                async move {
+                    c2.fetch_add(1, Ordering::SeqCst);
+                    42u32
+                }
+            });
+
+            t1.abort();
+
+            let r2 = shuttle::future::block_on(t2);
+            assert!(r2.is_ok());
+            assert_eq!(42u32, r2.unwrap());
+            assert_eq!(1, c2.load(Ordering::SeqCst), "sibling must still run");
+        },
+        None,
+    );
+}


### PR DESCRIPTION
Previously, task abort (added in [PR #87](https://github.com/awslabs/shuttle/pull/87)) only detached the task. As [issue #91](https://github.com/awslabs/shuttle/issues/91) pointed out, this does not match tokio semantics, which state that when `abort()` is called on `JoinHandle` or `AbortHandle`, "the task is signalled to shut down next time it yields at an .await point" (ref: https://docs.rs/tokio/latest/tokio/task/).

So this PR adds a shared AtomicBool flag to the Wrapper around Shuttle futures. When `abort()` is called, the flag is set and the task is woken. On the next poll, Shuttle checks the flag, drops the inner future (allowing destructors to run while TLS is still alive), and returns `Err(JoinError::Cancelled)` to the join handle waiter.

`JoinHandle::drop()` now calls detach instead of abort, matching tokio semantics where dropping a handle lets the task continue running.

The approach here is based on the ideas sketched out by sarsko and jamesbornholt in [PR #150](https://github.com/awslabs/shuttle/pull/150) (which was yanked).

Coauthored with Opus 4.6

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.