### PR TITLE
Performance improvements on semaphore acquires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Performance: `BatchSemaphore` no longer takes a `std::sync::Mutex` in a release-mode assertion on every `Acquire` poll, and allocates its `Waiter` only when an acquire actually blocks. Uncontended synchronization operations (`Mutex`, `RwLock`, `Semaphore`, channels) are 43-50% faster.
+
 * Performance: `backtrace_enabled` no longer reads the environment on every call. It is called from `Task::block` and `Task::sleep`, so on every block and every `Poll::Pending`, and `std::env::var` takes a lock on the environment and allocates. Lock-heavy workloads are 9-12% faster.
 
 # 0.9.3 (August 19, 2026)

--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -56,13 +56,22 @@ impl fmt::Debug for Waiter {
 }
 
 impl Waiter {
-    fn new(num_permits: usize) -> Self {
+    /// A `Waiter` is the part of an acquire that a *releasing* task can see and
+    /// mutate, so it only needs to exist once an acquire actually blocks.
+    ///
+    /// `clock` is passed in rather than read from the ambient execution state,
+    /// because it must be snapshotted when the `Acquire` was created, not when it
+    /// later blocks: it feeds the happens-before edge recorded in
+    /// `unblock_waiters_from_front`, and a scheduling point sits between those two
+    /// moments. `task_id`, in contrast, tracks the current poller (see
+    /// [`Waiter::task_id`]), so it is read here and refreshed on later polls.
+    fn new(num_permits: usize, clock: VectorClock) -> Self {
         Self {
             task_id: AtomicUsize::new(ExecutionState::me().into()),
             num_permits,
             is_queued: AtomicBool::new(false),
             has_permits: AtomicBool::new(false),
-            clock: current::clock(),
+            clock,
             waker: Mutex::new(None),
         }
     }
@@ -735,23 +744,90 @@ impl Default for BatchSemaphore {
 
 /// The future that results from async calls to `acquire*`.
 /// Callers must `await` on this future to obtain the necessary permits.
-#[derive(Debug)]
 pub struct Acquire<'a> {
-    waiter: Arc<Waiter>,
     semaphore: &'a BatchSemaphore,
+    num_permits: usize,
+
+    /// Snapshotted when this `Acquire` is created, and moved into the `Waiter` if
+    /// this acquire ends up blocking. See `Waiter::new` for why the snapshot must
+    /// happen here rather than at enqueue time.
+    clock: VectorClock,
+
+    /// The shared part of this acquire, allocated only once the acquire has to
+    /// block. An acquire that gets its permits immediately is never visible to
+    /// any other task, so it needs no shared state and no allocation. While this
+    /// is `None`, `has_permits` below is authoritative.
+    waiter: Option<Arc<Waiter>>,
+
+    /// Whether permits have been granted, for the case where no `Waiter` exists.
+    /// Once one does, the releasing task writes `Waiter::has_permits` instead and
+    /// this field is unused; read through `Acquire::has_permits`.
+    has_permits: bool,
+
     completed: bool, // Has the future completed yet?
     never_polled: bool,
 }
 
+// Implement Debug in order to not output the `VectorClock`, matching `Waiter`.
+impl fmt::Debug for Acquire<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Acquire")
+            .field("num_permits", &self.num_permits)
+            .field("waiter", &self.waiter)
+            .field("has_permits", &self.has_permits())
+            .field("completed", &self.completed)
+            .finish()
+    }
+}
+
 impl<'a> Acquire<'a> {
     fn new(semaphore: &'a BatchSemaphore, num_permits: usize) -> Self {
-        let waiter = Arc::new(Waiter::new(num_permits));
         Self {
-            waiter,
             semaphore,
+            num_permits,
+            clock: current::clock(),
+            waiter: None,
+            has_permits: false,
             completed: false,
             never_polled: true,
         }
+    }
+
+    /// Have permits been granted to this acquire? Once a `Waiter` exists the
+    /// releasing task owns that flag, so the shared copy is authoritative.
+    fn has_permits(&self) -> bool {
+        match &self.waiter {
+            Some(waiter) => waiter.has_permits.load(Ordering::SeqCst),
+            None => self.has_permits,
+        }
+    }
+
+    /// Is this acquire in the semaphore's waiter queue? Only possible once a
+    /// `Waiter` has been allocated, since the queue holds `Arc<Waiter>`.
+    fn is_queued(&self) -> bool {
+        match &self.waiter {
+            Some(waiter) => waiter.is_queued.load(Ordering::SeqCst),
+            None => false,
+        }
+    }
+
+    fn grant_permits(&mut self) {
+        match &self.waiter {
+            Some(waiter) => waiter.has_permits.store(true, Ordering::SeqCst),
+            None => self.has_permits = true,
+        }
+    }
+
+    /// The shared `Waiter` for this acquire, allocating it if this is the first
+    /// time the acquire has had to block. Returns an owned handle so callers can
+    /// still use `self.semaphore` without holding a borrow of `self`.
+    fn waiter_for_blocking(&mut self) -> Arc<Waiter> {
+        if let Some(waiter) = &self.waiter {
+            return Arc::clone(waiter);
+        }
+        let waiter = Arc::new(Waiter::new(self.num_permits, self.clock.clone()));
+        self.waiter = Some(Arc::clone(&waiter));
+        waiter
     }
 }
 
@@ -766,9 +842,9 @@ impl Future for Acquire<'_> {
         // instant, before the scheduling point below, so merging them is sound.
         // Reads *after* the switch must stay separate and fresh, because other
         // tasks may have run in between.
-        let will_succeed = self.waiter.has_permits.load(Ordering::SeqCst) || {
+        let will_succeed = self.has_permits() || {
             let state = self.semaphore.state.borrow();
-            state.closed || state.permits_available.available() >= self.waiter.num_permits
+            state.closed || state.permits_available.available() >= self.num_permits
         };
 
         // If the acquire will succeed on the first try, we need to context switch once to allow the previous
@@ -798,19 +874,19 @@ impl Future for Acquire<'_> {
         }
         self.never_polled = false;
 
-        let out = if self.waiter.has_permits.load(Ordering::SeqCst) {
-            assert!(!self.waiter.is_queued.load(Ordering::SeqCst));
+        let out = if self.has_permits() {
+            assert!(!self.is_queued());
             self.completed = true;
-            trace!("Acquire::poll for waiter {:?} with permits", self.waiter);
+            trace!("Acquire::poll for {:?} with permits", self);
             Poll::Ready(Ok(()))
         } else if self.semaphore.is_closed() {
-            assert!(!self.waiter.is_queued.load(Ordering::SeqCst));
+            assert!(!self.is_queued());
             self.completed = true;
-            trace!("Acquire::poll for waiter {:?} with closed", self.waiter);
+            trace!("Acquire::poll for {:?} with closed", self);
             Poll::Ready(Err(AcquireError::closed()))
         } else {
-            let is_queued = self.waiter.is_queued.load(Ordering::SeqCst);
-            trace!("Acquire::poll for waiter {:?}; is queued: {is_queued:?}", self.waiter);
+            let is_queued = self.is_queued();
+            trace!("Acquire::poll for {:?}; is queued: {is_queued:?}", self);
 
             // Sanity check: there should be a waker if the waiter is in
             // the queue. Also true for unfair semaphores, which wake by ref.
@@ -818,7 +894,12 @@ impl Future for Acquire<'_> {
             // `debug_assert` rather than `assert`: this takes a `std::sync::Mutex`
             // on every poll, including the uncontended fast path, purely to check
             // an internal invariant.
-            debug_assert_eq!(is_queued, self.waiter.waker.lock().unwrap().is_some());
+            debug_assert_eq!(
+                is_queued,
+                self.waiter
+                    .as_ref()
+                    .is_some_and(|waiter| waiter.waker.lock().unwrap().is_some())
+            );
 
             // Should the waiter try to acquire permits here? Four cases:
             // 1. unfair semaphore, waiter not yet enqueued;
@@ -853,24 +934,28 @@ impl Future for Acquire<'_> {
                 // clock, as this thread will be blocked below.
                 let mut state = self.semaphore.state.borrow_mut();
                 let id = state.id.unwrap();
-                let acquire_result = state.acquire_permits(self.waiter.num_permits, self.semaphore.fairness);
+                let acquire_result = state.acquire_permits(self.num_permits, self.semaphore.fairness);
                 drop(state);
 
                 match acquire_result {
                     Ok(()) => {
                         if is_queued {
+                            let waiter = self
+                                .waiter
+                                .clone()
+                                .expect("a queued acquire must have an allocated waiter");
                             crate::annotations::record_semaphore_acquire_unblocked(
                                 id,
-                                self.waiter.task_id(),
-                                self.waiter.num_permits,
+                                waiter.task_id(),
+                                waiter.num_permits,
                             );
-                            self.semaphore.remove_waiter(&self.waiter);
+                            self.semaphore.remove_waiter(&waiter);
                         } else {
-                            crate::annotations::record_semaphore_acquire_fast(id, self.waiter.num_permits);
+                            crate::annotations::record_semaphore_acquire_fast(id, self.num_permits);
                         }
-                        self.waiter.has_permits.store(true, Ordering::SeqCst);
+                        self.grant_permits();
                         self.completed = true;
-                        trace!("Acquire::poll for waiter {:?} that got permits", self.waiter);
+                        trace!("Acquire::poll for {:?} that got permits", self);
 
                         // If the semaphore is unfair, re-block other waiting
                         // threads that can no longer succeed.
@@ -879,17 +964,26 @@ impl Future for Acquire<'_> {
                         Poll::Ready(Ok(()))
                     }
                     Err(TryAcquireError::NoPermits) => {
-                        let mut maybe_waker = self.waiter.waker.lock().unwrap();
+                        // This acquire has to block, so it now becomes visible to
+                        // whichever task releases permits. That is the first point
+                        // at which shared state is needed, so it is where the
+                        // `Waiter` gets allocated.
+                        let waiter = self.waiter_for_blocking();
+
+                        let mut maybe_waker = waiter.waker.lock().unwrap();
                         *maybe_waker = Some(cx.waker().clone());
+                        drop(maybe_waker);
+
                         // Point the waiter at whoever is polling now: this future
                         // may have been created by a different task.
-                        self.waiter.set_task_id(ExecutionState::me());
+                        waiter.set_task_id(ExecutionState::me());
+
                         if !is_queued {
-                            crate::annotations::record_semaphore_acquire_blocked(id, self.waiter.num_permits);
-                            self.semaphore.enqueue_waiter(&self.waiter);
-                            self.waiter.is_queued.store(true, Ordering::SeqCst);
+                            crate::annotations::record_semaphore_acquire_blocked(id, self.num_permits);
+                            // `enqueue_waiter` sets `is_queued` itself.
+                            self.semaphore.enqueue_waiter(&waiter);
                         }
-                        trace!("Acquire::poll for waiter {:?} that is enqueued", self.waiter);
+                        trace!("Acquire::poll for {:?} that is enqueued", self);
                         Poll::Pending
                     }
                     Err(TryAcquireError::Closed) => unreachable!(),
@@ -902,8 +996,12 @@ impl Future for Acquire<'_> {
                 // waiting now. Without this, a permit granted to this waiter
                 // would unblock a task that is no longer interested, and the
                 // actual poller would never be woken.
-                *self.waiter.waker.lock().unwrap() = Some(cx.waker().clone());
-                self.waiter.set_task_id(ExecutionState::me());
+                let waiter = self
+                    .waiter
+                    .as_ref()
+                    .expect("a queued acquire must have an allocated waiter");
+                *waiter.waker.lock().unwrap() = Some(cx.waker().clone());
+                waiter.set_task_id(ExecutionState::me());
                 Poll::Pending
             }
         };
@@ -923,13 +1021,19 @@ impl Future for Acquire<'_> {
 
 impl Drop for Acquire<'_> {
     fn drop(&mut self) {
-        trace!("Acquire::drop for Acquire {:p} with waiter {:?}", self, self.waiter);
-        if self.waiter.is_queued.load(Ordering::SeqCst) {
+        trace!("Acquire::drop for {:?}", self);
+        if self.is_queued() {
             // If the associated waiter is in the wait list, remove it
-            self.semaphore.remove_waiter(&self.waiter);
-        } else if self.waiter.has_permits.load(Ordering::SeqCst) && !self.completed {
-            // If the waiter was granted permits, release them
-            self.semaphore.release(self.waiter.num_permits);
+            let waiter = self
+                .waiter
+                .clone()
+                .expect("a queued acquire must have an allocated waiter");
+            self.semaphore.remove_waiter(&waiter);
+        } else if self.has_permits() && !self.completed {
+            // If the waiter was granted permits, release them. Note this must also
+            // fire for an acquire that got its permits without ever allocating a
+            // waiter, otherwise the semaphore leaks permits.
+            self.semaphore.release(self.num_permits);
         }
     }
 }

--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -647,8 +647,10 @@ impl BatchSemaphore {
             state.permits_available.release(num_permits, clock.clone());
         });
 
-        let me = ExecutionState::me();
-        trace!(task = ?me, avail = ?state.permits_available, waiters = ?state.waiters, "released {} permits for semaphore {:p}", num_permits, &self.state);
+        // `ExecutionState::me()` is only wanted for this trace, so let the macro's
+        // level check decide whether to pay for it. Computing it eagerly cost an
+        // `ExecutionState::with` on every release even with tracing disabled.
+        trace!(task = ?ExecutionState::me(), avail = ?state.permits_available, waiters = ?state.waiters, "released {} permits for semaphore {:p}", num_permits, &self.state);
 
         match self.fairness {
             Fairness::StrictlyFair => {
@@ -759,9 +761,15 @@ impl Future for Acquire<'_> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         assert!(!self.completed);
 
-        let will_succeed = self.waiter.has_permits.load(Ordering::SeqCst)
-            || self.semaphore.is_closed()
-            || self.semaphore.available_permits() >= self.waiter.num_permits;
+        // One borrow of the semaphore state rather than two (`is_closed` and
+        // `available_permits` each took their own). Both reads describe the same
+        // instant, before the scheduling point below, so merging them is sound.
+        // Reads *after* the switch must stay separate and fresh, because other
+        // tasks may have run in between.
+        let will_succeed = self.waiter.has_permits.load(Ordering::SeqCst) || {
+            let state = self.semaphore.state.borrow();
+            state.closed || state.permits_available.available() >= self.waiter.num_permits
+        };
 
         // If the acquire will succeed on the first try, we need to context switch once to allow the previous
         // event to become visible. If we won't succeed, then we still need to context switch if the act of
@@ -806,7 +814,11 @@ impl Future for Acquire<'_> {
 
             // Sanity check: there should be a waker if the waiter is in
             // the queue. Also true for unfair semaphores, which wake by ref.
-            assert_eq!(is_queued, self.waiter.waker.lock().unwrap().is_some());
+            //
+            // `debug_assert` rather than `assert`: this takes a `std::sync::Mutex`
+            // on every poll, including the uncontended fast path, purely to check
+            // an internal invariant.
+            debug_assert_eq!(is_queued, self.waiter.waker.lock().unwrap().is_some());
 
             // Should the waiter try to acquire permits here? Four cases:
             // 1. unfair semaphore, waiter not yet enqueued;


### PR DESCRIPTION
Been looking a bit at performance, trying to get the hot paths down. Here's a commit that makes `BatchSemaphore` acquires faster always, and one commit that makes them faster when there is no contention (by not creating a `Waiter`)

----


`Acquire::poll` ran this in release builds on every poll:

    assert_eq!(is_queued, self.waiter.waker.lock().unwrap().is_some());

That takes a `std::sync::Mutex` to check an internal invariant, on the
uncontended fast path, for every `Mutex::lock`, `RwLock::read`/`write`,
`Semaphore::acquire`, and every channel send and recv in the program under test.
Make it a `debug_assert_eq!`.

Two smaller cleanups alongside it: the `will_succeed` computation took two
separate `RefCell` borrows of the semaphore state (`is_closed`, then
`available_permits`) where one suffices and gives a single consistent snapshot,
and `release()` computed `ExecutionState::me()` eagerly for a `trace!` argument,
paying an `ExecutionState::with` on every release even with tracing disabled.

Measured on an M1 Pro, release, single task, no contention, against an identical
61ns per-scheduling-decision control:

    operation            steps/op    before     after
    mutex lock/unlock           2     234ns     167ns   -29%
    rwlock write                2     240ns     163ns   -32%
    semaphore acquire           2     272ns     163ns   -40%
    mpsc send+recv              4     507ns     353ns   -30%

Attribution: restoring only the `assert_eq!` while keeping the two cleanups
returns the numbers to baseline, so the assertion accounts for essentially all of
it. An isolated `std::sync::Mutex` lock/unlock measures 10.4ns, so the remainder
is presumably the barrier interacting with the surrounding `SeqCst` atomics.

Note this only helps release builds, since `debug_assert` stays active under a
default `cargo test


---

perf(semaphore): allocate the waiter only when an acquire blocks
`BatchSemaphore::acquire` did `Arc::new(Waiter::new(num_permits))`
unconditionally, so every `Mutex::lock`, `RwLock::read`/`write`,
`Semaphore::acquire`, and every channel send and recv did a heap allocation.

The `Arc` exists because a blocked acquire is shared between two owners: the
`Acquire` future on the blocking task's stack, and the semaphore's
`waiters: VecDeque<Arc<Waiter>>`, which the releasing task reaches into to flip
`is_queued`/`has_permits`, read the clock, and take the waker. An acquire that
gets its permits immediately is never enqueued and never observed by another
task, so it needs none of that sharing.

`Acquire` now holds `num_permits`, `task_id`, `clock` and a plain `has_permits`
bool inline, with `waiter: Option<Arc<Waiter>>` allocated in the one branch that
enqueues. `has_permits()`, `is_queued()` and `grant_permits()` read the inline
copies while no waiter exists and the shared ones once it does, since from then
on the releasing task owns those writes.

`task_id` and `clock` are still snapshotted in `Acquire::new`, exactly as before,
and moved into the `Waiter` at enqueue. This is load bearing: `waiter.clock` feeds
the happens-before edge recorded in `unblock_waiters_from_front`, and a
`thread::switch()` sits between construction and blocking, so reading the clock at
enqueue time instead would silently change the happens-before graph that vector
clocks use to detect races.

A `Waiter` cannot instead live on the `Task` and be reused, because a task can
have several acquires outstanding at once: `future::batch_semaphore` already has a
test where one task drives two `lock()` futures for the same semaphore through
`FuturesUnordered`, and `upgrade()` polls an `Acquire` then releases while it is
still alive. Queue identity also matters, since `remove_waiter` locates entries by
`Arc::ptr_eq`.

Measured on an M1 Pro, release, single task, no contention, control 52-54ns:

    operation            steps/op    before     after   primitive work
    mutex lock/unlock           2     167ns     111ns    45ns ->  7ns
    rwlock write                2     163ns     113ns    42ns -> 10ns
    semaphore acquire           2     163ns     112ns    41ns ->  8ns
    mpsc send+recv              4     353ns     250ns   110ns -> 43ns

"primitive work" is cost above what the same number of bare scheduling decisions
takes. This beat the 33ns the allocation alone accounts for, because the fast path
also stopped touching `SeqCst` atomics: `has_permits` and `is_queued` are plain
bool reads when no waiter exists.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.