### PR TITLE
Switch CI test runner to cargo-nextest

### DIFF
--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -42,8 +42,12 @@ jobs:
         run: cargo fmt --all -- --check
       - name: cargo doc
         run: cargo doc --no-deps
-      - name: cargo test release
-        run: cargo test --release
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: cargo nextest
+        run: cargo nextest run --release --workspace
+      - name: cargo test --doc
+        run: cargo test --release --doc --workspace
       - name: Notify failed build
         uses: jayqi/failed-build-issue-action@v1
         if: failure() 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update stable
-      - name: cargo test
-        run: cargo test --release
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: cargo nextest
+        run: cargo nextest run --release --workspace
+      - name: cargo test --doc
+        run: cargo test --release --doc --workspace
 
   fmt:
     name: rustfmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,15 @@ GitHub provides additional document on [forking a repository](https://help.githu
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 
+## Running Tests
+CI uses [cargo-nextest](https://nexte.st) for test execution. Install it once with `cargo install cargo-nextest --locked`, then run the full suite the same way CI does:
+
+```bash
+cargo nextest run --release --workspace   # unit and integration tests
+cargo test --release --doc --workspace    # doctests (nextest does not run these)
+```
+
+
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 


### PR DESCRIPTION
### Description

This PR switches the test runner in CI from `cargo test` to `cargo-nextest`. 
Doc tests will still continue to be run using `cargo test` since `cargo-nextest` does not support doc tests yet. 
More information around `cargo-nextest` can be found here : https://nexte.st/

Why switch to `cargo-nextest` ?
`cargo test` compiles all tests into a single binary and runs them as parallel threads in one process. This means a crash in one test can take down the entire suite, and shared state can leak between tests. 
`cargo-nextest` runs each test in its own isolated process, so a failure stays contained to that one test and tests can never interfere with each other. 


### Issue link : https://github.com/awslabs/shuttle/issues/284

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.