### PR TITLE
Make tokio-util ready to publish

### DIFF
--- a/wrappers/tokio/impls/tokio-util/Cargo.toml
+++ b/wrappers/tokio/impls/tokio-util/Cargo.toml
@@ -2,8 +2,9 @@
 name = "shuttle-tokio-util-impl"
 version = "0.1.0" # Forked from "0.7.11"
 edition = "2021"
-
-publish = false
+license = "MIT"
+description = "Shuttle's internal implementation of the `tokio-util` crate. Do not depend on this crate directly; use `shuttle-tokio-util`."
+repository = "https://github.com/awslabs/shuttle"
 
 [features]
 # Shorthand for enabling everything
@@ -21,8 +22,8 @@ __docs_rs = []
 
 [dependencies]
 pin-project-lite = "0.2.11"
-tokio = { version = "*", package = "shuttle-tokio-impl", path = "../tokio", features = ["sync"] }
-shuttle = { path = "../../../../shuttle", version = "*" }
+tokio = { version = "0.1", package = "shuttle-tokio-impl", path = "../tokio", features = ["sync"] }
+shuttle = { path = "../../../../shuttle", version = "0.9" }
 tokio-util-orig = { version = "0.7.11", package = "tokio-util" }
 
 [dev-dependencies]

--- a/wrappers/tokio/impls/tokio-util/LICENSE
+++ b/wrappers/tokio/impls/tokio-util/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wrappers/tokio/wrappers/shuttle-tokio-util/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio-util/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "tokio-util wrapper for the Shuttle concurrency testing tool."
+repository = "https://github.com/awslabs/shuttle"
 
 [features]
 shuttle = ["dep:shuttle-tokio-util-impl"]


### PR DESCRIPTION
When this PR gets merged I'll publish `shuttle-tokio-util` and `shuttle-tokio-util-impl`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.