### PR TITLE
Publish 0.9.2, publish shuttle-engine, shuttle-schedulers, shuttle-std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Add support for 128-bit atomics (`AtomicI128`/`AtomicU128`) (#299)
 * Implement `Display` for `TaskId` to match tokio's `task::Id` (#307)
 * Add support for task abort (#278)
-* Refactor the `shuttle` crate into separate internal crates: `shuttle-runtime` (core runtime and the `Scheduler` trait), `shuttle-schedulers` (built-in schedulers and `check`/`replay` helpers), and `shuttle-std` (the `std` replacement primitives) (#286, #290, #292, #294). This is an internal reorganization and does not change the `shuttle` public API.
+* Refactor the `shuttle` crate into separate internal crates: `shuttle-engine` (core runtime and the `Scheduler` trait), `shuttle-schedulers` (built-in schedulers and `check`/`replay` helpers), and `shuttle-std` (the `std` replacement primitives) (#286, #290, #292, #294). This is an internal reorganization and does not change the `shuttle` public API.
+* Publish `shuttle-std`, `shuttle-schedulers` and `shuttle-engine`.
 
 # 0.9.1 (Apr 19, 2026)
 

--- a/shuttle-schedulers/Cargo.toml
+++ b/shuttle-schedulers/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 edition = "2021"
 description = "Scheduler implementations for the Shuttle concurrency testing framework"
 license = "Apache-2.0"
+repository = "https://github.com/awslabs/shuttle"
 
 [dependencies]
-shuttle-engine = { path = "../shuttle-engine" }
+shuttle-engine = { path = "../shuttle-engine", version = "0.1.0" }
 rand = "0.8.6"
 rand_pcg = "0.3.1"
 smallvec = { version = "1.11.2", features = ["const_new"] }

--- a/shuttle-std/Cargo.toml
+++ b/shuttle-std/Cargo.toml
@@ -7,7 +7,7 @@ description = "Mirrors of std compatible with the Shuttle concurrency testing to
 repository = "https://github.com/awslabs/shuttle"
 
 [dependencies]
-shuttle-engine = { path = "../shuttle-engine" }
+shuttle-engine = { path = "../shuttle-engine", version = "0.1.0" }
 assoc = "0.1.3"
 owo-colors = "4.3.0"
 smallvec = { version = "1.11.2", features = ["const_new"] }

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -10,9 +10,9 @@ categories = ["asynchronous", "concurrency", "development-tools::testing"]
 readme = "../README.md"
 
 [dependencies]
-shuttle-engine = { path = "../shuttle-engine" }
-shuttle-schedulers = { path = "../shuttle-schedulers" }
-shuttle-std = { path = "../shuttle-std" }
+shuttle-engine = { path = "../shuttle-engine", version = "0.1.0" }
+shuttle-schedulers = { path = "../shuttle-schedulers", version = "0.1.0" }
+shuttle-std = { path = "../shuttle-std", version = "0.1.0" }
 bitvec = "1.0.1"
 cfg-if = "1.0"
 hex = "0.4.2"


### PR DESCRIPTION
Publish Shuttle 0.9.2, shuttle-engine, shuttle-schedulers, shuttle-std 0.1.0.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.