### PR TITLE
 Refactor to not iterate over finished tasks for each call to schedule

### DIFF
--- a/shuttle-engine/src/runtime/execution.rs
+++ b/shuttle-engine/src/runtime/execution.rs
@@ -293,7 +293,7 @@ impl Execution {
                 // Task finished
                 Ok(true) => {
                     crate::annotations::record_task_terminated();
-                    ExecutionState::with(|state| state.current_mut().finish());
+                    ExecutionState::with(|state| state.finish_current_task());
                 }
                 // Task yielded
                 Ok(false) => {
@@ -346,6 +346,19 @@ pub struct ExecutionState {
     // Persistent Vec used as a bump allocator for references to runnable tasks to avoid slow allocation
     // on each scheduling decision. Should not be used outside of the `schedule` function
     runnable_tasks: Vec<*const Task>,
+
+    // Ids of all tasks that have not yet finished, kept sorted in ascending order.
+    //
+    // `tasks` never shrinks, so it accumulates every task ever created by the execution. Scanning it
+    // on every scheduling decision therefore costs O(tasks ever created), even though only the
+    // unfinished ones can ever be scheduled. This set lets `schedule` iterate just the live tasks.
+    //
+    // invariant: contains exactly the ids of the tasks in `tasks` that are not `Finished`, in
+    // ascending order. Maintained by pushing on task creation (ids are handed out sequentially, so
+    // pushing keeps this sorted) and removing in `finish_current_task`. This is sound because
+    // `Finished` is a terminal state: it is only ever set by `Task::finish`, and `block`, `sleep`,
+    // and `unblock` all assert that they are never applied to a finished task.
+    live_tasks: Vec<TaskId>,
 }
 
 impl std::fmt::Debug for ExecutionState {
@@ -401,6 +414,7 @@ impl ExecutionState {
             has_cleaned_up: false,
             top_level_span: tracing::Span::current(),
             runnable_tasks: Vec::with_capacity(DEFAULT_INLINE_TASKS),
+            live_tasks: Vec::with_capacity(DEFAULT_INLINE_TASKS),
         }
     }
 
@@ -548,7 +562,7 @@ impl ExecutionState {
                 None,
                 TaskSignature::new_parentless(caller),
             );
-            state.tasks.push(task);
+            state.add_task(task);
 
             task_id
         });
@@ -595,7 +609,7 @@ impl ExecutionState {
                 state.current_mut().signature.new_child(caller),
             );
 
-            state.tasks.push(task);
+            state.add_task(task);
 
             task_id
         });
@@ -641,7 +655,7 @@ impl ExecutionState {
                 Some(state.current().id()),
                 state.current_mut().signature.new_child(caller),
             );
-            state.tasks.push(task);
+            state.add_task(task);
 
             task_id
         });
@@ -659,6 +673,8 @@ impl ExecutionState {
         let (mut tasks, final_state) = Self::with(|state| {
             state.in_cleanup = true;
             assert!(state.current_task == ScheduledTask::Stopped || state.current_task == ScheduledTask::Finished);
+            // Keep the `live_tasks` invariant intact as the tasks are pulled out of the state.
+            state.live_tasks.clear();
             (std::mem::take(&mut state.tasks), state.current_task)
         });
 
@@ -782,6 +798,29 @@ impl ExecutionState {
         self.try_get(id).unwrap()
     }
 
+    /// Register a newly created task. Task ids are handed out sequentially as `tasks.len()`, so the
+    /// new id is always greater than every existing one and `live_tasks` stays sorted.
+    fn add_task(&mut self, task: Task) {
+        debug_assert!(self.live_tasks.last().is_none_or(|last| *last < task.id()));
+        self.live_tasks.push(task.id());
+        self.tasks.push(task);
+    }
+
+    /// Mark the task as finished and drop it from the set of live tasks.
+    fn finish_task(&mut self, task_id: TaskId) {
+        self.get_mut(task_id).finish();
+        let idx = self
+            .live_tasks
+            .binary_search(&task_id)
+            .expect("finished task must be live");
+        self.live_tasks.remove(idx);
+    }
+
+    /// Mark the current task as finished and drop it from the set of live tasks.
+    fn finish_current_task(&mut self) {
+        self.finish_task(self.current_task.id().unwrap());
+    }
+
     pub fn get_mut(&mut self, id: TaskId) -> &mut Task {
         self.tasks.get_mut(id.0).unwrap()
     }
@@ -879,10 +918,20 @@ impl ExecutionState {
         let mut all_runnable_detached = true;
         let mut any_runnable = false;
 
-        for task in &self.tasks {
-            if task.finished() {
-                continue;
-            }
+        // The loop below only looks at `live_tasks`, so a task missing from that set would silently
+        // never be scheduled. Check that direction of the invariant here; the loop itself checks the
+        // other direction (that no finished task is still in the set).
+        debug_assert!(
+            self.tasks
+                .iter()
+                .filter(|task| !task.finished() && task.runnable())
+                .all(|task| self.live_tasks.binary_search(&task.id()).is_ok()),
+            "live_tasks is missing a runnable unfinished task"
+        );
+
+        for &task_id in &self.live_tasks {
+            let task = &self.tasks[task_id.0];
+            debug_assert!(!task.finished());
             unfinished_attached |= !task.detached;
             let is_runnable = task.runnable();
             any_runnable |= is_runnable;


### PR DESCRIPTION
The current `schedule` implementation is quite inefficient, as it considers every single task on each scheduling decisions. This PR changes it to create `runnable_tasks` by only looking at the tasks which are not finished.

This change is 30-40% speedup on a real test.

Note that this can be improved on further, and I have done that in https://github.com/awslabs/shuttle/compare/main...incremental-runnable and https://github.com/awslabs/shuttle/compare/main...incremental-v2.

Might PR those later, but the change in this PR is a lot shorter and less likely to be wrong, and gets the majority of the benefit.

See below for benchmarks.

I am leaning towards merging this because it is small and very beneficial, then maybe refactoring more in the future.

We have previously talked about having task ownership be moved out into the schedulers, so that each scheduler can have a representation which benefits it (eg. a priority queue). That is a larger refactoring, but I think I am pro it. At the very least I'd like to modularize a bit such that the task database can be swapped and in that refactoring also implement the optimal tracking of runnable_tasks, where runnable_tasks is persistent and we update it on finishing, blocking and unblocking tasks.


----

Had Claude run some comparisons on one of the reftests:

## Benchmark

**Method.** 30 fixed proptest seeds (`REFTEST_RNG_SEED=1..30`) with a fixed Shuttle
scheduler seed (`SHUTTLE_RANDOM_SEED=12345`), 1 case x 25 iterations, single reftest release build. Both seeds pinned, so for a given seed every
variant executes an identical test case and identical schedules; the only difference is
the scheduling bookkeeping. Prebuilt binaries (no rebuild between runs) and variant
order shuffled within each seed so position cannot favour a variant. 120 runs, 0
failures. Baseline `PRE` = upstream Shuttle v0.9.0.

| Variant                  | Total (30 seeds) | Mean    | Median  | Min    | Max      |
|--------------------------|------------------|---------|---------|--------|----------|
| PRE (stock v0.9.0)       | 774.47s          | 25.82s  | 15.84s  | 3.32s  | 119.98s  |
| A (live_tasks)           | 558.65s          | 18.62s  | 13.17s  | 3.18s  | 70.34s   |
| B (original incremental) | 525.16s          | 17.51s  | 12.28s  | 3.13s  | 65.26s   |
| B2 (transition-hooked)   | 521.62s          | 17.39s  | 12.27s  | 3.09s  | 65.10s   |

Paired per-seed comparisons (same seed = same workload):

| Comparison | Mean per-seed | Total   | Seeds faster | Per-seed range     |
|------------|---------------|---------|--------------|--------------------|
| A vs PRE   | -16.61%       | -27.87% | 30/30        |                    |
| B vs PRE   | -20.75%       | -32.19% | 30/30        |                    |
| B2 vs PRE  | -21.20%       | -32.65% | 30/30        |                    |
| B vs A     | -5.12%        | -5.99%  | 30/30        |                    |
| B2 vs A    | -5.69%        | -6.63%  | 30/30        | -8.47% .. -2.83%   |
| B2 vs B    | -0.60%        | -0.67%  | 25/30        |                    |

Mean and total diverge because seed workloads span 3s-120s; totals weight the heavy
seeds, where the gains are larger.

## Cost vs benefit

| Variant | Diff        | Files | vs PRE  | vs A   | Notes                                                                 |
|---------|-------------|-------|---------|--------|-----------------------------------------------------------------------|
| A       | +52 / -8    | 1     | -16.6%  | --     | Relies on one one-way invariant: `Finished` is terminal, 1 call site   |
| B       | +166 / -28  | 1     | -20.8%  | -5.1%  | Hooks `get_mut` (hot path); dirty list + per-task summaries            |
| B2      | +244 / -76  | 9     | -21.2%  | -5.7%  | Changes visibility of 9 `Task` methods; edits `sync`/`future`/`thread` |

## Why the gains split this way

Instrumented run of the full suite (1020 executions):

| Metric                          | Value                                              |
|---------------------------------|----------------------------------------------------|
| Scheduling decisions            | 996,337,034 total; mean 976,801/exec; max 10.5M    |
| Total tasks per execution       | mean 392.1; median 245; p99 1731; max 3239         |
| Peak live (unfinished) tasks    | mean 44.7; max 94                                  |
| Schedulable tasks per decision  | mean 18.63; max 51                                 |

`tasks` never shrinks, so stock re-examines every task ever created on every scheduling
decision. The **8.8x** total:live ratio (392 -> 45) is what A eliminates. The remaining
**<=2.4x** live:schedulable ratio (45 -> 19) is all B/B2 can add, which is why they gain
only ~5% on top of A.


--- 


Also ran some longer tests:

| Variant                  | Wall            | Delta vs PRE | vs PRE  | vs A   |
|--------------------------|-----------------|--------------|---------|--------|
| PRE (stock v0.9.0)       | 2720s (45.3 min)| --           | --      | --     |
| A (live_tasks)           | 1642s (27.4 min)| -1078s       | -39.6%  | --     |
| B (original incremental) | 1646s (27.4 min)| -1074s       | -39.5%  | +0.2%  |
| B2 (transition-hooked)   | 1601s (26.7 min)| -1119s       | -41.1%  | -2.5%  |


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.