### PR TITLE
feat(parking_lot): Rebuild Shuttle wrapper on lock_api

### DIFF
--- a/wrappers/parking_lot/parking_lot_impl/Cargo.toml
+++ b/wrappers/parking_lot/parking_lot_impl/Cargo.toml
@@ -6,14 +6,20 @@ license = "Apache-2.0"
 description = "Internal implementation of the `parking_lot` crate for use with the Shuttle concurrency testing tool. Do not depend on this crate directly; use `shuttle-parking_lot`."
 
 [features]
-arc_lock = []
+# Enable `Arc`-based lock guards (`lock_arc`, `read_arc`, `write_arc`, ...). Forwarded to `lock_api`.
+arc_lock = ["lock_api/arc_lock"]
+# `serde`/`owning_ref`/`nightly` are forwarded to `lock_api`, matching `parking_lot`'s feature set.
+serde = ["lock_api/serde"]
+owning_ref = ["lock_api/owning_ref"]
+nightly = ["lock_api/nightly"]
+# `send_guard` makes lock guards `Send` (when the data allows), mirroring `parking_lot`; see the
+# `GuardMarker` impls in mutex.rs/rwlock.rs. The remaining two features concern the native
+# `parking_lot_core` backend, which Shuttle replaces entirely, so they have no effect here.
+send_guard = []
 deadlock_detection = []
 hardware-lock-elision = []
-nightly = []
-owning_ref = []
-send_guard = []
-serde = []
 
 [dependencies]
 shuttle = { path = "../../../shuttle", version = "<0.10"}
+lock_api = "0.4"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }

--- a/wrappers/parking_lot/parking_lot_impl/README.md
+++ b/wrappers/parking_lot/parking_lot_impl/README.md
@@ -1,6 +1,27 @@
 # Shuttle support for `parking_lot`
 
-This crate contains the implementation that enables testing of applications that use [parking_lot](https://crates.io/crates/parking_lot) with Shuttle. It should not be depended on directly, depend on `shuttle-parking_lot` instead.
+This crate contains the implementation that enables testing of applications that use
+[parking_lot](https://crates.io/crates/parking_lot) with Shuttle. It should not be depended on
+directly, depend on `shuttle-parking_lot` instead.
+
+## Implementation
+
+Like the real `parking_lot` crate, these implementations are layered on top of the
+[`lock_api`](https://crates.io/crates/lock_api) crate. This crate supplies Shuttle-backed *raw*
+locks (`RawMutex` and `RawRwLock`, built on Shuttle's `BatchSemaphore`) that implement the relevant
+`lock_api` raw traits; the user-facing `Mutex`/`RwLock`, their guards, the mapped guards, and the
+`Arc`-based guards are the generic `lock_api` types specialised to those raw locks. As a result the
+`Mutex`/`RwLock` surface — including `lock_arc`/`read_arc`/`write_arc`, upgradable reads, and
+downgrading — matches `parking_lot`, and the `lock_api` raw types are re-exported so code that names
+`parking_lot::RawMutex`, `parking_lot::RawRwLock`, `parking_lot::ArcRwLockReadGuard`, etc. continues
+to compile under the Shuttle feature.
 
 ## Limitations
-Shuttle's parking_lot functionality is currently limited to a subset of the `Mutex` and `RwLock` primitives. If your project needs functionality which is not currently supported, please file an issue or, better yet, open a PR to contribute the functionality.
+
+Shuttle's `parking_lot` functionality currently covers the `Mutex` and `RwLock` primitives (and
+their guards, including the `Arc`-based and mapped guards). Other `parking_lot` types (for example
+`ReentrantMutex` and `Condvar`), the `*Timed` lock APIs, and recursive read locks
+(`RwLock::read_recursive`) are not yet provided. As in `parking_lot`, guards are `!Send` by default
+and become `Send` (when the data allows) under the `send_guard` feature. If your project needs
+functionality which is not currently supported, please file an issue or, better yet, open a PR to
+contribute the functionality.

--- a/wrappers/parking_lot/parking_lot_impl/src/lib.rs
+++ b/wrappers/parking_lot/parking_lot_impl/src/lib.rs
@@ -5,9 +5,57 @@
 //! [`Shuttle`]: <https://crates.io/crates/shuttle>
 //!
 //! [`parking_lot`]: <https://crates.io/crates/parking_lot>
+//!
+//! # Architecture
+//!
+//! These implementations are built on top of the [`lock_api`] crate, exactly like the real
+//! `parking_lot` crate, and the module layout mirrors `parking_lot`'s:
+//!
+//! * `raw_mutex` / `raw_rwlock` contain the Shuttle-backed *raw* locks (`RawMutex` / `RawRwLock`,
+//!   built on Shuttle's `BatchSemaphore`) that route their blocking through Shuttle's scheduler by
+//!   implementing the relevant `lock_api` raw traits.
+//! * `mutex` / `rwlock` contain the user-facing `Mutex` / `RwLock` types, which are the generic
+//!   `lock_api` containers and guards specialised to those raw locks.
+//!
+//! This layering means the entire `parking_lot` guard surface — `Arc` guards, mapped guards,
+//! upgradable guards — is available under Shuttle without reimplementing it by hand.
 
 mod mutex;
+mod raw_mutex;
+mod raw_rwlock;
 mod rwlock;
 
-pub use mutex::*;
-pub use rwlock::*;
+// The marker that determines whether lock guards are `Send`, defined once here and referenced as
+// `crate::GuardMarker` by both raw lock impls (mirroring `parking_lot`'s own `lib.rs`). It gates
+// `Send` *in addition to* the data type: `lock_api`'s guards carry a `PhantomData<(&mut T,
+// GuardMarker)>`, so a guard is `Send` only when both the data permits it and this marker is `Send`.
+// We follow `parking_lot`'s `send_guard` feature exactly — guards are `!Send` by default and become
+// `Send` (when the data allows) with `send_guard` — so the Shuttle build's `Send` contract is
+// identical to production `parking_lot`. This is a private implementation detail, not public API.
+#[cfg(feature = "send_guard")]
+type GuardMarker = ::lock_api::GuardSend;
+#[cfg(not(feature = "send_guard"))]
+type GuardMarker = ::lock_api::GuardNoSend;
+
+// Re-export the public surface explicitly (rather than globbing the modules) so the crate's public
+// API is a deliberate, reviewable list that mirrors `parking_lot`'s own `lib.rs`. This matters
+// because `shuttle-parking_lot` re-exports this crate wholesale, so anything public here becomes
+// part of the client-facing `parking_lot` namespace.
+pub use self::raw_mutex::RawMutex;
+pub use self::raw_rwlock::RawRwLock;
+
+pub use self::mutex::{MappedMutexGuard, Mutex, MutexGuard, const_mutex};
+pub use self::rwlock::{
+    MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard,
+    RwLockWriteGuard, const_rwlock,
+};
+
+// The `Arc`-based guards are plain re-exports of the generic `lock_api` guard types (gated on
+// `arc_lock`), placed here at the crate root exactly as `parking_lot` does in its `lib.rs`.
+#[cfg(feature = "arc_lock")]
+pub use ::lock_api::{ArcMutexGuard, ArcRwLockReadGuard, ArcRwLockUpgradableReadGuard, ArcRwLockWriteGuard};
+
+// Re-export `lock_api` to mirror `parking_lot`'s own `pub use lock_api;`, so code that refers to
+// `parking_lot::lock_api::...` continues to resolve under the Shuttle feature. This is the same
+// `lock_api` instance the type aliases are built from, so the types unify.
+pub use ::lock_api;

--- a/wrappers/parking_lot/parking_lot_impl/src/mutex.rs
+++ b/wrappers/parking_lot/parking_lot_impl/src/mutex.rs
@@ -1,146 +1,100 @@
-//! An asynchronous mutual exclusion primitive.
+//! The user-facing `Mutex` types, mirroring [`parking_lot`]'s `mutex` module.
+//!
+//! These are the generic [`lock_api`] `Mutex` types specialised to Shuttle's
+//! [`RawMutex`](crate::RawMutex). The `Arc`-based [`ArcMutexGuard`](lock_api::ArcMutexGuard)
+//! is re-exported from the crate root (see `lib.rs`), matching `parking_lot`.
+//!
+//! [`parking_lot`]: <https://crates.io/crates/parking_lot>
 
-// This implementation is adapted from the one in shuttle-tokio
+use crate::raw_mutex::RawMutex;
 
-use shuttle::future::batch_semaphore::{BatchSemaphore, Fairness, TryAcquireError};
-use std::cell::UnsafeCell;
-use std::error::Error;
-use std::fmt::{self, Debug, Display};
-use std::ops::{Deref, DerefMut};
-use std::thread;
-use tracing::trace;
+/// A mutual exclusion primitive, backed by Shuttle. Mirrors `parking_lot::Mutex`.
+pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
 
-/// An asynchronous mutex
-pub struct Mutex<T: ?Sized> {
-    semaphore: BatchSemaphore,
-    inner: UnsafeCell<T>,
+/// An RAII scoped lock guard for a [`Mutex`]. Mirrors `parking_lot::MutexGuard`.
+pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
+
+/// An RAII mutex guard returned by `MutexGuard::map`. Mirrors `parking_lot::MappedMutexGuard`.
+pub type MappedMutexGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawMutex, T>;
+
+/// Creates a new mutex in an unlocked state ready for use.
+///
+/// This allows creating a mutex in a constant context on stable Rust. Mirrors
+/// `parking_lot::const_mutex`.
+pub const fn const_mutex<T>(val: T) -> Mutex<T> {
+    Mutex::const_new(<RawMutex as lock_api::RawMutex>::INIT, val)
 }
 
-/// A handle to a held `Mutex`. The guard can be held across any `.await` point
-/// as it is [`Send`].
-pub struct MutexGuard<'a, T: ?Sized> {
-    mutex: &'a Mutex<T>,
-}
+#[cfg(test)]
+mod tests {
+    use super::Mutex;
+    use shuttle::{check_dfs, thread};
+    use std::sync::Arc;
 
-impl<T: ?Sized + Display> Display for MutexGuard<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Display::fmt(&**self, f)
-    }
-}
-
-/// Error returned from the [`Mutex::try_lock`], `RwLock::try_read` and
-/// `RwLock::try_write` functions.
-#[derive(Debug)]
-pub struct TryLockError(pub(super) ());
-
-impl Display for TryLockError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "operation would block")
-    }
-}
-
-impl Error for TryLockError {}
-
-// As long as T: Send, it's fine to send and share Mutex<T> between threads.
-// If T was not Send, sending and sharing a Mutex<T> would be bad, since you can
-// access T through Mutex<T>.
-unsafe impl<T> Send for Mutex<T> where T: ?Sized + Send {}
-unsafe impl<T> Sync for Mutex<T> where T: ?Sized + Send {}
-unsafe impl<T> Sync for MutexGuard<'_, T> where T: ?Sized + Send + Sync {}
-
-impl<T> Mutex<T> {
-    /// Creates a new lock in an unlocked state ready for use.
-    pub const fn new(t: T) -> Self {
-        Self {
-            semaphore: BatchSemaphore::const_new(1, Fairness::StrictlyFair),
-            inner: UnsafeCell::new(t),
-        }
+    #[test]
+    fn smoke() {
+        check_dfs(
+            || {
+                let m = Mutex::new(0);
+                *m.lock() += 1;
+                assert_eq!(*m.lock(), 1);
+            },
+            None,
+        );
     }
 
-    /// Consumes the mutex, returning the underlying data.
-    pub fn into_inner(self) -> T {
-        self.inner.into_inner()
-    }
-}
-
-impl<T: ?Sized> Mutex<T> {
-    fn acquire(&self) {
-        trace!("acquiring parking_lot lock {:p}", self);
-        self.semaphore.acquire_blocking(1).unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and
-            // we own it exclusively, which means that this can never happen.
-            if !thread::panicking() {
-                unreachable!()
-            }
-        });
-        trace!("acquired parking_lot lock {:p}", self);
+    #[test]
+    fn try_lock_contended() {
+        check_dfs(
+            || {
+                let m = Arc::new(Mutex::new(()));
+                let _g = m.lock();
+                // Held by the current task, so a non-blocking try must fail.
+                assert!(m.try_lock().is_none());
+            },
+            None,
+        );
     }
 
-    /// Acquires a mutex, blocking the current thread until it is able to do so.
-    pub fn lock(&self) -> MutexGuard<'_, T> {
-        self.acquire();
-
-        MutexGuard { mutex: self }
+    #[test]
+    fn mutex_no_lost_updates() {
+        check_dfs(
+            || {
+                let m = Arc::new(Mutex::new(0usize));
+                let m2 = m.clone();
+                let t = thread::spawn(move || {
+                    *m2.lock() += 1;
+                });
+                *m.lock() += 1;
+                t.join().unwrap();
+                // Both increments must be observed; a broken `unlock` or missing exclusion would
+                // let the two read-modify-write sequences interleave and drop one update.
+                assert_eq!(*m.lock(), 2);
+            },
+            None,
+        );
     }
 
-    fn try_acquire(&self) -> Result<(), TryAcquireError> {
-        self.semaphore.try_acquire(1)
-    }
-
-    /// Attempts to acquire this lock.
-    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
-        match self.try_acquire() {
-            Ok(()) => Some(MutexGuard { mutex: self }),
-            Err(_) => None,
-        }
-    }
-}
-
-impl<T: ?Sized + Debug> Debug for Mutex<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // SAFETY: Shuttle is running single-threaded, only we are able to access `inner` at the time of this call.
-        Debug::fmt(&unsafe { &*self.inner.get() }, f)
-    }
-}
-
-impl<T: ?Sized> Deref for MutexGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.mutex.inner.get() }
-    }
-}
-
-impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.mutex.inner.get() }
-    }
-}
-
-impl<T: ?Sized> Drop for MutexGuard<'_, T> {
-    fn drop(&mut self) {
-        trace!("releasing lock {:p}", self);
-        self.mutex.semaphore.release(1);
-    }
-}
-
-impl<T: ?Sized + Debug> Debug for MutexGuard<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Debug::fmt(&self.mutex, f)
-    }
-}
-
-impl<T> From<T> for Mutex<T> {
-    fn from(s: T) -> Self {
-        Self::new(s)
-    }
-}
-
-impl<T> Default for Mutex<T>
-where
-    T: Default,
-{
-    fn default() -> Self {
-        Self::new(T::default())
+    #[cfg(feature = "arc_lock")]
+    #[test]
+    fn arc_guard_mutual_exclusion() {
+        check_dfs(
+            || {
+                let m = Arc::new(Mutex::new(0usize));
+                let m2 = m.clone();
+                let t = thread::spawn(move || {
+                    // `lock_arc` returns an owned guard with no lifetime tied to `m2`.
+                    let mut g = m2.lock_arc();
+                    *g += 1;
+                });
+                {
+                    let mut g = m.lock_arc();
+                    *g += 1;
+                }
+                t.join().unwrap();
+                assert_eq!(*m.lock(), 2);
+            },
+            None,
+        );
     }
 }

--- a/wrappers/parking_lot/parking_lot_impl/src/raw_mutex.rs
+++ b/wrappers/parking_lot/parking_lot_impl/src/raw_mutex.rs
@@ -1,0 +1,66 @@
+//! The Shuttle-backed raw mutex that underpins [`crate::Mutex`].
+//!
+//! This provides [`RawMutex`], an implementation of [`lock_api::RawMutex`] (and the fair variant)
+//! routed through Shuttle's scheduler. The user-facing `Mutex`/`MutexGuard`/`ArcMutexGuard` are the
+//! generic `lock_api` types specialised to this raw lock (see [`crate::Mutex`]), exactly how the
+//! real `parking_lot` crate layers its `Mutex` on top of `lock_api`.
+
+use shuttle::future::batch_semaphore::{BatchSemaphore, Fairness};
+use std::thread;
+use tracing::trace;
+
+/// A Shuttle-backed raw mutex implementing [`lock_api::RawMutex`].
+///
+/// The lock is modelled as a [`BatchSemaphore`] with a single permit: acquiring the lock takes the
+/// permit, releasing it returns the permit. All blocking happens through Shuttle's scheduler, so
+/// every lock/unlock is a scheduling point that Shuttle can explore.
+#[derive(Debug)]
+pub struct RawMutex {
+    semaphore: BatchSemaphore,
+}
+
+// Safety: `RawMutex` guarantees exclusivity because the underlying semaphore has exactly one permit,
+// so at most one context can hold the lock at a time.
+unsafe impl lock_api::RawMutex for RawMutex {
+    // A "non-constant" const item is the legacy `lock_api` mechanism for supplying an initial value
+    // to a `const`-constructed lock. `BatchSemaphore::const_new` lets us honour it. Because a `const`
+    // is a value template (not a shared `static`), every `Mutex::new` materialises a fresh
+    // semaphore; the semaphore registers with the current Shuttle execution lazily on first use.
+    #[allow(clippy::declare_interior_mutable_const)]
+    const INIT: RawMutex = RawMutex {
+        semaphore: BatchSemaphore::const_new(1, Fairness::StrictlyFair),
+    };
+
+    // Gated by `send_guard`; defined once as `crate::GuardMarker` (see `lib.rs`).
+    type GuardMarker = crate::GuardMarker;
+
+    fn lock(&self) {
+        trace!("acquiring parking_lot mutex {:p}", self);
+        self.semaphore.acquire_blocking(1).unwrap_or_else(|_| {
+            // The semaphore is never explicitly closed and we own it exclusively, so a closed
+            // semaphore here can only be observed while unwinding from a panic.
+            if !thread::panicking() {
+                unreachable!()
+            }
+        });
+        trace!("acquired parking_lot mutex {:p}", self);
+    }
+
+    fn try_lock(&self) -> bool {
+        self.semaphore.try_acquire(1).is_ok()
+    }
+
+    unsafe fn unlock(&self) {
+        trace!("releasing parking_lot mutex {:p}", self);
+        self.semaphore.release(1);
+    }
+}
+
+// Safety: Shuttle's semaphore is strictly fair, so a plain `release` already hands the permit to the
+// next waiter in FIFO order. Fair unlocking is therefore identical to a normal unlock.
+unsafe impl lock_api::RawMutexFair for RawMutex {
+    unsafe fn unlock_fair(&self) {
+        trace!("fair-releasing parking_lot mutex {:p}", self);
+        self.semaphore.release(1);
+    }
+}

--- a/wrappers/parking_lot/parking_lot_impl/src/raw_rwlock.rs
+++ b/wrappers/parking_lot/parking_lot_impl/src/raw_rwlock.rs
@@ -1,0 +1,208 @@
+//! The Shuttle-backed raw reader-writer lock that underpins [`crate::RwLock`].
+//!
+//! This provides [`RawRwLock`], an implementation of [`lock_api::RawRwLock`] and its upgrade,
+//! downgrade, and fair extensions, routed through Shuttle's scheduler. The user-facing `RwLock`,
+//! guards, and `Arc`-based guards are the generic `lock_api` types specialised to this raw lock
+//! (see [`crate::RwLock`]), exactly how the real `parking_lot` crate layers its `RwLock` on top of
+//! `lock_api`.
+//!
+//! # Modelling
+//!
+//! The lock is modelled with two [`BatchSemaphore`]s:
+//!
+//! * `sem` holds `MAX_READERS` permits. A shared (read) lock takes a single permit; an exclusive
+//!   (write) lock takes *all* `MAX_READERS` permits, so it can only be held when no readers are
+//!   present.
+//! * `upgradable_sem` holds a single permit and is taken by an upgradable read lock, guaranteeing
+//!   there is at most one upgradable reader at a time (a requirement for deadlock-free upgrades). An
+//!   upgradable reader also takes one permit from `sem`, so it behaves like a shared reader that can
+//!   later escalate to a writer.
+
+use shuttle::future::batch_semaphore::{BatchSemaphore, Fairness};
+use std::thread;
+use tracing::trace;
+
+/// Sentinel permit count representing "all readers". An exclusive (write) lock is modelled by
+/// acquiring all `MAX_READERS` permits, so it can only be taken when no reader holds one; a shared
+/// (read) lock takes a single permit. This also bounds the number of concurrent readers, but the
+/// bound (~2.3×10^18 on a 64-bit target) is unreachable in any Shuttle execution.
+///
+/// Shuttle's `BatchSemaphore` stores its permit count as a plain `usize` (no reserved bits, unlike
+/// tokio's native `Semaphore`), and correct lock pairing keeps the available count within
+/// `[0, MAX_READERS]`, so this value cannot overflow the semaphore's accounting. `usize::MAX >> 3`
+/// leaves an 8x defensive margin while staying close to `parking_lot`'s own large reader capacity.
+const MAX_READERS: usize = usize::MAX >> 3;
+
+/// A Shuttle-backed raw reader-writer lock implementing [`lock_api::RawRwLock`] and its upgrade,
+/// downgrade, and fair extensions.
+#[derive(Debug)]
+pub struct RawRwLock {
+    /// Coordinates read/write access. `MAX_READERS` permits total; a read takes 1, a write takes all.
+    sem: BatchSemaphore,
+    /// Ensures at most one upgradable reader exists at a time.
+    upgradable_sem: BatchSemaphore,
+}
+
+impl RawRwLock {
+    #[inline]
+    fn acquire(sem: &BatchSemaphore, permits: usize) {
+        sem.acquire_blocking(permits).unwrap_or_else(|_| {
+            // The semaphores are never explicitly closed and are owned exclusively by this lock, so
+            // a closed semaphore here can only be observed while unwinding from a panic.
+            if !thread::panicking() {
+                unreachable!()
+            }
+        });
+    }
+}
+
+// Safety: exclusivity is guaranteed because a writer acquires all `MAX_READERS` permits of `sem`,
+// which cannot succeed while any reader holds a permit, and a reader cannot acquire a permit while a
+// writer holds them all.
+unsafe impl lock_api::RawRwLock for RawRwLock {
+    #[allow(clippy::declare_interior_mutable_const)]
+    const INIT: RawRwLock = RawRwLock {
+        sem: BatchSemaphore::const_new(MAX_READERS, Fairness::StrictlyFair),
+        upgradable_sem: BatchSemaphore::const_new(1, Fairness::StrictlyFair),
+    };
+
+    // Gated by `send_guard`; defined once as `crate::GuardMarker` (see `lib.rs`).
+    type GuardMarker = crate::GuardMarker;
+
+    fn lock_shared(&self) {
+        trace!("acquiring parking_lot rwlock {:p} (shared)", self);
+        Self::acquire(&self.sem, 1);
+        trace!("acquired parking_lot rwlock {:p} (shared)", self);
+    }
+
+    fn try_lock_shared(&self) -> bool {
+        self.sem.try_acquire(1).is_ok()
+    }
+
+    unsafe fn unlock_shared(&self) {
+        trace!("releasing parking_lot rwlock {:p} (shared)", self);
+        self.sem.release(1);
+    }
+
+    fn lock_exclusive(&self) {
+        trace!("acquiring parking_lot rwlock {:p} (exclusive)", self);
+        Self::acquire(&self.sem, MAX_READERS);
+        trace!("acquired parking_lot rwlock {:p} (exclusive)", self);
+    }
+
+    fn try_lock_exclusive(&self) -> bool {
+        self.sem.try_acquire(MAX_READERS).is_ok()
+    }
+
+    unsafe fn unlock_exclusive(&self) {
+        trace!("releasing parking_lot rwlock {:p} (exclusive)", self);
+        self.sem.release(MAX_READERS);
+    }
+}
+
+// Safety: Shuttle's semaphore is strictly fair, so a plain `release` already hands permits to the
+// next waiter in FIFO order. Fair unlocking is therefore identical to a normal unlock.
+unsafe impl lock_api::RawRwLockFair for RawRwLock {
+    unsafe fn unlock_shared_fair(&self) {
+        self.sem.release(1);
+    }
+
+    unsafe fn unlock_exclusive_fair(&self) {
+        self.sem.release(MAX_READERS);
+    }
+}
+
+// Safety: downgrading only ever releases permits, so it cannot violate exclusivity; the caller
+// still holds a shared permit afterwards.
+unsafe impl lock_api::RawRwLockDowngrade for RawRwLock {
+    unsafe fn downgrade(&self) {
+        // Exclusive holds all `MAX_READERS` permits; a shared lock holds 1. Release the difference,
+        // keeping one so no writer can slip in during the transition.
+        trace!("downgrading parking_lot rwlock {:p} (exclusive -> shared)", self);
+        self.sem.release(MAX_READERS - 1);
+    }
+}
+
+// Safety: an upgradable lock holds exactly one `sem` permit plus the single `upgradable_sem` permit,
+// so it excludes writers and other upgradable readers while still permitting plain shared readers.
+unsafe impl lock_api::RawRwLockUpgrade for RawRwLock {
+    fn lock_upgradable(&self) {
+        trace!("acquiring parking_lot rwlock {:p} (upgradable)", self);
+        // Take the upgradable slot first, then a shared permit. Ordering matters so that a failed
+        // acquisition never leaves the upgradable slot held while blocking on `sem`.
+        Self::acquire(&self.upgradable_sem, 1);
+        Self::acquire(&self.sem, 1);
+        trace!("acquired parking_lot rwlock {:p} (upgradable)", self);
+    }
+
+    fn try_lock_upgradable(&self) -> bool {
+        if self.upgradable_sem.try_acquire(1).is_err() {
+            return false;
+        }
+        if self.sem.try_acquire(1).is_err() {
+            // Roll back the upgradable slot so we don't leak it.
+            self.upgradable_sem.release(1);
+            return false;
+        }
+        true
+    }
+
+    unsafe fn unlock_upgradable(&self) {
+        trace!("releasing parking_lot rwlock {:p} (upgradable)", self);
+        self.sem.release(1);
+        self.upgradable_sem.release(1);
+    }
+
+    unsafe fn upgrade(&self) {
+        trace!("upgrading parking_lot rwlock {:p} (upgradable -> exclusive)", self);
+        // We currently hold 1 `sem` permit; acquire the remaining `MAX_READERS - 1`. Using the
+        // semaphore's `upgrade` (rather than a naive acquire) preserves FIFO ordering and avoids the
+        // deadlock where the upgrader would block on the very permit it already holds. The returned
+        // future must be driven to completion via `block_on`.
+        shuttle::future::block_on(self.sem.upgrade(1, MAX_READERS)).unwrap_or_else(|_| {
+            if !thread::panicking() {
+                unreachable!()
+            }
+        });
+        // Now an exclusive writer; release the upgradable slot so future upgradable readers may
+        // queue (they will still block on `sem` until we release exclusive access).
+        self.upgradable_sem.release(1);
+    }
+
+    unsafe fn try_upgrade(&self) -> bool {
+        // We hold 1 `sem` permit; grabbing the remaining `MAX_READERS - 1` yields exclusive access.
+        if self.sem.try_acquire(MAX_READERS - 1).is_ok() {
+            self.upgradable_sem.release(1);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+// Safety: these conversions preserve the invariant that a writer always holds all permits and an
+// upgradable/shared reader holds at least one, so no illegal overlap is possible mid-transition.
+unsafe impl lock_api::RawRwLockUpgradeDowngrade for RawRwLock {
+    unsafe fn downgrade_upgradable(&self) {
+        // Upgradable (1 `sem` + upgradable slot) -> shared (1 `sem`). Just drop the upgradable slot.
+        trace!("downgrading parking_lot rwlock {:p} (upgradable -> shared)", self);
+        self.upgradable_sem.release(1);
+    }
+
+    unsafe fn downgrade_to_upgradable(&self) {
+        // Exclusive (all permits) -> upgradable (1 `sem` + upgradable slot). While exclusive, no
+        // other upgradable reader can exist, so the upgradable slot is free and acquiring it cannot
+        // block. Take it first, then release down to a single `sem` permit.
+        trace!("downgrading parking_lot rwlock {:p} (exclusive -> upgradable)", self);
+        Self::acquire(&self.upgradable_sem, 1);
+        self.sem.release(MAX_READERS - 1);
+    }
+}
+
+// Safety: fair unlocking is identical to normal unlocking for a strictly fair semaphore.
+unsafe impl lock_api::RawRwLockUpgradeFair for RawRwLock {
+    unsafe fn unlock_upgradable_fair(&self) {
+        self.sem.release(1);
+        self.upgradable_sem.release(1);
+    }
+}

--- a/wrappers/parking_lot/parking_lot_impl/src/rwlock.rs
+++ b/wrappers/parking_lot/parking_lot_impl/src/rwlock.rs
@@ -1,496 +1,52 @@
-//! An asynchronous reader-writer lock.
+//! The user-facing `RwLock` types, mirroring [`parking_lot`]'s `rwlock` module.
+//!
+//! These are the generic [`lock_api`] `RwLock` types specialised to Shuttle's
+//! [`RawRwLock`](crate::RawRwLock). The `Arc`-based guards
+//! ([`ArcRwLockReadGuard`](lock_api::ArcRwLockReadGuard) etc.) are re-exported from the crate root
+//! (see `lib.rs`), matching `parking_lot`.
+//!
+//! [`parking_lot`]: <https://crates.io/crates/parking_lot>
 
-// This implementation is adapted from the one in shuttle-tokio
+use crate::raw_rwlock::RawRwLock;
 
-use shuttle::future::batch_semaphore::{BatchSemaphore, Fairness, TryAcquireError};
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
-use std::{fmt, ops};
-use tracing::trace;
+/// A reader-writer lock, backed by Shuttle. Mirrors `parking_lot::RwLock`.
+pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
 
-const MAX_READERS: usize = usize::MAX >> 3;
+/// RAII structure used to release shared read access when dropped. Mirrors
+/// `parking_lot::RwLockReadGuard`.
+pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
 
-/// A reader-writer lock
-#[derive(Debug)]
-pub struct RwLock<T: ?Sized> {
-    // maximum number of concurrent readers
-    max_readers: usize,
+/// RAII structure used to release exclusive write access when dropped. Mirrors
+/// `parking_lot::RwLockWriteGuard`.
+pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
 
-    //semaphore to coordinate read and write access to T
-    sem: BatchSemaphore,
+/// RAII read lock guard returned by `RwLockReadGuard::map`. Mirrors
+/// `parking_lot::MappedRwLockReadGuard`.
+pub type MappedRwLockReadGuard<'a, T> = lock_api::MappedRwLockReadGuard<'a, RawRwLock, T>;
 
-    // There can only be one upgradable read at a time, so this semaphore
-    // is used to ensure that.
-    upgradable_read_sem: BatchSemaphore,
+/// RAII write lock guard returned by `RwLockWriteGuard::map`. Mirrors
+/// `parking_lot::MappedRwLockWriteGuard`.
+pub type MappedRwLockWriteGuard<'a, T> = lock_api::MappedRwLockWriteGuard<'a, RawRwLock, T>;
 
-    //inner data T
-    inner: UnsafeCell<T>,
-}
+/// RAII structure used to release upgradable read access when dropped. Mirrors
+/// `parking_lot::RwLockUpgradableReadGuard`.
+pub type RwLockUpgradableReadGuard<'a, T> = lock_api::RwLockUpgradableReadGuard<'a, RawRwLock, T>;
 
-impl<T> RwLock<T> {
-    /// Creates a new instance of an `RwLock<T>` which is unlocked.
-    pub const fn new(value: T) -> Self {
-        Self::with_max_readers(value, MAX_READERS)
-    }
-
-    /// Creates a new instance of an `RwLock<T>` which is unlocked
-    /// and allows a maximum of `max_readers` concurrent readers.
-    const fn with_max_readers(value: T, max_readers: usize) -> Self {
-        RwLock {
-            max_readers,
-            sem: BatchSemaphore::const_new(max_readers, Fairness::StrictlyFair),
-            upgradable_read_sem: BatchSemaphore::const_new(1, Fairness::StrictlyFair),
-            inner: UnsafeCell::new(value),
-        }
-    }
-}
-
-impl<T: ?Sized> RwLock<T> {
-    /// Locks this `RwLock` with shared read access, blocking the current thread
-    /// until it can be acquired.
-    ///
-    /// The calling thread will be blocked until there are no more writers which
-    /// hold the lock. There may be other readers currently inside the lock when
-    /// this method returns.
-    ///
-    /// Note that attempts to recursively acquire a read lock on a `RwLock` when
-    /// the current thread already holds one may result in a deadlock.
-    ///
-    /// Returns an RAII guard which will release this thread's shared access
-    /// once it is dropped.
-    #[inline]
-    pub fn read(&self) -> RwLockReadGuard<'_, T> {
-        trace!("parking_lot rwlock {:p} read acquiring RwLockReadGuard", self);
-        self.sem.acquire_blocking(1).unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            if !std::thread::panicking() {
-                unreachable!()
-            }
-        });
-
-        trace!("parking_lot rwlock {:p} read acquired RwLockReadGuard", self);
-
-        RwLockReadGuard {
-            sem: &self.sem,
-            data: self.inner.get(),
-            _p: PhantomData,
-        }
-    }
-
-    /// Attempts to acquire this `RwLock` with shared read access.
-    ///
-    /// If the access couldn't be acquired immediately, returns [`TryLockError`].
-    /// Otherwise, an RAII guard is returned which will release read access
-    /// when dropped.
-    pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
-        trace!("parking_lot rwlock {:p} try_read acquiring RwlockReadGuard", self);
-
-        match self.sem.try_acquire(1) {
-            Ok(permit) => permit,
-            Err(TryAcquireError::NoPermits) => return None,
-            Err(TryAcquireError::Closed) => {
-                if !std::thread::panicking() {
-                    unreachable!()
-                }
-                return None;
-            }
-        }
-
-        trace!("parking_lot rwlock {:p} try_read acquired RwLockReadGuard", self);
-
-        Some(RwLockReadGuard {
-            sem: &self.sem,
-            data: self.inner.get(),
-            _p: PhantomData,
-        })
-    }
-
-    /// Locks this `RwLock` with exclusive write access, blocking the current
-    /// thread until it can be acquired.
-    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
-        trace!("parking_lot rwlock {:p} write acquiring RwLockWriteGuard", self);
-        self.sem.acquire_blocking(self.max_readers).unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            if !std::thread::panicking() {
-                unreachable!()
-            }
-        });
-
-        trace!("parking_lot rwlock {:p} write acquired RwLockWriteGuard", self);
-        RwLockWriteGuard {
-            permits_acquired: self.max_readers,
-            sem: &self.sem,
-            data: self.inner.get(),
-            _p: PhantomData,
-        }
-    }
-
-    /// Attempts to acquire this `RwLock` with exclusive write access.
-    ///
-    /// If the access couldn't be acquired immediately, returns [`TryLockError`].
-    /// Otherwise, an RAII guard is returned which will release write access
-    /// when dropped.
-    pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
-        tracing::trace!("parking_lot rwlock {:p} try_write acquiring RwLockWriteGuard", self);
-
-        match self.sem.try_acquire(self.max_readers) {
-            Ok(permit) => permit,
-            Err(TryAcquireError::NoPermits) => return None,
-            Err(TryAcquireError::Closed) => {
-                if !std::thread::panicking() {
-                    unreachable!()
-                }
-                return None;
-            }
-        }
-
-        tracing::trace!("parking_lot rwlock {:p} try_write acquired RwLockWriteGuard", self);
-
-        Some(RwLockWriteGuard {
-            permits_acquired: self.max_readers,
-            sem: &self.sem,
-            data: self.inner.get(),
-            _p: PhantomData,
-        })
-    }
-
-    /// Locks this `RwLock` with upgradable read access, blocking the current
-    /// thread until it can be acquired.
-    #[inline]
-    #[track_caller]
-    pub fn upgradable_read(&self) -> RwLockUpgradableReadGuard<'_, T> {
-        trace!(
-            "parking_lot rwlock {:p} upgradeable_read acquiring upgradable_read_sem",
-            self
-        );
-
-        self.upgradable_read_sem.acquire_blocking(1).unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            if !std::thread::panicking() {
-                unreachable!()
-            }
-        });
-
-        trace!(
-            "parking_lot rwlock {:p} upgradeable_read acquiring RwLockUpgradableReadGuard",
-            self
-        );
-
-        let drop_guard = UpgradableRwLockSemWrapper {
-            upgradable_read_sem: &self.upgradable_read_sem,
-        };
-
-        self.sem.acquire_blocking(1).unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            if !std::thread::panicking() {
-                unreachable!()
-            }
-        });
-
-        trace!(
-            "parking_lot rwlock {:p} upgradeable_read acquired RwLockUpgradableReadGuard",
-            self
-        );
-
-        RwLockUpgradableReadGuard {
-            sem: &self.sem,
-            _upgradable_read_sem: drop_guard,
-            max_readers: self.max_readers,
-            data: self.inner.get(),
-            _p: PhantomData,
-        }
-    }
-
-    /// Attempts to acquire this `RwLock` with upgradable read access.
-    ///
-    /// If the access could not be granted at this time, then `None` is returned.
-    /// Otherwise, an RAII guard is returned which will release the shared access
-    /// when it is dropped.
-    ///
-    /// This function does not block.
-    #[inline]
-    #[track_caller]
-    pub fn try_upgradable_read(&self) -> Option<RwLockUpgradableReadGuard<'_, T>> {
-        trace!(
-            "parking_lot rwlock {:p} try_upgradeable_read acquiring upgradable_read_sem",
-            self
-        );
-
-        if let Err(try_acquire_error) = self.upgradable_read_sem.try_acquire(1) {
-            trace!(
-                "parking_lot rwlock {:p} try_upgradeable_read returned {try_acquire_error:?}, returning None",
-                self
-            );
-            return None;
-        }
-
-        let drop_guard = UpgradableRwLockSemWrapper {
-            upgradable_read_sem: &self.upgradable_read_sem,
-        };
-
-        trace!(
-            "parking_lot rwlock {:p} try_upgradeable_read acquiring RwLockUpgradableReadGuard",
-            self
-        );
-
-        if let Err(try_acquire_error) = self.sem.try_acquire(1) {
-            trace!(
-                "parking_lot rwlock {:p} try_upgradeable_read returned {try_acquire_error:?}, returning None",
-                self
-            );
-            return None;
-        }
-
-        trace!(
-            "parking_lot rwlock {:p} try_upgradeable_read acquired RwLockUpgradableReadGuard",
-            self
-        );
-
-        Some(RwLockUpgradableReadGuard {
-            sem: &self.sem,
-            _upgradable_read_sem: drop_guard,
-            max_readers: self.max_readers,
-            data: self.inner.get(),
-            _p: PhantomData,
-        })
-    }
-
-    /// Returns a mutable reference to the underlying data.
-    ///
-    /// Since this call borrows the `RwLock` mutably, no actual locking needs to
-    /// take place -- the mutable borrow statically guarantees no locks exist.
-    pub fn get_mut(&mut self) -> &mut T {
-        unsafe {
-            // Safety: This is https://github.com/rust-lang/rust/pull/76936
-            &mut *self.inner.get()
-        }
-    }
-
-    /// Consumes the lock, returning the underlying data.
-    pub fn into_inner(self) -> T
-    where
-        T: Sized,
-    {
-        self.inner.into_inner()
-    }
-}
-
-/// An RAII guard for upgradable read access to an `RwLock`.
-pub struct RwLockUpgradableReadGuard<'a, T: ?Sized> {
-    _upgradable_read_sem: UpgradableRwLockSemWrapper<'a>,
-    sem: &'a BatchSemaphore,
-    max_readers: usize,
-    data: *const T,
-    _p: PhantomData<&'a T>,
-}
-
-impl<'a, T: ?Sized> RwLockUpgradableReadGuard<'a, T> {
-    /// Atomically upgrades an upgradable read lock lock into an exclusive write lock,
-    /// blocking the current thread until it can be acquired.
-    #[inline]
-    pub fn upgrade(s: Self) -> RwLockWriteGuard<'a, T> {
-        s.sem.upgrade(1, s.max_readers);
-
-        // When we return, the `UpgradableRwLockSemWrapper` goes out of scope and it's possible for another
-        // task to acquire the upgradable read lock.
-
-        RwLockWriteGuard {
-            permits_acquired: s.max_readers,
-            sem: s.sem,
-            data: s.data as *mut T,
-            _p: PhantomData,
-        }
-    }
-
-    /// Atomically downgrades an upgradable read lock lock into a shared read lock
-    /// without allowing any writers to take exclusive access of the lock in the
-    /// meantime.
-    ///
-    /// Note that if there are any writers currently waiting to take the lock
-    /// then other readers may not be able to acquire the lock even if it was
-    /// downgraded.
-    #[track_caller]
-    pub fn downgrade(s: Self) -> RwLockReadGuard<'a, T> {
-        // When we return, the `UpgradableRwLockSemWrapper` goes out of scope and it's possible for another
-        // task to acquire the upgradable read lock.
-
-        RwLockReadGuard {
-            sem: s.sem,
-            data: s.data as *mut T,
-            _p: PhantomData,
-        }
-    }
-}
-
-impl<T: ?Sized> std::ops::Deref for RwLockUpgradableReadGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*self.data }
-    }
-}
-
-impl<T> From<T> for RwLock<T> {
-    fn from(s: T) -> Self {
-        Self::new(s)
-    }
-}
-
-impl<T> Default for RwLock<T>
-where
-    T: Default,
-{
-    fn default() -> Self {
-        Self::new(T::default())
-    }
-}
-
-// As long as T: Send + Sync, it's fine to send and share RwLock<T> between threads.
-// If T were not Send, sending and sharing a RwLock<T> would be bad, since you can access T through
-// RwLock<T>.
-unsafe impl<T> Send for RwLock<T> where T: ?Sized + Send {}
-unsafe impl<T> Sync for RwLock<T> where T: ?Sized + Send + Sync {}
-// NB: These impls need to be explicit since we're storing a raw pointer.
-// Safety: Stores a raw pointer to `T`, so if `T` is `Sync`, the lock guard over
-// `T` is `Send`.
-unsafe impl<T> Send for RwLockReadGuard<'_, T> where T: ?Sized + Send + Sync {}
-unsafe impl<T> Sync for RwLockReadGuard<'_, T> where T: ?Sized + Sync {}
-
-// Safety: Stores a raw pointer to `T`, so if `T` is `Sync`, the lock guard over
-// `T` is `Send` - but since this is also provides mutable access, we need to
-// make sure that `T` is `Send` since its value can be sent across thread
-// boundaries.
-unsafe impl<T> Send for RwLockWriteGuard<'_, T> where T: ?Sized + Send + Sync {}
-unsafe impl<T> Sync for RwLockWriteGuard<'_, T> where T: ?Sized + Sync {}
-
-// SAFETY: The raw pointer is not actually sent across threads
-unsafe impl<T> Send for RwLockUpgradableReadGuard<'_, T> where T: ?Sized + Send + Sync {}
-// SAFETY: The raw pointer is not actually sent across threads
-unsafe impl<T> Sync for RwLockUpgradableReadGuard<'_, T> where T: ?Sized + Sync {}
-
-/// RAII structure used to release the shared read access of a lock when
-/// dropped.
+/// Creates a new instance of an `RwLock` which is unlocked.
 ///
-/// This structure is created by the [`read`] method on
-/// [`RwLock`].
-///
-/// [`read`]: method@crate::sync::RwLock::read
-/// [`RwLock`]: struct@crate::sync::RwLock
-pub struct RwLockReadGuard<'a, T: ?Sized> {
-    sem: &'a BatchSemaphore,
-    data: *const T,
-    _p: PhantomData<&'a T>,
-}
-
-impl<T: ?Sized> ops::Deref for RwLockReadGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*self.data }
-    }
-}
-
-impl<T: ?Sized> fmt::Debug for RwLockReadGuard<'_, T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
-    }
-}
-
-impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
-    fn drop(&mut self) {
-        self.sem.release(1);
-    }
-}
-
-struct UpgradableRwLockSemWrapper<'a> {
-    upgradable_read_sem: &'a BatchSemaphore,
-}
-
-impl<'a> Drop for UpgradableRwLockSemWrapper<'a> {
-    fn drop(&mut self) {
-        self.upgradable_read_sem.release(1);
-    }
-}
-
-/// RAII structure used to release the exclusive write access of a lock when
-/// dropped.
-pub struct RwLockWriteGuard<'a, T: ?Sized> {
-    permits_acquired: usize,
-    sem: &'a BatchSemaphore,
-    data: *mut T,
-    _p: PhantomData<&'a mut T>,
-}
-
-impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
-    /// Atomically downgrades a write lock into a read lock without allowing
-    /// any writers to take exclusive access of the lock in the meantime.
-    ///
-    /// **Note:** This won't *necessarily* allow any additional readers to acquire
-    /// locks, since [`RwLock`] is fair and it is possible that a writer is next
-    /// in line.
-    pub fn downgrade(self) -> RwLockReadGuard<'a, T> {
-        let RwLockWriteGuard { sem, data, .. } = self;
-        let to_release = self.permits_acquired - 1;
-
-        tracing::trace!(
-            "parking_lot rwlock {:p} downgrade RwLockWriteGuard to RwLockReadGuard",
-            &self
-        );
-
-        // NB: Forget to avoid drop impl from being called.
-        std::mem::forget(self);
-
-        // Release all but one of the permits held by the write guard
-        sem.release(to_release);
-
-        RwLockReadGuard {
-            sem,
-            data,
-            _p: PhantomData,
-        }
-    }
-}
-
-impl<T: ?Sized> ops::Deref for RwLockWriteGuard<'_, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        unsafe { &*self.data }
-    }
-}
-
-impl<T: ?Sized> ops::DerefMut for RwLockWriteGuard<'_, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.data }
-    }
-}
-
-impl<T: ?Sized> fmt::Debug for RwLockWriteGuard<'_, T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
-    }
-}
-
-impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
-    fn drop(&mut self) {
-        self.sem.release(self.permits_acquired);
-    }
+/// This allows creating an `RwLock` in a constant context on stable Rust. Mirrors
+/// `parking_lot::const_rwlock`.
+pub const fn const_rwlock<T>(val: T) -> RwLock<T> {
+    RwLock::const_new(<RawRwLock as lock_api::RawRwLock>::INIT, val)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RwLock, RwLockUpgradableReadGuard};
-    use shuttle::{check_dfs, thread::spawn};
+    use super::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
+    use shuttle::{
+        check_dfs,
+        thread::{self, spawn},
+    };
     use std::sync::{Arc, atomic::Ordering};
 
     #[test]
@@ -577,7 +133,6 @@ mod tests {
             move || {
                 let rwlock = Arc::new(RwLock::new(0));
                 let r1 = rwlock.clone();
-
                 let rg = rwlock.upgradable_read();
                 let t2 = spawn(move || {
                     let _g = r1.write();
@@ -585,6 +140,203 @@ mod tests {
                 let g = RwLockUpgradableReadGuard::upgrade(rg);
                 drop(g);
                 t2.join().unwrap();
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn downgrade_write_to_read() {
+        check_dfs(
+            move || {
+                let rwlock = Arc::new(RwLock::new(0));
+                let mut w = rwlock.write();
+                *w += 1;
+                let r = RwLockWriteGuard::downgrade(w);
+                // Still holding a read guard; the value we wrote is visible and a concurrent
+                // reader can also acquire.
+                assert_eq!(*r, 1);
+                let r1 = rwlock.clone();
+                let t = spawn(move || {
+                    assert_eq!(*r1.read(), 1);
+                });
+                drop(r);
+                t.join().unwrap();
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn writer_excludes_readers() {
+        check_dfs(
+            move || {
+                let lock = Arc::new(RwLock::new(0i32));
+                let w = lock.clone();
+                let writer = spawn(move || {
+                    let mut g = w.write();
+                    // Transiently write an invalid value, then restore. The `yield_now` is a
+                    // scheduling point: if `lock_exclusive` failed to exclude readers, a reader
+                    // could be scheduled here and observe the `-1`.
+                    *g = -1;
+                    thread::yield_now();
+                    *g = 1;
+                });
+                {
+                    let r = lock.read();
+                    assert!(*r == 0 || *r == 1, "reader observed writer's intermediate state");
+                }
+                writer.join().unwrap();
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn concurrent_readers_coexist() {
+        check_dfs(
+            move || {
+                let lock = Arc::new(RwLock::new(0));
+                let l2 = lock.clone();
+                // Hold a read guard for the whole scope...
+                let first = lock.read();
+                let t = spawn(move || {
+                    // ...a second reader must be able to acquire while the first is still held.
+                    // If reads didn't share, this would block until `first` drops (after `join`),
+                    // and Shuttle would report a deadlock.
+                    let g = l2.read();
+                    assert_eq!(*g, 0);
+                });
+                t.join().unwrap();
+                drop(first);
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn try_semantics() {
+        check_dfs(
+            || {
+                let lock = RwLock::new(0);
+                {
+                    let _r = lock.read();
+                    assert!(lock.try_read().is_some(), "read should not exclude another read");
+                    assert!(lock.try_write().is_none(), "read must exclude a write");
+                }
+                {
+                    let _w = lock.write();
+                    assert!(lock.try_read().is_none(), "write must exclude a read");
+                    assert!(lock.try_write().is_none(), "write must exclude another write");
+                }
+                {
+                    let _u = lock.upgradable_read();
+                    assert!(lock.try_read().is_some(), "upgradable read should not exclude a read");
+                    assert!(lock.try_write().is_none(), "upgradable read must exclude a write");
+                    assert!(
+                        lock.try_upgradable_read().is_none(),
+                        "there may be at most one upgradable reader",
+                    );
+                }
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn try_upgrade_semantics() {
+        check_dfs(
+            || {
+                // Succeeds when the upgradable reader is the only lock holder.
+                {
+                    let lock = RwLock::new(5);
+                    let u = lock.upgradable_read();
+                    let mut w = match RwLockUpgradableReadGuard::try_upgrade(u) {
+                        Ok(w) => w,
+                        Err(_) => panic!("try_upgrade should succeed when no readers are present"),
+                    };
+                    *w = 6;
+                    assert_eq!(*w, 6);
+                }
+                // Fails while a plain reader is also held, and hands the upgradable guard back.
+                {
+                    let lock = RwLock::new(5);
+                    let u = lock.upgradable_read();
+                    let r = lock.read();
+                    match RwLockUpgradableReadGuard::try_upgrade(u) {
+                        Ok(_) => panic!("try_upgrade must fail while a reader is held"),
+                        Err(u_back) => drop(u_back),
+                    }
+                    drop(r);
+                }
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn downgrade_to_upgradable() {
+        check_dfs(
+            move || {
+                let lock = Arc::new(RwLock::new(0));
+                let mut w = lock.write();
+                *w = 1;
+                let u = RwLockWriteGuard::downgrade_to_upgradable(w);
+                // The value written under exclusive access is visible through the upgradable guard.
+                assert_eq!(*u, 1);
+                // An upgradable reader still excludes writers...
+                assert!(lock.try_write().is_none(), "upgradable read must exclude a write");
+                // ...but permits plain readers.
+                let r1 = lock.clone();
+                let t = spawn(move || {
+                    assert_eq!(*r1.read(), 1);
+                });
+                t.join().unwrap();
+                drop(u);
+            },
+            None,
+        );
+    }
+
+    #[test]
+    fn upgradable_downgrade_to_read() {
+        check_dfs(
+            move || {
+                let lock = Arc::new(RwLock::new(7));
+                let u = lock.upgradable_read();
+                let r = RwLockUpgradableReadGuard::downgrade(u);
+                assert_eq!(*r, 7);
+                // Downgrading released the upgradable slot, so another task may now take an
+                // upgradable read; if the slot had leaked, this would deadlock.
+                let l2 = lock.clone();
+                let t = spawn(move || {
+                    let _u2 = l2.upgradable_read();
+                });
+                t.join().unwrap();
+                drop(r);
+            },
+            None,
+        );
+    }
+
+    #[cfg(feature = "arc_lock")]
+    #[test]
+    fn arc_guards_reader_writer() {
+        check_dfs(
+            move || {
+                let rwlock = Arc::new(RwLock::new(0usize));
+                let w = rwlock.clone();
+                let t = spawn(move || {
+                    // `write_arc` returns an owned guard with a `'static` lifetime.
+                    let mut g = w.write_arc();
+                    *g += 1;
+                });
+                {
+                    // `read_arc` likewise owns the `Arc`, so the guard has no borrow of `rwlock`.
+                    let _g = rwlock.read_arc();
+                }
+                t.join().unwrap();
+                assert_eq!(*rwlock.read(), 1);
             },
             None,
         );


### PR DESCRIPTION
Reimplement the `shuttle-parking_lot` wrapper as a thin layer over the [`lock_api`](https://docs.rs/lock_api) crate, mirroring how the upstream [`parking_lot`](https://docs.rs/parking_lot) crate is structured. Rather than hand-rolling `Mutex`/`RwLock` and their guards, provide Shuttle-backed raw locks (`RawMutex`, `RawRwLock`) built on `BatchSemaphore` that implement `lock_api`'s raw traits; the user-facing `Mutex`/`RwLock`, mapped guards, and `Arc`-based guards then come from `lock_api` for free.

This adds the previously-missing `Arc` guards (`lock_arc`, `read_arc`, `write_arc`), mapped guards, and upgrade/downgrade support, and exposes `RawMutex`/`RawRwLock` so consumer code that names those types compiles under Shuttle.

Guard `Send`-ness follows parking_lot's `send_guard` feature (`GuardNoSend` by default, `GuardSend` with `send_guard`), keeping the `Send` contract identical to production. The code is split into `raw_mutex.rs`, `raw_rwlock.rs`, `mutex.rs`, and `rwlock.rs` with explicit crate-root re-exports, matching parking_lot's own module layout.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.