### PR TITLE
Prepare shuttle 0.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.9.2 (August 6, 2026)
+
+* Add support for 128-bit atomics (`AtomicI128`/`AtomicU128`) (#299)
+* Implement `Display` for `TaskId` to match tokio's `task::Id` (#307)
+* Add support for task abort (#278)
+* Refactor the `shuttle` crate into separate internal crates: `shuttle-runtime` (core runtime and the `Scheduler` trait), `shuttle-schedulers` (built-in schedulers and `check`/`replay` helpers), and `shuttle-std` (the `std` replacement primitives) (#286, #290, #292, #294). This is an internal reorganization and does not change the `shuttle` public API.
+
+# 0.9.1 (Apr 19, 2026)
+
+* Readd README that was lost in refactoring. (#276)
+
 # 0.9.0 (Apr 19, 2026)
 
 * Fix: `JoinHandle<T>` is now `Send` and `Sync` even if `T` is not.

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"


### PR DESCRIPTION
Update changelog for 0.9.2.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.