### PR TITLE
Extract shuttle-schedulers crate from shuttle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "shuttle-core",
+    "shuttle-schedulers",
     "shuttle",
     "wrappers/shuttle_rand_0.8",
     "wrappers/shuttle_sync",

--- a/shuttle-schedulers/Cargo.toml
+++ b/shuttle-schedulers/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "shuttle-schedulers"
+version = "0.1.0"
+edition = "2021"
+description = "Scheduler implementations for the Shuttle concurrency testing framework"
+license = "MIT"
+
+[dependencies]
+shuttle-core = { path = "../shuttle-core" }
+rand = "0.8.6"
+rand_pcg = "0.3.1"
+smallvec = { version = "1.11.2", features = ["const_new"] }
+tracing = { version = "0.1.36", default-features = false, features = ["std"] }
+
+[features]
+annotation = ["shuttle-core/annotation"]

--- a/shuttle-schedulers/src/annotation.rs
+++ b/shuttle-schedulers/src/annotation.rs
@@ -1,6 +1,6 @@
-use crate::annotations::{record_random, record_schedule, start_annotations, stop_annotations};
-use crate::runtime::task::{Task, TaskId};
-use crate::scheduler::{Schedule, Scheduler};
+use shuttle_core::annotations::{record_random, record_schedule, start_annotations, stop_annotations};
+use shuttle_core::runtime::task::{Task, TaskId};
+use shuttle_core::scheduler::{Schedule, Scheduler};
 
 /// An `AnnotationScheduler` wraps an inner `Scheduler` and enables the
 /// creation of an annotated schedule (for use with Shuttle Explorer).

--- a/shuttle-schedulers/src/dfs.rs
+++ b/shuttle-schedulers/src/dfs.rs
@@ -1,7 +1,7 @@
-use crate::runtime::task::{Task, TaskId};
-use crate::scheduler::data::fixed::FixedDataSource;
-use crate::scheduler::data::DataSource;
-use crate::scheduler::{Schedule, Scheduler};
+use shuttle_core::runtime::task::{Task, TaskId};
+use shuttle_core::scheduler::data::fixed::FixedDataSource;
+use shuttle_core::scheduler::data::DataSource;
+use shuttle_core::scheduler::{Schedule, Scheduler};
 
 const DFS_RANDOM_SEED: u64 = 0x12345678;
 

--- a/shuttle-schedulers/src/lib.rs
+++ b/shuttle-schedulers/src/lib.rs
@@ -1,0 +1,17 @@
+mod annotation;
+mod dfs;
+mod pct;
+mod random;
+mod replay;
+mod round_robin;
+mod uncontrolled_nondeterminism;
+mod urw;
+
+pub use annotation::AnnotationScheduler;
+pub use dfs::DfsScheduler;
+pub use pct::PctScheduler;
+pub use random::RandomScheduler;
+pub use replay::ReplayScheduler;
+pub use round_robin::RoundRobinScheduler;
+pub use uncontrolled_nondeterminism::UncontrolledNondeterminismCheckScheduler;
+pub use urw::UrwRandomScheduler;

--- a/shuttle-schedulers/src/pct.rs
+++ b/shuttle-schedulers/src/pct.rs
@@ -1,12 +1,12 @@
-use crate::runtime::task::{Task, TaskId, DEFAULT_INLINE_TASKS};
-use crate::scheduler::data::random::RandomDataSource;
-use crate::scheduler::data::DataSource;
-use crate::scheduler::{Schedule, Scheduler};
-use crate::seed_from_env;
 use rand::rngs::OsRng;
 use rand::seq::{index::sample, SliceRandom};
 use rand::{Rng, RngCore, SeedableRng};
 use rand_pcg::Pcg64Mcg;
+use shuttle_core::runtime::task::{Task, TaskId, DEFAULT_INLINE_TASKS};
+use shuttle_core::scheduler::data::random::RandomDataSource;
+use shuttle_core::scheduler::data::DataSource;
+use shuttle_core::scheduler::{Schedule, Scheduler};
+use shuttle_core::seed_from_env;
 use std::collections::{HashMap, HashSet};
 
 /// A scheduler that implements the Probabilistic Concurrency Testing (PCT) algorithm.

--- a/shuttle-schedulers/src/random.rs
+++ b/shuttle-schedulers/src/random.rs
@@ -1,12 +1,12 @@
-use crate::runtime::task::{Task, TaskId};
-use crate::scheduler::data::random::RandomDataSource;
-use crate::scheduler::data::DataSource;
-use crate::scheduler::{Schedule, Scheduler};
-use crate::seed_from_env;
 use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
 use rand::{RngCore, SeedableRng};
 use rand_pcg::Pcg64Mcg;
+use shuttle_core::runtime::task::{Task, TaskId};
+use shuttle_core::scheduler::data::random::RandomDataSource;
+use shuttle_core::scheduler::data::DataSource;
+use shuttle_core::scheduler::{Schedule, Scheduler};
+use shuttle_core::seed_from_env;
 
 /// A scheduler that randomly chooses a runnable task at each context switch.
 ///

--- a/shuttle-schedulers/src/replay.rs
+++ b/shuttle-schedulers/src/replay.rs
@@ -1,8 +1,8 @@
-use crate::runtime::task::{clock::VectorClock, Task, TaskId};
-use crate::scheduler::data::random::RandomDataSource;
-use crate::scheduler::data::DataSource;
-use crate::scheduler::serialization::deserialize_schedule;
-use crate::scheduler::{Schedule, ScheduleStep, Scheduler};
+use shuttle_core::runtime::task::{clock::VectorClock, Task, TaskId};
+use shuttle_core::scheduler::data::random::RandomDataSource;
+use shuttle_core::scheduler::data::DataSource;
+use shuttle_core::scheduler::serialization::deserialize_schedule;
+use shuttle_core::scheduler::{Schedule, ScheduleStep, Scheduler};
 use std::fs::OpenOptions;
 use std::io::Read;
 use std::path::Path;

--- a/shuttle-schedulers/src/round_robin.rs
+++ b/shuttle-schedulers/src/round_robin.rs
@@ -1,7 +1,7 @@
-use crate::runtime::task::{Task, TaskId};
-use crate::scheduler::data::random::RandomDataSource;
-use crate::scheduler::data::DataSource;
-use crate::scheduler::{Schedule, Scheduler};
+use shuttle_core::runtime::task::{Task, TaskId};
+use shuttle_core::scheduler::data::random::RandomDataSource;
+use shuttle_core::scheduler::data::DataSource;
+use shuttle_core::scheduler::{Schedule, Scheduler};
 
 /// A round robin scheduler that chooses the next available runnable task at each context switch.
 #[derive(Debug)]

--- a/shuttle-schedulers/src/uncontrolled_nondeterminism.rs
+++ b/shuttle-schedulers/src/uncontrolled_nondeterminism.rs
@@ -1,5 +1,5 @@
-use crate::runtime::task::{Task, TaskId, DEFAULT_INLINE_TASKS};
-use crate::scheduler::{Schedule, Scheduler};
+use shuttle_core::runtime::task::{Task, TaskId, DEFAULT_INLINE_TASKS};
+use shuttle_core::scheduler::{Schedule, Scheduler};
 use smallvec::SmallVec;
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/shuttle-schedulers/src/urw.rs
+++ b/shuttle-schedulers/src/urw.rs
@@ -1,12 +1,12 @@
-use crate::runtime::task::{Task, TaskId};
-use crate::scheduler::data::random::RandomDataSource;
-use crate::scheduler::data::DataSource;
-use crate::scheduler::{Schedule, Scheduler};
-use crate::seed_from_env;
 use rand::rngs::OsRng;
 use rand::seq::SliceRandom;
 use rand::{RngCore, SeedableRng};
 use rand_pcg::Pcg64Mcg;
+use shuttle_core::runtime::task::{Task, TaskId};
+use shuttle_core::scheduler::data::random::RandomDataSource;
+use shuttle_core::scheduler::data::DataSource;
+use shuttle_core::scheduler::{Schedule, Scheduler};
+use shuttle_core::seed_from_env;
 use std::collections::{HashMap, HashSet};
 use tracing::{trace, warn};
 

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 
 [dependencies]
 shuttle-core = { path = "../shuttle-core" }
+shuttle-schedulers = { path = "../shuttle-schedulers" }
 assoc = "0.1.3"
 bitvec = "1.0.1"
 cfg-if = "1.0"
@@ -51,7 +52,7 @@ bench = false
 [features]
 default = []
 vector-clocks = ["shuttle-core/vector-clocks"]
-annotation = ["shuttle-core/annotation", "dep:serde", "dep:serde_json", "dep:regex"]
+annotation = ["shuttle-core/annotation", "shuttle-schedulers/annotation", "dep:serde", "dep:serde_json", "dep:regex"]
 # The following feature overrides the `vector-clocks` feature. It SHOULD NOT be used in production.
 # Its purpose is solely to allow `cargo bench` to be run without vector clocks enabled, as they
 # are otherwise always enabled via a dev-dependency to ensure all *test* assertions utilizing vector

--- a/shuttle/src/lib.rs
+++ b/shuttle/src/lib.rs
@@ -205,10 +205,8 @@ pub use shuttle_core::{
 // Re-export constants
 pub use shuttle_core::{ANNOTATION_FILE, CAPTURE_BACKTRACE, SILENCE_WARNINGS};
 
-// Re-export internal helpers used by the scheduler impls in this crate
-#[cfg(feature = "annotation")]
-pub(crate) use shuttle_core::annotation_file;
-pub(crate) use shuttle_core::{seed_from_env, silence_warnings};
+// Re-export internal helpers used in this crate
+pub(crate) use shuttle_core::silence_warnings;
 
 /// Run the given function once under a round-robin concurrency scheduler.
 // TODO consider removing this -- round robin scheduling is never what you want.

--- a/shuttle/src/scheduler/mod.rs
+++ b/shuttle/src/scheduler/mod.rs
@@ -1,25 +1,10 @@
 //! Implementations of different scheduling strategies for concurrency testing.
 
-mod annotation;
-mod dfs;
-mod pct;
-mod random;
-mod replay;
-mod round_robin;
-mod uncontrolled_nondeterminism;
-mod urw;
-
 // Re-export core scheduler types from shuttle-core
-pub(crate) use shuttle_core::scheduler::data;
-pub(crate) use shuttle_core::scheduler::serialization;
-pub(crate) use shuttle_core::scheduler::ScheduleStep;
 pub use shuttle_core::scheduler::{DataSource, RandomDataSource, Schedule, Scheduler, Task, TaskId};
 
-pub use annotation::AnnotationScheduler;
-pub use dfs::DfsScheduler;
-pub use pct::PctScheduler;
-pub use random::RandomScheduler;
-pub use replay::ReplayScheduler;
-pub use round_robin::RoundRobinScheduler;
-pub use uncontrolled_nondeterminism::UncontrolledNondeterminismCheckScheduler;
-pub use urw::UrwRandomScheduler;
+// Re-export scheduler implementations from shuttle-schedulers
+pub use shuttle_schedulers::{
+    AnnotationScheduler, DfsScheduler, PctScheduler, RandomScheduler, ReplayScheduler, RoundRobinScheduler,
+    UncontrolledNondeterminismCheckScheduler, UrwRandomScheduler,
+};


### PR DESCRIPTION
This is the second of four PRs to refactor shuttle as discussed in https://github.com/awslabs/shuttle/issues/249.

This PR moves scheduler implementation files (random, pct, dfs, replay, round_robin, urw, annotation, uncontrolled_nondeterminism) into a new `shuttle-schedulers` crate. The shuttle crate re-exports all scheduler types so its public API is unchanged.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.