### PR TITLE
Fix license field for shuttle-schedulers

### DIFF
--- a/shuttle-schedulers/Cargo.toml
+++ b/shuttle-schedulers/Cargo.toml
@@ -3,7 +3,7 @@ name = "shuttle-schedulers"
 version = "0.1.0"
 edition = "2021"
 description = "Scheduler implementations for the Shuttle concurrency testing framework"
-license = "MIT"
+license = "Apache-2.0"
 
 [dependencies]
 shuttle-core = { path = "../shuttle-core" }


### PR DESCRIPTION
https://github.com/awslabs/shuttle/pull/290 accidentally licensed shuttle-schedulers under MIT, but it should be Apache-2.0, like the rest of Shuttle. All the shuttle-schedulers code has been contributed under Apache-2.0, ie., the field in the Cargo.toml is just wrong, and this PR does not constitute relicensing any code. 


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.