### PR TITLE
Add shuttle-tokio-util wrapper crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "wrappers/tokio/wrappers/shuttle-tokio",
     "wrappers/tokio/wrappers/shuttle-tokio-stream",
     "wrappers/tokio/wrappers/shuttle-tokio-retry",
+    "wrappers/tokio/wrappers/shuttle-tokio-util",
     "wrappers/tokio/impls/tokio-retry",
     "wrappers/parking_lot",
     "wrappers/async_stream",

--- a/wrappers/tokio/wrappers/shuttle-tokio-util/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio-util/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "shuttle-tokio-util"
+version = "0.7.0" 
+edition = "2021"
+license = "Apache-2.0"
+description = "tokio-util wrapper for the Shuttle concurrency testing tool."
+
+[features]
+shuttle = ["dep:shuttle-tokio-util-impl"]
+
+# Shorthand for enabling everything
+full = ["codec", "compat", "io", "io-util", "time", "net", "rt"]
+
+codec = ["tokio-util/codec", "shuttle-tokio-util-impl?/codec"]
+compat = ["tokio-util/compat", "shuttle-tokio-util-impl?/compat"]
+io = ["tokio-util/io", "shuttle-tokio-util-impl?/io"]
+io-util = ["tokio-util/io-util", "shuttle-tokio-util-impl?/io-util"]
+time = ["tokio-util/time", "shuttle-tokio-util-impl?/time"]
+net = ["tokio-util/net", "shuttle-tokio-util-impl?/net"]
+rt = ["tokio-util/rt", "shuttle-tokio-util-impl?/rt"]
+
+[dependencies]
+cfg-if = "1.0"
+tokio-util = "0.7"
+shuttle-tokio-util-impl = { version = "0.1", optional = true, path = "../../impls/tokio-util" }

--- a/wrappers/tokio/wrappers/shuttle-tokio-util/README.md
+++ b/wrappers/tokio/wrappers/shuttle-tokio-util/README.md
@@ -1,0 +1,23 @@
+# Shuttle support for `tokio-util`
+
+This crate contains the wrapper that enables testing of applications that use [tokio-util](https://crates.io/crates/tokio-util) with Shuttle.
+
+## How to use
+
+To use it, add the following in your Cargo.toml:
+
+```
+[features]
+shuttle = [
+   "tokio-util/shuttle",
+]
+
+[dependencies]
+tokio-util = { package = "shuttle-tokio-util", version = "VERSION_NUMBER" }
+```
+
+The code will then behave as before when the `shuttle` feature flag is not provided, and will run with Shuttle-compatible primitives when the `shuttle` feature flag is provided.
+
+## Limitations
+
+For the list of current limitations, see the [shuttle-tokio-util-impl](https://crates.io/crates/shuttle-tokio-util-impl) inner crate.

--- a/wrappers/tokio/wrappers/shuttle-tokio-util/src/lib.rs
+++ b/wrappers/tokio/wrappers/shuttle-tokio-util/src/lib.rs
@@ -1,0 +1,27 @@
+//! This crate provides a Shuttle-compatible implementation and wrapper for [`tokio-util`] in order to make it
+//! more ergonomic to run a codebase using [`tokio-util`] under Shuttle.
+//!
+//! [`tokio-util`]: <https://crates.io/crates/tokio-util>
+//!
+//! To use this crate, add something akin to the following to your Cargo.toml:
+//!
+//! ```ignore
+//! [features]
+//! shuttle = [
+//!    "tokio-util/shuttle",
+//! ]
+//!
+//! [dependencies]
+//! tokio-util = { package = "shuttle-tokio-util", version = "VERSION_NUMBER" }
+//! ```
+//!
+//! The rest of the codebase then remains unchanged, and running with Shuttle-compatible `tokio-util`
+//! can be done via the "shuttle" feature flag.
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "shuttle")] {
+        pub use shuttle_tokio_util_impl::*;
+    } else {
+        pub use tokio_util::*;
+    }
+}


### PR DESCRIPTION
Adds a wrapper crate for tokio-util. Implementation crate exists already.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.