### PR TITLE
Publish shuttle-tokio as 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 * Better instrument backtraces for blocked futures. (#215)
 * Fix the `annotation` feature. (#334)
 * `shuttle-tokio`'s `full` feature now matches tokio's, and tokio's remaining features (including its implicit optional-dependency features) are mirrored as pass-throughs, so switching a crate from `tokio` to `shuttle-tokio` no longer breaks on an unknown feature. (#335, #337)
-* Publish `shuttle-tokio`, `shuttle-tokio-impl` and `shuttle-tokio-impl-inner` 0.1.1.
+* Publish `shuttle-tokio-impl` and `shuttle-tokio-impl-inner` 0.1.1.
 * Publish `shuttle-tokio-retry` 0.3.0 and `shuttle-tokio-retry-impl` 0.1.0 for the first time. (#275)
+* `shuttle-tokio` is now versioned 1.0.0, so that it mirrors the version of the crate it wraps like every other wrapper does and a downstream crate can depend on it with the same `version = "1"` requirement it would have used for `tokio`. The 0.1 line is unchanged and still resolves to 0.1.1; moving to the 1.x line is opt-in. (#327)
 
 # 0.9.3 (August 19, 2026)
 

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -48,7 +48,7 @@ For example, if you want to pin `tokio` to `1.36.0`, you can add the following:
 
 ```toml
 [dependencies]
-tokio = { package = "shuttle-tokio", version = "0.1.0" }
+tokio = { package = "shuttle-tokio", version = "1" }
 tokio-version-importer-do-not-use-directly = { package = "tokio", version = "=1.36.0" }
 ```
 

--- a/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "shuttle-tokio"
-version = "0.1.1"
+# Wrappers mirror the version of the crate they wrap, so that a downstream crate can depend on the
+# wrapper using the same version requirement it would have used for the real crate. `tokio` is at
+# 1.x, so this is too.
+version = "1.0.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "tokio wrapper for the Shuttle concurrency testing tool."


### PR DESCRIPTION
The wrappers mirror the version of the crate they wrap, so that a downstream crate can depend on the wrapper using the same version requirement it would have used for the real crate:

| Wrapper | Version | Wraps |
| --- | --- | --- |
| `shuttle-parking_lot` | 0.12.5 | `parking_lot` 0.12 |
| `shuttle-dashmap` | 6.1.0 | `dashmap` 6.1 |
| `shuttle-lazy_static` | 1.5.0 | `lazy_static` 1.5 |
| `shuttle-rand` | 0.8.6 | `rand` 0.8.6 |
| `shuttle-async-stream` | 0.3.6 | `async-stream` 0.3.6 |
| `shuttle-tokio-util` | 0.7.0 | `tokio-util` 0.7 |
| `shuttle-tokio-retry` | 0.3.0 | `tokio-retry` 0.3 |
| **`shuttle-tokio`** | **0.1.0** | **`tokio` 1.x** |

`shuttle-tokio` was the odd one out. It also made `wrappers/README.md` contradict itself, telling users to write `version = "1"` in two places and `version = "0.1.0"` in a third.

This bumps it to 1.0.0 so it follows the same scheme as its siblings, and fixes the one stale reference in `wrappers/README.md` so all three examples agree.

## Notes for review

- This is a **major version bump of an already-published crate** — 0.1.0 is on crates.io. Under Cargo's rules `0.1.0` and `1.0.0` are separate incompatible lines, so anyone currently on `version = "0.1"` keeps resolving to 0.1.0 and is not broken by the release; they opt in by changing their requirement to `1`.
- Nothing in this repository depends on `shuttle-tokio`. It is a leaf that only downstream users consume, so the change is contained to its own manifest. Verified with `grep -rn 'package = "shuttle-tokio"' --include=Cargo.toml`, which matches only its own `[package]` name.
- The `shuttle-tokio` README and crate docs use a `VERSION_NUMBER` placeholder rather than a literal, so they needed no change.
- `shuttle-tokio-stream` stays at 0.1.0: `tokio-stream` is itself 0.1.x, so it already matches the scheme.
- `cargo check --workspace` and `cargo fmt --all -- --check` clean with `RUSTFLAGS=-Dwarnings`.

No CHANGELOG entry, matching the convention that release-prep PRs aggregate them.

## Relation to other open PRs

- #325 (`shuttle_enabler`) depends on this, since its dependency on `shuttle-tokio` needs the `1` requirement. It is stacked on this branch and will retarget to `main` automatically once this merges.
- #326 (README rewrite) documents `version = "1"` on the strength of this change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.