### PR TITLE
Fix scheduling points to precede sync operations in tokio wrapper

### DIFF
--- a/wrappers/tokio/impls/tokio/inner/src/sync/notify.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/notify.rs
@@ -128,8 +128,6 @@ impl Notify {
     /// [`notified().await`] will complete immediately consuming the permit made
     /// available by this call to `notify_one()`.
     pub fn notify_one(&self) {
-        // Scheduling point precedes the visible notification operation
-        shuttle::thread::yield_now();
         let mut state = self.state.lock().unwrap();
         // Need to choose a waiter that is Pending
         let mut pending = Vec::with_capacity(state.waiters.len());
@@ -169,8 +167,6 @@ impl Notify {
     /// already registered waiters. Registering for notification is done by
     /// acquiring an instance of the `Notified` future via calling `notified()`.
     pub fn notify_waiters(&self) {
-        // Scheduling point precedes the visible notification operation
-        shuttle::thread::yield_now();
         let mut state = self.state.lock().unwrap();
         // Notify all waiters, including those not yet enabled
         let waiters = std::mem::take(&mut state.waiters);

--- a/wrappers/tokio/impls/tokio/inner/src/sync/notify.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/notify.rs
@@ -128,6 +128,8 @@ impl Notify {
     /// [`notified().await`] will complete immediately consuming the permit made
     /// available by this call to `notify_one()`.
     pub fn notify_one(&self) {
+        // Scheduling point precedes the visible notification operation
+        shuttle::thread::yield_now();
         let mut state = self.state.lock().unwrap();
         // Need to choose a waiter that is Pending
         let mut pending = Vec::with_capacity(state.waiters.len());
@@ -151,9 +153,11 @@ impl Notify {
             state.pending = false;
             drop(state);
             trace!("notify_one for {:?} waking waiter {:?}", self, waiter.id);
-            // Must set flag before notifying waiter
+            // Must set flag before notifying waiter.
+            // The send may fail if the Notified future is dropped between the flag store
+            // and the send (the flag is already NOTIFIED, so the future already completed).
             waiter.flag.store(NOTIFIED, Ordering::SeqCst);
-            waiter.tx.send(()).unwrap();
+            let _ = waiter.tx.send(());
         }
     }
 
@@ -163,8 +167,10 @@ impl Notify {
     /// `notify_one()`, no permit is stored to be used by the next call to
     /// `notified().await`. The purpose of this method is to notify all
     /// already registered waiters. Registering for notification is done by
-    /// acquiring an instance of the `Notified` future via calling `notified()`.    
+    /// acquiring an instance of the `Notified` future via calling `notified()`.
     pub fn notify_waiters(&self) {
+        // Scheduling point precedes the visible notification operation
+        shuttle::thread::yield_now();
         let mut state = self.state.lock().unwrap();
         // Notify all waiters, including those not yet enabled
         let waiters = std::mem::take(&mut state.waiters);

--- a/wrappers/tokio/impls/tokio/inner/src/sync/oneshot.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/oneshot.rs
@@ -71,9 +71,9 @@ impl<T> Sender<T> {
     /// not be sent.
     pub fn send(self, t: T) -> Result<(), T> {
         trace!("Sending message on oneshot {:p}", &self.0);
-        let send_result = self.0.send(t);
+        // Scheduling point precedes the visible send operation
         shuttle::thread::yield_now();
-        send_result
+        self.0.send(t)
     }
 
     /// Waits for the associated [`Receiver`] handle to close.
@@ -102,19 +102,20 @@ impl<T> Sender<T> {
 impl<T> Receiver<T> {
     /// Prevents the associated [`Sender`] handle from sending a value.
     pub fn close(&mut self) {
-        self.0.close();
+        // Scheduling point precedes the visible close operation
         shuttle::thread::yield_now();
+        self.0.close();
     }
 
     /// Attempts to receive a value.
     pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
-        let out = match self.0.try_recv() {
+        // Scheduling point precedes the visible receive operation
+        shuttle::thread::yield_now();
+        match self.0.try_recv() {
             Ok(Some(v)) => Ok(v),
             Ok(None) => Err(TryRecvError::Empty),
             Err(_) => Err(TryRecvError::Closed),
-        };
-        shuttle::thread::yield_now();
-        out
+        }
     }
 
     /// Blocking receive to call outside of asynchronous contexts.

--- a/wrappers/tokio/impls/tokio/inner/tests/notify.rs
+++ b/wrappers/tokio/impls/tokio/inner/tests/notify.rs
@@ -300,3 +300,23 @@ fn notify_mpmc_no_deadlock() {
 fn notify_mpmc_deadlock() {
     notify_mpmc_channel_2_test(false);
 }
+
+// Regression test: `notify_one` must not panic when the `Notified` future is
+// dropped after the waiter's flag is set to NOTIFIED but before the internal
+// oneshot send completes. This race is reachable because the oneshot `Sender::send`
+// now yields before sending, allowing the woken task to run (and drop the receiver)
+// before the send. The fix is `let _ = waiter.tx.send(())` instead of `.unwrap()`.
+#[test]
+fn notify_one_drop_notified_before_send() {
+    check_dfs(|| {
+        future::block_on(async {
+            let notify = Arc::new(Notify::new());
+            let notify2 = notify.clone();
+            let handle = future::spawn(async move {
+                notify2.notified().await;
+            });
+            notify.notify_one();
+            handle.await.unwrap();
+        });
+    });
+}

--- a/wrappers/tokio/impls/tokio/inner/tests/notify.rs
+++ b/wrappers/tokio/impls/tokio/inner/tests/notify.rs
@@ -303,20 +303,41 @@ fn notify_mpmc_deadlock() {
 
 // Regression test: `notify_one` must not panic when the `Notified` future is
 // dropped after the waiter's flag is set to NOTIFIED but before the internal
-// oneshot send completes. This race is reachable because the oneshot `Sender::send`
-// now yields before sending, allowing the woken task to run (and drop the receiver)
-// before the send. The fix is `let _ = waiter.tx.send(())` instead of `.unwrap()`.
+// oneshot send completes.
+//
+// The race:
+//   1. Spawned task polls `notified()`, enabling its waiter (flag = ENABLED).
+//   2. `handle.abort()` wakes the task so it is runnable for cancellation.
+//   3. `notify_one()` finds the ENABLED waiter, removes it, sets flag = NOTIFIED,
+//      then calls `tx.send()` which yields before the actual send.
+//   4. At that yield the DFS scheduler runs the aborted task, dropping the
+//      `Notified` future (and its oneshot receiver) while flag is already NOTIFIED.
+//   5. The send resumes and returns `Err` — `let _ =` handles it; `.unwrap()` panics.
 #[test]
 fn notify_one_drop_notified_before_send() {
     check_dfs(|| {
         future::block_on(async {
             let notify = Arc::new(Notify::new());
             let notify2 = notify.clone();
+
             let handle = future::spawn(async move {
                 notify2.notified().await;
             });
+
+            // Let the spawned task poll its Notified future, transitioning
+            // the waiter from INIT to ENABLED.
+            shuttle::future::yield_now().await;
+
+            // Abort the task — this wakes it so it is runnable for
+            // cancellation at the next scheduling point.
+            handle.abort();
+
+            // notify_one sets flag = NOTIFIED then yields inside tx.send().
+            // The DFS scheduler may run the aborted task at that yield,
+            // dropping the receiver before the send completes.
             notify.notify_one();
-            handle.await.unwrap();
+
+            let _ = handle.await;
         });
     });
 }


### PR DESCRIPTION
###  What was fixed : 

1. oneshot.rs : When sending a message, closing a channel, or trying to receive, the scheduler was being notified after the action happened. Now, this is moved to before the action happens so that scheduler gets a chance to run other tasks. 

2. notify.rs : notify_one was using .unwrap() when sending on an internal channel, which could panic. This has been changed to let _ = to safely ignore the error, since it seems expected and harmless.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.