### PR TITLE
perf(semaphore): hold the waiter's waker in a RefCell, not a std Mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Performance: `BatchSemaphore` no longer takes a `std::sync::Mutex` in a release-mode assertion on every `Acquire` poll, and allocates its `Waiter` only when an acquire actually blocks. Uncontended synchronization operations (`Mutex`, `RwLock`, `Semaphore`, channels) are 43-50% faster.
+* Performance: a `Waiter`'s waker slot is a `RefCell` rather than a `std::sync::Mutex`, removing a `pthread_mutex_init`/`_destroy` pair and a heap allocation per blocking acquire.
 
 * Performance: `backtrace_enabled` no longer reads the environment on every call. It is called from `Task::block` and `Task::sleep`, so on every block and every `Poll::Pending`, and `std::env::var` takes a lock on the environment and allocates. Lock-heavy workloads are 9-12% faster.
 

--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -11,7 +11,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::task::{Context, Poll, Waker};
 use tracing::trace;
 
@@ -39,8 +38,21 @@ struct Waiter {
     /// permits, and keeping the original enqueue clock is conservative (it can
     /// only add happens-before edges, never remove them).
     clock: VectorClock,
-    waker: Mutex<Option<Waker>>,
+    /// `RefCell` rather than `std::sync::Mutex`: a `Waiter` is shared between the blocking task and
+    /// whichever task releases permits, but those are continuations on a single OS thread, never real
+    /// threads. The mutex cost a `pthread_mutex_init`/`_destroy` pair per blocking acquire, which
+    /// showed up in profiles.
+    waker: RefCell<Option<Waker>>,
 }
+
+// Safety: as for `BatchSemaphore` below, a `Waiter` is never actually passed across true threads,
+// only across continuations, so the `RefCell` cannot be preempted mid-borrow.
+//
+// This impl is load bearing, not belt-and-braces: `Acquire` holds an `Arc<Waiter>`, so without it
+// any future holding an outstanding acquire across an await stops being `Send` and cannot be
+// spawned. `timeout(.., mutex.lock())` inside `future::spawn` is exactly that shape, and there are
+// tests which do it.
+unsafe impl Sync for Waiter {}
 
 // Implement debug in order to not output the `VectorClock`
 impl fmt::Debug for Waiter {
@@ -72,7 +84,7 @@ impl Waiter {
             is_queued: AtomicBool::new(false),
             has_permits: AtomicBool::new(false),
             clock,
-            waker: Mutex::new(None),
+            waker: RefCell::new(None),
         }
     }
 
@@ -300,7 +312,7 @@ impl BatchSemaphoreState {
                 waiter.is_queued.store(false, Ordering::SeqCst);
                 // Preserve the "queued <=> waker registered" invariant asserted
                 // in `Acquire::poll`; waking a finished task's waker is a no-op.
-                waiter.waker.lock().unwrap().take();
+                waiter.waker.borrow_mut().take();
                 trace!("dropping stale waiter {:?} for finished task", waiter);
                 continue;
             }
@@ -335,8 +347,8 @@ impl BatchSemaphoreState {
                     task.clock.update(&clock);
                     task.unblock();
                 });
-                let mut maybe_waker = waiter.waker.lock().unwrap();
-                if let Some(waker) = maybe_waker.take() {
+                let maybe_waker = waiter.waker.borrow_mut().take();
+                if let Some(waker) = maybe_waker {
                     waker.wake();
                 }
             } else {
@@ -487,8 +499,8 @@ impl BatchSemaphore {
                     exec_state.get_mut(waiter.task_id()).unblock();
                 }
             });
-            let mut maybe_waker = waiter.waker.lock().unwrap();
-            if let Some(waker) = maybe_waker.take() {
+            let maybe_waker = waiter.waker.borrow_mut().take();
+            if let Some(waker) = maybe_waker {
                 waker.wake();
             }
         }
@@ -691,7 +703,7 @@ impl BatchSemaphore {
                         if stale {
                             continue;
                         }
-                        let maybe_waker = waiter.waker.lock().unwrap();
+                        let maybe_waker = waiter.waker.borrow().clone();
                         if let Some(waker) = maybe_waker.as_ref() {
                             waker.wake_by_ref();
                         }
@@ -898,7 +910,7 @@ impl Future for Acquire<'_> {
                 is_queued,
                 self.waiter
                     .as_ref()
-                    .is_some_and(|waiter| waiter.waker.lock().unwrap().is_some())
+                    .is_some_and(|waiter| waiter.waker.borrow().is_some())
             );
 
             // Should the waiter try to acquire permits here? Four cases:
@@ -970,9 +982,7 @@ impl Future for Acquire<'_> {
                         // `Waiter` gets allocated.
                         let waiter = self.waiter_for_blocking();
 
-                        let mut maybe_waker = waiter.waker.lock().unwrap();
-                        *maybe_waker = Some(cx.waker().clone());
-                        drop(maybe_waker);
+                        *waiter.waker.borrow_mut() = Some(cx.waker().clone());
 
                         // Point the waiter at whoever is polling now: this future
                         // may have been created by a different task.
@@ -1000,7 +1010,7 @@ impl Future for Acquire<'_> {
                     .waiter
                     .as_ref()
                     .expect("a queued acquire must have an allocated waiter");
-                *waiter.waker.lock().unwrap() = Some(cx.waker().clone());
+                *waiter.waker.borrow_mut() = Some(cx.waker().clone());
                 waiter.set_task_id(ExecutionState::me());
                 Poll::Pending
             }

--- a/shuttle-engine/src/future/batch_semaphore.rs
+++ b/shuttle-engine/src/future/batch_semaphore.rs
@@ -4,12 +4,12 @@ use crate::runtime::task::{clock::VectorClock, TaskId};
 use crate::runtime::thread;
 use crate::sync_types::{ResourceSignature, ResourceType};
 use crate::{backtrace_enabled, current};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use tracing::trace;
@@ -27,9 +27,10 @@ struct Waiter {
     /// mirrors tokio's own `batch_semaphore`, which refreshes its waiter's
     /// `Waker` under a `will_wake` check.
     ///
-    /// Stored as an atomic rather than a `Cell` to keep `Waiter` (and hence
-    /// `Acquire`) `Sync`.
-    task_id: AtomicUsize,
+    /// A plain `Cell` suffices: `Waiter` is `Sync` by the `unsafe impl` below,
+    /// which the `waker` field needs anyway, so there is nothing for an atomic
+    /// to buy here.
+    task_id: Cell<TaskId>,
     num_permits: usize,
     is_queued: AtomicBool,
     has_permits: AtomicBool,
@@ -46,7 +47,7 @@ struct Waiter {
 }
 
 // Safety: as for `BatchSemaphore` below, a `Waiter` is never actually passed across true threads,
-// only across continuations, so the `RefCell` cannot be preempted mid-borrow.
+// only across continuations, so the `RefCell` and `Cell` cannot be preempted mid-borrow.
 //
 // This impl is load bearing, not belt-and-braces: `Acquire` holds an `Arc<Waiter>`, so without it
 // any future holding an outstanding acquire across an await stops being `Send` and cannot be
@@ -79,7 +80,7 @@ impl Waiter {
     /// [`Waiter::task_id`]), so it is read here and refreshed on later polls.
     fn new(num_permits: usize, clock: VectorClock) -> Self {
         Self {
-            task_id: AtomicUsize::new(ExecutionState::me().into()),
+            task_id: Cell::new(ExecutionState::me()),
             num_permits,
             is_queued: AtomicBool::new(false),
             has_permits: AtomicBool::new(false),
@@ -90,13 +91,13 @@ impl Waiter {
 
     /// The task currently waiting on this waiter. See [`Waiter::task_id`].
     fn task_id(&self) -> TaskId {
-        TaskId::from(self.task_id.load(Ordering::SeqCst))
+        self.task_id.get()
     }
 
     /// Point this waiter at the task that is polling it now, so that a later
     /// `release` unblocks the current poller rather than whoever polled first.
     fn set_task_id(&self, task_id: TaskId) {
-        self.task_id.store(task_id.into(), Ordering::SeqCst);
+        self.task_id.set(task_id);
     }
 }
 


### PR DESCRIPTION
Stacked on #321 — based on `perf-bsem`, so the diff here is the single commit on top.
GitHub will retarget this to `main` when #321 merges. Rebased onto the current
`perf-bsem`, so this sits on top of #317 and #318.

## Problem

`Waiter::waker` is a `std::sync::Mutex<Option<Waker>>`. A `Waiter` is genuinely
shared — between the task blocking on the acquire and whichever task releases
permits — but those are continuations on a single OS thread, never real threads. The
mutex therefore bought no safety and cost a
`pthread_mutex_init`/`pthread_mutex_destroy` pair plus a heap allocation on every
blocking acquire.

## Change

`waker: RefCell<Option<Waker>>`, plus `unsafe impl Sync for Waiter`.

Two access sites also stopped holding the guard across `Waker::wake`; the waker is
taken or cloned out first. Waking reenters `ExecutionState`, and holding a lock
across that was a latent hazard with the `Mutex` too. Shuttle's wakers carry no
resources (the task id lives in the pointer), so the clone is free.

## The design question this raises, and I'd like your call on it

#317 added this comment to `Waiter::task_id`:

> Stored as an atomic rather than a `Cell` to keep `Waiter` (and hence `Acquire`)
> `Sync`.

So avoiding an `unsafe impl Sync` here looks like a deliberate, recently-made
decision, and this PR cuts against it. Worth deciding explicitly rather than letting
me smuggle it in. Three options as I see them:

1. **Take the `unsafe impl` (this PR).** It is consistent with what
   `BatchSemaphore` already does two screens further down — "Semaphore is never
   actually passed across true threads, only across continuations" — so it is not a
   new assumption, just a newly-relied-upon one. As a bonus it would then also let
   `task_id` go back to a plain `Cell<TaskId>` and drop those atomics, which I have
   *not* done here.
2. **Use an `AtomicWaker`** (the `atomic-waker` crate, as bach does). Naturally
   `Sync`, no pthread mutex, no allocation, no `unsafe` in Shuttle. Costs a small
   dependency in `shuttle-engine`. Probably gets most of the same win.
3. **Leave it alone** and accept ~10% on blocking-heavy tests.

Happy to switch to 2 if you'd rather not widen the unsafe surface — it is a small
change from here.

Note the impl is load bearing rather than defensive, whichever way you go: `Acquire`
holds an `Arc<Waiter>`, so without something keeping `Waiter: Sync`, any future
holding an outstanding acquire across an await stops being `Send` and cannot be
spawned. I confirmed by removing it — `cargo build --workspace` still passes, but
`--all-targets` does not:

```
error: `RefCell<Option<Waker>>` cannot be shared between threads safely
  --> wrappers/tokio/impls/tokio/inner/tests/time.rs:87
     let h = future::spawn(async move {
         let l = timeout(Duration::from_secs(1), left_fork.lock()).await;
```

`timeout(.., mutex.lock())` inside `future::spawn` is an ordinary shape, so this
would otherwise have been a silent breaking change to which futures are `Send`.

## Measurements

4 tasks contending for 1 permit, each holding it across a yield, so nearly every
acquire blocks and therefore allocates a `Waiter`. Minimum over 60 short reps,
alternating between the two builds; five rounds of that, measured on this branch's
current base:

| round | before | after |
| --- | --- | --- |
| 1 | 112.2 µs | 101.4 µs |
| 2 | 111.1 µs | 99.6 µs |
| 3 | 110.5 µs | 98.3 µs |
| 4 | 112.4 µs | 98.4 µs |
| 5 | 108.6 µs | 98.2 µs |

Best of each: **108.6 µs → 98.2 µs, -9.6%** per execution, or 170 ns → 151 ns per
scheduling step. The distributions do not overlap.

Both builds report an identical 649 scheduling decisions per execution, which is a
useful check that this changes cost and not behaviour.

The design deliberately uses many short reps with a minimum rather than a few long
runs: my machine was busy, and a minimum over short samples approximates the
uninterrupted case far better than a mean.

How much a given test gains scales with how often it blocks, since after #321 the
uncontended path does not allocate a `Waiter` at all.

## Supporting profile evidence

Found by sampling profile rather than inspection. On a 16-task, 4-permit semaphore
workload (measured before the rebase, so on #321 without #317):

* `drop_in_place<std::sys::sync::mutex::pthread::Mutex>`: 1.6% of self time → gone
* `alloc::alloc`: 3.6% → below 1.4%

The second line is the useful one: it identifies the `std::sync::Mutex` as the
allocation source, not the `Arc<Waiter>`. Which also means a `Waiter` free list —
something I had queued as a follow-up — is not worth doing, since the allocation it
would have removed is largely this one.

## Testing

- `cargo nextest run --release --workspace` — 649 passed, 24 skipped
- `cargo test --release --doc --workspace` — passes
- `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D clippy::all` — clean
- `cargo build -p shuttle-engine --features vector-clocks` — builds
- `cargo build --workspace --all-targets` — builds, which is what caught the `Sync` requirement
