### PR TITLE
Chore: Bump siphasher version in deterministic collections to 1

### DIFF
--- a/wrappers/collections/deterministic_collections/Cargo.toml
+++ b/wrappers/collections/deterministic_collections/Cargo.toml
@@ -6,5 +6,5 @@ license = "Apache-2.0"
 description = "HashMap and HashSet with deterministic iteration order for reproducible testing"
 
 [dependencies]
-siphasher = "0.3"
+siphasher = "1"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.