### PR TITLE
shuttle-tokio test macro: Bump default stack size

### DIFF
--- a/wrappers/tokio/impls/tokio/inner/src/lib.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/lib.rs
@@ -41,7 +41,7 @@ pub mod macros;
 #[doc(hidden)]
 pub fn default_shuttle_config() -> shuttle::Config {
     let mut config = shuttle::Config::new();
-    config.stack_size = 0x0008_0000;
+    config.stack_size = 0x000F_0000;
     config.max_steps = shuttle::MaxSteps::FailAfter(10_000_000);
     config
 }
@@ -50,7 +50,7 @@ pub fn default_shuttle_config() -> shuttle::Config {
 #[doc(hidden)]
 pub fn __default_shuttle_config() -> shuttle::Config {
     let mut config = shuttle::Config::new();
-    config.stack_size = 0x0008_0000;
+    config.stack_size = 0x000F_0000;
     config.max_steps = shuttle::MaxSteps::FailAfter(10_000_000);
     config
 }


### PR DESCRIPTION
CoroSensei requires slightly larger stacks. 

Larger stack is safer and saves developer time due to removing segfaults. Having a low stack size to avoid overallocating is premature optimization.

IMO the one in Shuttle should be increased as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.