### PR TITLE
Fix the weekly cron job and move workflows off Node 20

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,24 @@
+# Configuration for `cargo audit`, run by the weekly cron in
+# .github/workflows/crons.yml. See:
+# https://github.com/rustsec/rustsec/blob/main/cargo-audit/audit.toml.example
+
+[advisories]
+ignore = [
+    # RUSTSEC-2022-0040: multiple soundness issues in `owning_ref`.
+    #
+    # Not reachable in any build we produce. `owning_ref` enters Cargo.lock only
+    # as an *optional* dependency of `lock_api`, which is reached three ways:
+    # `parking_lot` 0.12 and `dashmap` 6 (transitively), and
+    # `shuttle-parking_lot-impl` (directly). In every case pulling in
+    # `owning_ref` requires the non-default `owning_ref` feature, which nothing
+    # in this workspace enables. `cargo tree -i owning_ref --workspace` reports
+    # no match, confirming it is absent from the resolved build graph; `cargo
+    # audit` flags it anyway because it scans the lockfile, which records
+    # optional dependencies whether or not their feature is activated.
+    #
+    # The advisory has no fixed upgrade available, so it cannot be resolved by
+    # bumping. Revisit if `lock_api` drops the `owning_ref` dependency, or if
+    # this workspace ever enables the `owning_ref` feature by default -- at that
+    # point the code would genuinely be exposed and this entry must be removed.
+    "RUSTSEC-2022-0040",
+]

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true # This step will not fail the job if it errors
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - uses: boa-dev/criterion-compare-action@v3

--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -1,6 +1,9 @@
 name: Cron jobs
+
+# Least privilege by default. Note that naming any scope here implicitly sets
+# every unnamed scope to `none`, so jobs needing more must opt in explicitly.
 permissions:
-  contents: write
+  contents: read
 
 on:
   push:
@@ -14,7 +17,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - name: Install Audit
@@ -26,8 +29,14 @@ jobs:
   # Exists to not get "caught off guard" by new Rust versions bringing new clippies.
   beta:
     runs-on: ubuntu-latest
+    # `issues: write` is required by the "Notify failed build" step below, which
+    # opens an issue when this job fails. Job-level permissions replace the
+    # top-level block outright, so `contents: read` has to be restated here.
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update beta
       - name: Default to beta

--- a/.github/workflows/crons.yml
+++ b/.github/workflows/crons.yml
@@ -16,6 +16,10 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    # See the note on the `beta` job below.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust
@@ -24,6 +28,17 @@ jobs:
         run: cargo install cargo-audit
       - name: cargo audit
         run: cargo audit
+      # Uses its own label so this is tracked separately from the `beta` job's
+      # notification: a new advisory and a beta toolchain regression are
+      # unrelated failures with unrelated fixes, and should not share an issue
+      # thread.
+      - name: Notify failed build
+        uses: drivendataorg/failed-build-issue-action@v1
+        if: failure()
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-name: "audit failed"
+          title-template: "Failed cargo audit: {{workflow}}"
   
   # Runs Clippy, fmt, doc and tests on beta. 
   # Exists to not get "caught off guard" by new Rust versions bringing new clippies.
@@ -57,8 +72,14 @@ jobs:
         run: cargo nextest run --release --workspace
       - name: cargo test --doc
         run: cargo test --release --doc --workspace
+      # Requires v1.3.0 or newer: earlier releases declare `runs.using: node20`,
+      # and Node 20 is removed from the runners on 2026-09-16. The action also
+      # moved from jayqi/ to drivendataorg/; the old path still redirects, but
+      # naming the canonical owner avoids depending on that.
       - name: Notify failed build
-        uses: jayqi/failed-build-issue-action@v1
-        if: failure() 
+        uses: drivendataorg/failed-build-issue-action@v1
+        if: failure()
         with:
+          # Optional as of v1.3.0, which defaults it to `github.token`, but kept
+          # explicit to keep the token this step uses obvious at the call site.
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,7 @@
+name: Release
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -18,7 +22,7 @@ jobs:
     name: Benchmarks (with vector clocks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - name: cargo bench

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - name: Install nextest
@@ -34,7 +34,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - name: Install rustfmt
@@ -46,11 +46,11 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - name: Install clippy
-        run: rustup component add rustfmt
+        run: rustup component add clippy
       - name: clippy
         run: cargo clippy --all-targets -- -D clippy::all
 
@@ -58,7 +58,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Install Rust
         run: rustup update stable
       - name: cargo doc


### PR DESCRIPTION
The `Cron jobs` workflow has failed on every scheduled run since at least mid-June ([latest](https://github.com/awslabs/shuttle/actions/runs/31987845860), [a month earlier](https://github.com/awslabs/shuttle/actions/runs/29713604671)). There were two independent causes, and one hid the other.

### 1. `cargo audit` fails on an unreachable advisory

The `audit` job exits 1 on [RUSTSEC-2022-0040](https://rustsec.org/advisories/RUSTSEC-2022-0040) (`owning_ref` 0.4.1, multiple soundness issues, no fixed upgrade available).

The advisory is not reachable in anything we build. `owning_ref` enters `Cargo.lock` only as an *optional* dependency of `lock_api`, which is reached three ways: transitively via `parking_lot` 0.12 and `dashmap` 6, and directly by `shuttle-parking_lot-impl`. In every case pulling it in requires the non-default `owning_ref` feature, which nothing in this workspace enables. `cargo tree -i owning_ref --workspace` reports no match, confirming it is absent from the resolved build graph. `cargo audit` flags it regardless because it scans the lockfile, which records optional dependencies whether or not their feature is activated.

Since there is no fixed version to upgrade to, this adds `.cargo/audit.toml` ignoring the advisory, with the reachability analysis and the conditions for removing the entry recorded next to it.

### 2. Nobody was told, because the notifier was broken too

The workflow set a top-level `permissions: contents: write`. Naming any scope [implicitly sets every unnamed scope to `none`](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/assigning-permissions-to-jobs), which left `issues: none`, so the notify step could not open an issue and failed with `Resource not accessible by integration`.

This drops to `contents: read` at the top level, which is all either job needs, and grants `issues: write` on the jobs that notify.

The notify step was also only wired to the `beta` job, so the `audit` job — the one actually failing — had no notification path at all. It now has one, under its own label: the action reuses an open issue carrying the configured label, so a shared label would file an audit failure as a comment on a beta toolchain issue.

### 3. Node 20 action runtime

Every run carried `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v2, jayqi/failed-build-issue-action@v1`. Node 20 is removed from the runners on **2026-09-16**, at which point these stop working.

- `actions/checkout` v2/v3 → v5, the first major declaring `using: node24`. Deliberately not v7: v6 changed checkout to persist git credentials to a separate file, and `bench.yml` uses `boa-dev/criterion-compare-action@v3`, which last shipped in 2022 and runs its own git operations against the base branch. v5 clears the deadline without taking on that behavioural change.
- The notifier tracked `jayqi/failed-build-issue-action@v1`, which resolved to v1.2.0 on node20. Upstream has since released v1.3.0 on node24 and `v1` now points at it. The action also moved from `jayqi/` to `drivendataorg/`; the old path still redirects, but this references the canonical owner rather than relying on that.

### Unrelated fixes to workflows touched anyway

- `release.yml` had no `name:` and no `permissions:` block at any level, so it displayed by file path and inherited the repository default token scope.
- The `clippy` job in `tests.yml` ran `rustup component add rustfmt`, so it never installed the component it is named for. It only worked because the runner image ships clippy already.

### Testing

`cargo audit` reproduced locally against cargo-audit 0.22.2: exit 1 before, exit 0 after, with output matching CI run 31987845860 exactly. All four workflows re-parsed and permissions verified per job.

Note that `crons.yml` only triggers on `schedule` and on pushes to `main` touching `Cargo.toml`, so CI on this PR will not exercise the audit job. It is worth a manual `gh workflow run` (or waiting for the Monday run) after merge to confirm green.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
