### PR TITLE
Clarify why Arc is re-exported from std rather than modeled

### DIFF
--- a/shuttle-std/src/sync/mod.rs
+++ b/shuttle-std/src/sync/mod.rs
@@ -21,7 +21,12 @@ pub use rwlock::RwLockWriteGuard;
 
 pub use std::sync::{LockResult, PoisonError, TryLockError, TryLockResult};
 
-// TODO implement true support for `Arc`
+// We re-export `std::sync::Arc` rather than modeling it in Shuttle. `Arc` is typically used to
+// share data across threads, not to synchronize, so modeling its reference-count operations
+// (which would require a context switch on every count modification) would significantly hurt
+// performance for little gain. This means Shuttle misses some behaviors, e.g. around `Weak`
+// upgrade/downgrade races. If we ever want to support those, it should be opt-in or configurable
+// rather than the default.
 pub use std::sync::{Arc, Weak};
 
 pub use shuttle_core::sync_types::{ResourceSignature, ResourceType};


### PR DESCRIPTION


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.