### PR TITLE
feat: add watch::Sender::clone and JoinSet::abort_all methods

### DIFF
--- a/wrappers/tokio/impls/tokio/inner/src/sync/watch.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/watch.rs
@@ -983,7 +983,7 @@ impl<T> Sender<T> {
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
-        // Mirrors tokio's behaviour: cloning bumps the sender ref count so
+        // Mirrors tokio's behavior: cloning bumps the sender ref count so
         // the channel only closes when the last sender drops.
         self.shared.ref_count_tx.fetch_add(1, Ordering::SeqCst);
         Self {

--- a/wrappers/tokio/impls/tokio/inner/src/sync/watch.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/watch.rs
@@ -129,6 +129,10 @@ struct Shared<T> {
     /// Tracks the number of `Receiver` instances.
     ref_count_rx: AtomicUsize,
 
+    /// Tracks the number of `Sender` instances. The channel is marked
+    /// closed (and receivers notified) only when the last sender drops.
+    ref_count_tx: AtomicUsize,
+
     /// Notifies waiting receivers that the value changed.
     notify_rx: Notify,
 
@@ -268,6 +272,7 @@ pub fn channel<T>(init: T) -> (Sender<T>, Receiver<T>) {
         value: RwLock::new(init),
         state: AtomicState::new(),
         ref_count_rx: AtomicUsize::new(1),
+        ref_count_tx: AtomicUsize::new(1),
         notify_rx: Notify::new(),
         notify_tx: Notify::new(),
     });
@@ -976,10 +981,23 @@ impl<T> Sender<T> {
     }
 }
 
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        // Mirrors tokio's behaviour: cloning bumps the sender ref count so
+        // the channel only closes when the last sender drops.
+        self.shared.ref_count_tx.fetch_add(1, Ordering::SeqCst);
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
-        self.shared.state.set_closed();
-        self.shared.notify_rx.notify_waiters();
+        if 1 == self.shared.ref_count_tx.fetch_sub(1, Ordering::SeqCst) {
+            self.shared.state.set_closed();
+            self.shared.notify_rx.notify_waiters();
+        }
     }
 }
 

--- a/wrappers/tokio/impls/tokio/inner/src/task.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/task.rs
@@ -296,6 +296,17 @@ pub mod join_set {
         }
     }
 
+    impl<T> JoinSet<T> {
+        /// Mirrors `tokio::task::JoinSet::abort_all`: aborts every task in the
+        /// set. Already-completed tasks are unaffected; aborted tasks remain
+        /// in the set until their `JoinError` is consumed via `join_next`.
+        pub fn abort_all(&mut self) {
+            for jh in &self.inner {
+                jh.abort();
+            }
+        }
+    }
+
     impl<T: 'static> JoinSet<T> {
         /// Spawn the provided task on the `JoinSet`, returning an [`AbortHandle`]
         /// that can be used to remotely cancel the task.


### PR DESCRIPTION
These are supported in tokio and should be included in the shuttle mock.

https://docs.rs/tokio/latest/src/tokio/sync/watch.rs.html#201-209
https://docs.rs/tokio/latest/src/tokio/task/join_set.rs.html#463-465

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.