### PR TITLE
Publish shuttle-parking_lot-impl 0.1.1

### DIFF
--- a/wrappers/parking_lot/parking_lot_impl/CHANELOG.md
+++ b/wrappers/parking_lot/parking_lot_impl/CHANELOG.md
@@ -1,6 +1,6 @@
 # 0.1.1 (Jul 31, 2026)
 
-* Refactor to be buil on lock_api (#302). Adds `lock_arc`, `read_arc`, `write_arc`, and exposes `RawMutex` and `RawRwLock`.
+* Refactor to be built on `lock_api` (#302). Adds `lock_arc`, `read_arc`, `write_arc`, and exposes `RawMutex` and `RawRwLock`.
 
 # 0.1.0
 

--- a/wrappers/parking_lot/parking_lot_impl/CHANELOG.md
+++ b/wrappers/parking_lot/parking_lot_impl/CHANELOG.md
@@ -1,0 +1,7 @@
+# 0.1.1 (Jul 31, 2026)
+
+* Refactor to be buil on lock_api (#302). Adds `lock_arc`, `read_arc`, `write_arc`, and exposes `RawMutex` and `RawRwLock`.
+
+# 0.1.0
+
+* Initial release

--- a/wrappers/parking_lot/parking_lot_impl/Cargo.toml
+++ b/wrappers/parking_lot/parking_lot_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-parking_lot-impl"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Internal implementation of the `parking_lot` crate for use with the Shuttle concurrency testing tool. Do not depend on this crate directly; use `shuttle-parking_lot`."


### PR DESCRIPTION
Publishes shuttle-parking_lot-impl version 0.1.1

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.