### PR TITLE
Prepare shuttle 0.9.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
-# shuttle-engine, shuttle-schedulers, shuttle-std 0.1.1 (August 19, 2026)
-
-There is no accompanying `shuttle` release: the `shuttle` crate itself is unchanged since 0.9.2, and its `shuttle-engine = "0.1.0"` requirement already admits 0.1.1, so `cargo update` is enough to pick these changes up.
+# 0.9.3 (August 19, 2026)
 
 * Fix `BatchSemaphore` waking the wrong task when an `Acquire` future is polled by a task other than the one that created it (the motivating case is an in-flight acquire cached inside a longer-lived object, such as a tokio `Receiver` that is moved between tasks). Waiters left behind by a cancelled `Acquire` whose task has since finished are now also treated as stale instead of consuming permits or blocking a finished task. (#317)
 * Performance: `schedule` no longer iterates over tasks that have already finished. This does not change scheduling decisions. (#318)
 * Add READMEs for `shuttle-engine`, `shuttle-schedulers`, `shuttle-std` and the wrapper crates. Make `shuttle-async-stream-impl` publishable. (#315)
 * Fix doc comment paths that got broken in the crate refactoring.
+* Publish `shuttle-engine`, `shuttle-schedulers` and `shuttle-std` 0.1.1.
 
 # 0.9.2 (August 6, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.9.3 (August 19, 2026)
+
+* Fix `BatchSemaphore` waking the wrong task when an `Acquire` future is polled by a task other than the one that created it (the motivating case is an in-flight acquire cached inside a longer-lived object, such as a tokio `Receiver` that is moved between tasks). Waiters left behind by a cancelled `Acquire` whose task has since finished are now also treated as stale instead of consuming permits or blocking a finished task. (#317)
+* Performance: `schedule` no longer iterates over tasks that have already finished. This does not change scheduling decisions. (#318)
+* Add READMEs for `shuttle-engine`, `shuttle-schedulers`, `shuttle-std` and the wrapper crates. Make `shuttle-async-stream-impl` publishable. (#315)
+* Fix doc comment paths that got broken in the crate refactoring.
+* Publish `shuttle-engine`, `shuttle-schedulers` and `shuttle-std` 0.1.1.
+
 # 0.9.2 (August 6, 2026)
 
 * Add support for 128-bit atomics (`AtomicI128`/`AtomicU128`) (#299)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# 0.9.3 (August 19, 2026)
+# shuttle-engine, shuttle-schedulers, shuttle-std 0.1.1 (August 19, 2026)
+
+There is no accompanying `shuttle` release: the `shuttle` crate itself is unchanged since 0.9.2, and its `shuttle-engine = "0.1.0"` requirement already admits 0.1.1, so `cargo update` is enough to pick these changes up.
 
 * Fix `BatchSemaphore` waking the wrong task when an `Acquire` future is polled by a task other than the one that created it (the motivating case is an in-flight acquire cached inside a longer-lived object, such as a tokio `Receiver` that is moved between tasks). Waiters left behind by a cancelled `Acquire` whose task has since finished are now also treated as stale instead of consuming permits or blocking a finished task. (#317)
 * Performance: `schedule` no longer iterates over tasks that have already finished. This does not change scheduling decisions. (#318)
 * Add READMEs for `shuttle-engine`, `shuttle-schedulers`, `shuttle-std` and the wrapper crates. Make `shuttle-async-stream-impl` publishable. (#315)
 * Fix doc comment paths that got broken in the crate refactoring.
-* Publish `shuttle-engine`, `shuttle-schedulers` and `shuttle-std` 0.1.1.
 
 # 0.9.2 (August 6, 2026)
 

--- a/shuttle-engine/Cargo.toml
+++ b/shuttle-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-engine"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Core runtime and scheduler trait for Shuttle concurrency testing"

--- a/shuttle-schedulers/Cargo.toml
+++ b/shuttle-schedulers/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "shuttle-schedulers"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Scheduler implementations for the Shuttle concurrency testing framework"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/shuttle"
 
 [dependencies]
-shuttle-engine = { path = "../shuttle-engine", version = "0.1.0" }
+shuttle-engine = { path = "../shuttle-engine", version = "0.1.1" }
 rand = "0.8.6"
 rand_pcg = "0.3.1"
 smallvec = { version = "1.11.2", features = ["const_new"] }

--- a/shuttle-std/Cargo.toml
+++ b/shuttle-std/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "shuttle-std"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Mirrors of std compatible with the Shuttle concurrency testing tool"
 repository = "https://github.com/awslabs/shuttle"
 
 [dependencies]
-shuttle-engine = { path = "../shuttle-engine", version = "0.1.0" }
+shuttle-engine = { path = "../shuttle-engine", version = "0.1.1" }
 assoc = "0.1.3"
 owo-colors = "4.3.0"
 smallvec = { version = "1.11.2", features = ["const_new"] }

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.9.3"
+version = "0.9.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for testing concurrent Rust code"
@@ -10,9 +10,9 @@ categories = ["asynchronous", "concurrency", "development-tools::testing"]
 readme = "../README.md"
 
 [dependencies]
-shuttle-engine = { path = "../shuttle-engine", version = "0.1.0" }
-shuttle-schedulers = { path = "../shuttle-schedulers", version = "0.1.0" }
-shuttle-std = { path = "../shuttle-std", version = "0.1.0" }
+shuttle-engine = { path = "../shuttle-engine", version = "0.1.1" }
+shuttle-schedulers = { path = "../shuttle-schedulers", version = "0.1.1" }
+shuttle-std = { path = "../shuttle-std", version = "0.1.1" }
 bitvec = "1.0.1"
 cfg-if = "1.0"
 hex = "0.4.2"


### PR DESCRIPTION
Cuts 0.9.3 for the four commits that have landed on `main` since 0.9.2: the `BatchSemaphore` fix (#317), the scheduling refactor (#318), the READMEs and publishable `shuttle-async-stream-impl` (#315), and the doc comment path fix.

`shuttle` goes 0.9.2 -> 0.9.3, and `shuttle-engine`, `shuttle-schedulers` and `shuttle-std` go 0.1.0 -> 0.1.1.

The internal crates have to move along with `shuttle`. Both #317 and #318 live in `shuttle-engine`, so a `shuttle` 0.9.3 that still required `shuttle-engine` 0.1.0 would be published against an engine without either change. `shuttle-schedulers` and `shuttle-std` move so the new READMEs and the doc comment path fixes reach crates.io and docs.rs.

Raising the `shuttle-engine` requirement to 0.1.1 is what makes the `shuttle` bump meaningful: cargo prefers versions already in the lock file, so under a `^0.1.0` requirement a user moving to 0.9.3 would keep `shuttle-engine` 0.1.0 and get a new `shuttle` containing none of the fixes.

Patch rather than minor: #318 preserves ascending-task-id iteration order, so scheduling decisions are unchanged and existing serialized schedules still replay. The wrapper crates depend on `shuttle` via `0.9`, `<0.10` or `*`, so they need no changes.

Publish order once merged: `shuttle-engine`, then `shuttle-schedulers` and `shuttle-std`, then `shuttle`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
