### PR TITLE
Fix version pinning example in wrappers README

### DIFF
--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -49,7 +49,7 @@ For example, if you want to pin `tokio` to `1.36.0`, you can add the following:
 ```toml
 [dependencies]
 tokio = { package = "shuttle-tokio", version = "0.1.0" }
-tokio-version-importer-do-not-use-directly = { version = "=1.36.0" }
+tokio-version-importer-do-not-use-directly = { package = "tokio", version = "=1.36.0" }
 ```
 
 A more robust alternative which removes the possibility of accidentally using the version importer crate is the following:


### PR DESCRIPTION
The version pinning example in `wrappers/README.md` was missing the `package = "tokio"` key on the version-importer dependency:

```toml
tokio-version-importer-do-not-use-directly = { version = "=1.36.0" }
```

As written, cargo would look for a crate literally named `tokio-version-importer-do-not-use-directly` instead of pulling in the real `tokio` crate, so the example would fail to resolve.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.