### PR TITLE
Fix issue when BatchSemaphore is moved between tasks

### DIFF
--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -9,17 +9,35 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::{Context, Poll, Waker};
 use tracing::trace;
 
 struct Waiter {
-    task_id: TaskId,
+    /// The task waiting on this waiter's `Acquire`.
+    ///
+    /// Refreshed on every poll (like `waker`) rather than frozen at creation
+    /// time. An `Acquire` future is not necessarily owned by the task that
+    /// created it: it can be cached inside a longer-lived object and later
+    /// polled by a different task (tokio's `poll_recv(&mut self, cx)` is the
+    /// motivating example — the in-flight acquire lives in the `Receiver`, and
+    /// a `Receiver` may be moved between tasks). The semaphore must unblock
+    /// whoever is actually waiting now, so this follows the poller. This
+    /// mirrors tokio's own `batch_semaphore`, which refreshes its waiter's
+    /// `Waker` under a `will_wake` check.
+    ///
+    /// Stored as an atomic rather than a `Cell` to keep `Waiter` (and hence
+    /// `Acquire`) `Sync`.
+    task_id: AtomicUsize,
     num_permits: usize,
     is_queued: AtomicBool,
     has_permits: AtomicBool,
+    /// Clock of the task that created this waiter. Note this is *not* refreshed
+    /// when `task_id` is: it is only used to seed the causality of the acquired
+    /// permits, and keeping the original enqueue clock is conservative (it can
+    /// only add happens-before edges, never remove them).
     clock: VectorClock,
     waker: Mutex<Option<Waker>>,
 }
@@ -28,7 +46,7 @@ struct Waiter {
 impl fmt::Debug for Waiter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Waiter")
-            .field("task_id", &self.task_id)
+            .field("task_id", &self.task_id())
             .field("num_permits", &self.num_permits)
             .field("is_queued", &self.is_queued)
             .field("has_permits", &self.has_permits)
@@ -40,13 +58,24 @@ impl fmt::Debug for Waiter {
 impl Waiter {
     fn new(num_permits: usize) -> Self {
         Self {
-            task_id: ExecutionState::me(),
+            task_id: AtomicUsize::new(ExecutionState::me().into()),
             num_permits,
             is_queued: AtomicBool::new(false),
             has_permits: AtomicBool::new(false),
             clock: current::clock(),
             waker: Mutex::new(None),
         }
+    }
+
+    /// The task currently waiting on this waiter. See [`Waiter::task_id`].
+    fn task_id(&self) -> TaskId {
+        TaskId::from(self.task_id.load(Ordering::SeqCst))
+    }
+
+    /// Point this waiter at the task that is polling it now, so that a later
+    /// `release` unblocks the current poller rather than whoever polled first.
+    fn set_task_id(&self, task_id: TaskId) {
+        self.task_id.store(task_id.into(), Ordering::SeqCst);
     }
 }
 
@@ -242,12 +271,36 @@ impl BatchSemaphoreState {
 
     fn unblock_waiters_from_front(&mut self) {
         while let Some(front) = self.waiters.front() {
+            // A waiter whose task has already finished is stale: its `Acquire`
+            // future was cancelled (e.g. a `select!` branch lost, or a
+            // `poll_recv`-style API cached the `Acquire` inside a longer-lived
+            // object) and the registering task then exited. There is nobody to
+            // unblock, so discard the waiter without consuming permits; if the
+            // `Acquire` is still alive and some other task polls it, it will
+            // re-acquire from the (still available) permits.
+            //
+            // `remove_waiter` can reach this during execution cleanup, when the
+            // task list is gone, so probe defensively and treat "can't tell" as
+            // not stale (i.e. preserve the old behaviour).
+            let front_is_stale = ExecutionState::try_with(|s| {
+                !s.in_cleanup() && s.try_get(front.task_id()).is_some_and(|t| t.finished())
+            })
+            .unwrap_or(false);
+            if front_is_stale {
+                let waiter = self.waiters.pop_front().unwrap();
+                waiter.is_queued.store(false, Ordering::SeqCst);
+                // Preserve the "queued <=> waker registered" invariant asserted
+                // in `Acquire::poll`; waking a finished task's waker is a no-op.
+                waiter.waker.lock().unwrap().take();
+                trace!("dropping stale waiter {:?} for finished task", waiter);
+                continue;
+            }
             if front.num_permits <= self.permits_available.available() {
                 let waiter = self.waiters.pop_front().unwrap();
 
                 crate::annotations::record_semaphore_acquire_unblocked(
                     self.id.unwrap(),
-                    waiter.task_id,
+                    waiter.task_id(),
                     waiter.num_permits,
                 );
 
@@ -266,7 +319,7 @@ impl BatchSemaphoreState {
                 assert!(waiter.is_queued.swap(false, Ordering::SeqCst));
                 assert!(!waiter.has_permits.swap(true, Ordering::SeqCst));
                 ExecutionState::with(|s| {
-                    let task = s.get_mut(waiter.task_id);
+                    let task = s.get_mut(waiter.task_id());
                     assert!(!task.finished());
                     // The acquiry is causally dependent on the event
                     // which released the acquired permits.
@@ -419,8 +472,10 @@ impl BatchSemaphore {
             assert!(waiter.is_queued.swap(false, Ordering::SeqCst));
             assert!(!waiter.has_permits.load(Ordering::SeqCst)); // sanity check
             ExecutionState::with(|exec_state| {
-                if !exec_state.in_cleanup() {
-                    exec_state.get_mut(waiter.task_id).unblock();
+                // A waiter whose task has finished is stale (its `Acquire` was
+                // cancelled and the task exited); there is nothing to unblock.
+                if !exec_state.in_cleanup() && !exec_state.get(waiter.task_id()).finished() {
+                    exec_state.get_mut(waiter.task_id()).unblock();
                 }
             });
             let mut maybe_waker = waiter.waker.lock().unwrap();
@@ -487,11 +542,13 @@ impl BatchSemaphore {
             ExecutionState::with(|s| {
                 for waiter in &state.waiters {
                     let available = state.permits_available.available();
-                    if available < waiter.num_permits {
+                    // Skip stale waiters: the task that registered the waiter
+                    // has finished, so there is nothing to block.
+                    if available < waiter.num_permits && s.try_get(waiter.task_id()).is_some_and(|t| !t.finished()) {
                         // Block this waiter: it cannot succeed (there are not
                         // enough permits available); its `poll` would return
                         // without resolving.
-                        s.get_mut(waiter.task_id).block(false);
+                        s.get_mut(waiter.task_id()).block(false);
                     }
                 }
             });
@@ -605,11 +662,24 @@ impl BatchSemaphore {
                 let num_available = state.permits_available.available();
                 for waiter in &mut state.waiters {
                     if waiter.num_permits <= num_available {
-                        ExecutionState::with(|s| {
-                            let task = s.get_mut(waiter.task_id);
-                            assert!(!task.finished());
-                            task.unblock();
+                        // A waiter whose task has already finished is stale: its
+                        // `Acquire` was cancelled (and possibly cached in a
+                        // longer-lived object) and the task then exited. Unlike
+                        // the strictly fair case there is nothing to clean up —
+                        // an unfair waiter holds no permits, so it blocks
+                        // nobody — but there is also nobody to unblock.
+                        let stale = ExecutionState::with(|s| {
+                            let task = s.get_mut(waiter.task_id());
+                            if task.finished() {
+                                true
+                            } else {
+                                task.unblock();
+                                false
+                            }
                         });
+                        if stale {
+                            continue;
+                        }
                         let maybe_waker = waiter.waker.lock().unwrap();
                         if let Some(waker) = maybe_waker.as_ref() {
                             waker.wake_by_ref();
@@ -779,7 +849,7 @@ impl Future for Acquire<'_> {
                         if is_queued {
                             crate::annotations::record_semaphore_acquire_unblocked(
                                 id,
-                                self.waiter.task_id,
+                                self.waiter.task_id(),
                                 self.waiter.num_permits,
                             );
                             self.semaphore.remove_waiter(&self.waiter);
@@ -799,6 +869,9 @@ impl Future for Acquire<'_> {
                     Err(TryAcquireError::NoPermits) => {
                         let mut maybe_waker = self.waiter.waker.lock().unwrap();
                         *maybe_waker = Some(cx.waker().clone());
+                        // Point the waiter at whoever is polling now: this future
+                        // may have been created by a different task.
+                        self.waiter.set_task_id(ExecutionState::me());
                         if !is_queued {
                             crate::annotations::record_semaphore_acquire_blocked(id, self.waiter.num_permits);
                             self.semaphore.enqueue_waiter(&self.waiter);
@@ -810,7 +883,15 @@ impl Future for Acquire<'_> {
                     Err(TryAcquireError::Closed) => unreachable!(),
                 }
             } else {
-                // No progress made, future is still pending.
+                // No progress made, future is still pending. The waiter stays in
+                // the queue, but re-point it at the current poller and refresh
+                // its waker: this future may have been created by (or last
+                // polled by) another task, and `release` must wake whoever is
+                // waiting now. Without this, a permit granted to this waiter
+                // would unblock a task that is no longer interested, and the
+                // actual poller would never be woken.
+                *self.waiter.waker.lock().unwrap() = Some(cx.waker().clone());
+                self.waiter.set_task_id(ExecutionState::me());
                 Poll::Pending
             }
         }

--- a/shuttle/tests/future/batch_semaphore.rs
+++ b/shuttle/tests/future/batch_semaphore.rs
@@ -370,6 +370,170 @@ fn batch_semaphore_signal() {
     );
 }
 
+/// A queued `Acquire` that is polled by a second task must wake *that* task.
+///
+/// An `Acquire` is a future like any other: it can be created and first polled
+/// by one task, stored in a longer-lived object, and later polled by a different
+/// task. Tokio's `Receiver::poll_recv(&mut self, cx)` is the motivating example
+/// — it keeps its in-flight acquire inside the `Receiver`, so a `Receiver` that
+/// is moved between tasks carries the acquire with it.
+///
+/// The waiter therefore has to follow the poller, both its waker and the task it
+/// unblocks. If it keeps pointing at whoever polled first, a later `release`
+/// hands the permits to a task that is no longer waiting and never notifies the
+/// task that actually is.
+///
+/// The two pollers here use their own wakers so the test can assert *which* one
+/// the semaphore notified. Asserting on the wakers rather than on progress is
+/// deliberate: a lost wakeup does not reliably deadlock, because a `Pending`
+/// future is left sleeping and Shuttle may schedule a spurious re-poll that
+/// papers over the missing notification.
+#[test]
+fn queued_acquire_polled_by_second_task_is_woken() {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::AtomicBool;
+    use std::task::Context;
+
+    shuttle::lazy_static! {
+        static ref SEM: BatchSemaphore = BatchSemaphore::new(0, Fairness::StrictlyFair);
+        // Parks the first task so it stays alive (and thus not "stale") while
+        // the second task waits on the acquire it registered.
+        static ref PARK: BatchSemaphore = BatchSemaphore::new(0, Fairness::StrictlyFair);
+    }
+
+    /// Records whether it was woken, so the test can tell *which* poller the
+    /// semaphore notified.
+    #[derive(Debug, Default)]
+    struct Recorder(AtomicBool);
+
+    impl Recorder {
+        fn woken(&self) -> bool {
+            self.0.load(Ordering::SeqCst)
+        }
+    }
+
+    impl futures::task::ArcWake for Recorder {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// Polls `acquire` once with a waker belonging to `recorder`, asserting it
+    /// does not resolve, so the waiter stays queued.
+    fn poll_pending(acquire: &mut Pin<Box<Acquire<'static>>>, recorder: &Arc<Recorder>) {
+        let waker = futures::task::waker(recorder.clone());
+        let mut cx = Context::from_waker(&waker);
+        assert!(acquire.as_mut().poll(&mut cx).is_pending());
+    }
+
+    check_dfs(
+        || {
+            future::block_on(async {
+                // The `Acquire` outlives the task that first polls it. A stdlib
+                // mutex keeps the handoff free of extra yield points.
+                let acquire = Arc::new(Mutex::new(Some(Box::pin(SEM.acquire(1)))));
+                let recorder_a = Arc::new(Recorder::default());
+                let recorder_b = Arc::new(Recorder::default());
+                let (polled_tx, polled_rx) = shuttle::sync::mpsc::channel();
+
+                let mut tasks = vec![];
+                for recorder in [recorder_a.clone(), recorder_b.clone()] {
+                    let acquire = acquire.clone();
+                    let polled_tx = polled_tx.clone();
+                    tasks.push(future::spawn(async move {
+                        let mut acq = acquire.lock().unwrap().take().unwrap();
+                        // No permits are available, so this leaves a waiter
+                        // queued, pointing at this task and this waker.
+                        poll_pending(&mut acq, &recorder);
+                        // Hand the still-queued acquire on, then park without
+                        // ever polling it again.
+                        *acquire.lock().unwrap() = Some(acq);
+                        polled_tx.send(()).unwrap();
+                        PARK.acquire(1).await.unwrap();
+                    }));
+                    // Serialize the two polls: the second task must be the last
+                    // one to have polled when the release below happens.
+                    polled_rx.recv().unwrap();
+                }
+
+                // Grants the permit to the queued waiter, which must notify the
+                // task that polled most recently rather than the one that first
+                // registered.
+                SEM.release(1);
+                assert!(recorder_b.woken(), "second poller was not woken");
+                assert!(!recorder_a.woken(), "first poller was woken instead");
+
+                PARK.release(2);
+                for task in tasks {
+                    task.await.unwrap();
+                }
+            });
+        },
+        // The handshake above pins down the ordering the assertions depend on,
+        // so the remaining interleavings are incidental; a bounded search keeps
+        // this cheap.
+        Some(500),
+    );
+}
+
+/// Releasing permits to a waiter whose task has finished must not panic, and
+/// must not lose the permits.
+///
+/// The companion case to `queued_acquire_polled_by_second_task_is_woken`: here
+/// the task that registered the waiter exits without ever resolving or dropping
+/// its `Acquire`, because the `Acquire` was stored somewhere that outlives the
+/// task. Nobody is waiting on that waiter, so a later `release` has nobody to
+/// unblock — it must discard the waiter rather than assert that the registering
+/// task is still alive.
+///
+/// The permits must stay available: the abandoned `Acquire` is still a live
+/// future, and polling it from a task that *is* running has to succeed.
+#[test]
+fn release_to_waiter_of_finished_task() {
+    // A `lazy_static` semaphore gives the `Acquire` a `'static` borrow, so it can
+    // be handed to a `'static` spawned task and outlive it.
+    shuttle::lazy_static! {
+        static ref SEM: BatchSemaphore = BatchSemaphore::new(0, Fairness::StrictlyFair);
+    }
+
+    check_dfs(
+        || {
+            future::block_on(async {
+                // A stdlib mutex keeps the handoff free of extra yield points.
+                let acquire = Arc::new(Mutex::new(None));
+
+                let acquire2 = Arc::clone(&acquire);
+                let registrant = future::spawn(async move {
+                    // Created *and* first polled by this task, so the queued
+                    // waiter belongs to the task that is about to finish.
+                    let mut acq = Box::pin(SEM.acquire(1));
+                    // No permits are available, so this leaves a waiter queued.
+                    assert!(futures::poll!(acq.as_mut()).is_pending());
+                    // Hand the still-queued acquire back out so it outlives this
+                    // task, then finish without polling or dropping it again.
+                    *acquire2.lock().unwrap() = Some(acq);
+                });
+                registrant.await.unwrap();
+
+                // The only queued waiter belongs to a task that has finished.
+                SEM.release(1);
+                assert_eq!(
+                    SEM.available_permits(),
+                    1,
+                    "permits were consumed by a waiter nobody is waiting on"
+                );
+
+                // The abandoned acquire is still usable by a live task.
+                let acq = acquire.lock().unwrap().take().unwrap();
+                acq.await.unwrap();
+                assert_eq!(SEM.available_permits(), 0);
+            });
+        },
+        None,
+    );
+}
+
 #[test]
 fn batch_semaphore_close_acquire() {
     // Check that closing a semaphore is handled gracefully

--- a/wrappers/tokio/impls/tokio/inner/src/sync/mod.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/mod.rs
@@ -70,4 +70,157 @@ mod test {
     fn check_select_mutex_bug() {
         shuttle::check_dfs(select_mutex_bug, None);
     }
+
+    /// A cancelled `recv()` must not leave a waiter registered in the channel's
+    /// `recv_semaphore`.
+    ///
+    /// `Receiver::poll_recv` caches its `Acquire` future in `ReceiverInternal::
+    /// pending_acquire` so the waiter survives across polls. The waiter records
+    /// the `TaskId` of whichever task first polled it, and it is only removed
+    /// when the *Receiver* is dropped/closed — not when the `recv()` future is
+    /// dropped. So if a task cancels `recv()` (a documented cancel-safe
+    /// operation in Tokio) and then exits while the `Receiver` lives on, a
+    /// waiter belonging to a finished task stays queued. The next `send` calls
+    /// `recv_semaphore.release(1)`, and Shuttle's
+    /// `BatchSemaphoreState::unblock_waiters_from_front` trips
+    /// `assert!(!task.finished())`.
+    fn cancelled_recv_leaves_stale_waiter() {
+        use crate::sync::mpsc;
+        use shuttle::sync::{Arc, Mutex};
+
+        shuttle::future::block_on(async {
+            let (tx, rx) = mpsc::channel::<u32>(1);
+            // The Receiver outlives the task that polls it.
+            let rx = Arc::new(Mutex::new(Some(rx)));
+            let rx2 = rx.clone();
+
+            let h = shuttle::future::spawn(async move {
+                let mut receiver = rx2.lock().unwrap().take().unwrap();
+                {
+                    let mut recv = Box::pin(receiver.recv());
+                    // Channel is empty: the first poll enqueues a waiter for *this* task.
+                    assert!(futures::poll!(recv.as_mut()).is_pending());
+                    // Cancel the `recv()` (as `select!` would).
+                }
+                // Hand the Receiver back so it outlives this task, then finish
+                // with the waiter still queued.
+                *rx2.lock().unwrap() = Some(receiver);
+            });
+            h.await.unwrap();
+
+            // Releases a permit on `recv_semaphore`, which tries to unblock the
+            // waiter left behind by the finished task.
+            tx.try_send(1).unwrap();
+
+            // The cancelled `recv()` must not have consumed the message.
+            let mut receiver = rx.lock().unwrap().take().unwrap();
+            assert_eq!(receiver.recv().await, Some(1));
+        });
+    }
+
+    #[test_log::test]
+    fn check_cancelled_recv_leaves_stale_waiter() {
+        shuttle::check_dfs(cancelled_recv_leaves_stale_waiter, None);
+    }
+
+    /// Control for `cancelled_recv_leaves_stale_waiter`: identical cancellation,
+    /// except the `Receiver` is dropped inside the task. Dropping the Receiver
+    /// drops the cached `Acquire`, whose `Drop` calls `remove_waiter`, so no
+    /// stale waiter is left behind and the later `send` is fine. This shows the
+    /// deregistration hook works — cancelling `recv()` just never reaches it,
+    /// because the `Acquire` is owned by the `Receiver`, not by the `recv()`
+    /// future that got dropped.
+    fn cancelled_recv_with_receiver_dropped() {
+        use crate::sync::mpsc;
+
+        shuttle::future::block_on(async {
+            let (tx, mut receiver) = mpsc::channel::<u32>(1);
+
+            let h = shuttle::future::spawn(async move {
+                {
+                    let mut recv = Box::pin(receiver.recv());
+                    assert!(futures::poll!(recv.as_mut()).is_pending());
+                    // Cancel the `recv()` ...
+                }
+                // ... and drop the Receiver, which runs `Acquire::drop`.
+                drop(receiver);
+            });
+            h.await.unwrap();
+
+            // No waiter is queued, so this release has nobody to unblock.
+            assert!(tx.try_send(1).is_err());
+        });
+    }
+
+    #[test_log::test]
+    fn check_cancelled_recv_with_receiver_dropped() {
+        shuttle::check_dfs(cancelled_recv_with_receiver_dropped, None);
+    }
+
+    /// A `Receiver` moved to another task while its registering task is *still
+    /// alive* must deliver to the new poller.
+    ///
+    /// Same setup as `cancelled_recv_leaves_stale_waiter`, except the first task
+    /// never exits, so nothing is "finished" and no assertion fires. Instead the
+    /// queued waiter still points at task A: `Acquire::poll` from task B hits the
+    /// "fair semaphore, already queued" case and returns `Pending`, and a later
+    /// `release` unblocks A (which is not waiting) rather than B. B is then never
+    /// woken and Shuttle reports a deadlock. Shuttle's semaphore must re-point a
+    /// queued waiter (and its waker) at whoever polls it, as tokio's own
+    /// `batch_semaphore` does via its `will_wake` refresh.
+    fn moved_recv_wakes_new_poller() {
+        use crate::sync::mpsc;
+        use shuttle::sync::{Arc, Mutex};
+
+        shuttle::future::block_on(async {
+            let (tx, rx) = mpsc::channel::<u32>(1);
+            let rx = Arc::new(Mutex::new(Some(rx)));
+            // Sequences task A's poll before task B's, and keeps A alive until
+            // the end of the test.
+            let (a_polled_tx, a_polled_rx) = mpsc::channel::<()>(1);
+            let (release_a_tx, release_a_rx) = mpsc::channel::<()>(1);
+
+            let rx_a = rx.clone();
+            let a = shuttle::future::spawn(async move {
+                let mut receiver = rx_a.lock().unwrap().take().unwrap();
+                {
+                    let mut recv = Box::pin(receiver.recv());
+                    // Nothing has been sent yet, so this enqueues a waiter for
+                    // task A rather than completing.
+                    assert!(futures::poll!(recv.as_mut()).is_pending());
+                    // Cancel the `recv()`, leaving the waiter queued.
+                }
+                *rx_a.lock().unwrap() = Some(receiver);
+                a_polled_tx.send(()).await.unwrap();
+                // Stay alive, but never poll the Receiver again.
+                let mut release_a_rx = release_a_rx;
+                let _ = release_a_rx.recv().await;
+            });
+
+            // Don't send anything until A has polled and handed the Receiver
+            // back, so A's poll is deterministically the one that registers.
+            let mut a_polled_rx = a_polled_rx;
+            a_polled_rx.recv().await.unwrap();
+
+            let rx_b = rx.clone();
+            let b = shuttle::future::spawn(async move {
+                let mut receiver = rx_b.lock().unwrap().take().unwrap();
+                // Must be woken by the send below, even though the queued waiter
+                // was registered by task A.
+                let got = receiver.recv().await;
+                *rx_b.lock().unwrap() = Some(receiver);
+                got
+            });
+
+            tx.send(1).await.unwrap();
+            assert_eq!(b.await.unwrap(), Some(1));
+            release_a_tx.send(()).await.unwrap();
+            a.await.unwrap();
+        });
+    }
+
+    #[test_log::test]
+    fn check_moved_recv_wakes_new_poller() {
+        shuttle::check_random(moved_recv_wakes_new_poller, 200);
+    }
 }


### PR DESCRIPTION
This PR makes `BatchSemaphore` movable.

Ran into assertion issues hitting `assert!(!task.finished());` when waking wakers in `BatchSemaphore`. The reason the assertion would get hit is because the application would store a tokio mpsc `Receiver` which would be polled in a `select!`, then later polled in a `select!` by a different task (ie., the `Receiver` would get moved between tasks).

This is a valid use of a `Receiver` and of `BatchSemaphore`, therefore the assertion has to be removed.

This also highlighted a `Waker` staleness, where the `Waker` would not get updated when polled by the second task. This PR fixes that as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.