### PR TITLE
Fix the annotation feature

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,20 @@ jobs:
       - name: cargo test --doc
         run: cargo test --release --doc --workspace
 
+  test-annotation:
+    env:
+      RUST_LOG: off
+    name: Tests (annotation)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - name: cargo nextest
+        run: cargo nextest run --release --workspace --features annotation
+
   fmt:
     name: rustfmt
     runs-on: ubuntu-latest
@@ -53,6 +67,8 @@ jobs:
         run: rustup component add rustfmt
       - name: clippy
         run: cargo clippy --all-targets -- -D clippy::all
+      - name: clippy (annotation)
+        run: cargo clippy --all-targets --features annotation -- -D clippy::all
 
   docs:
     name: Docs

--- a/shuttle-engine/Cargo.toml
+++ b/shuttle-engine/Cargo.toml
@@ -32,5 +32,7 @@ proptest = "1.0.0"
 [features]
 default = []
 vector-clocks = []
-annotation = ["dep:serde", "dep:serde_json", "dep:regex"]
+# Annotated schedules record each task's vector clock so that Shuttle Explorer can
+# show causal dependence between tasks, so `annotation` implies `vector-clocks`.
+annotation = ["vector-clocks", "dep:serde", "dep:serde_json", "dep:regex"]
 bench-no-vector-clocks = []

--- a/shuttle-engine/src/annotations/mod.rs
+++ b/shuttle-engine/src/annotations/mod.rs
@@ -11,8 +11,17 @@
 //       also be reflected in the parsing
 // TODO: introduce version numbers to make sure breaking changes are noticed
 
+// `annotation` turns on `vector-clocks`, but `bench-no-vector-clocks` overrides it and would
+// leave every clock in the annotated schedule empty, hiding all causal dependence from the
+// Shuttle Explorer.
+#[cfg(all(feature = "annotation", feature = "bench-no-vector-clocks"))]
+compile_error!(
+    "the `annotation` feature requires vector clocks, so it cannot be combined with `bench-no-vector-clocks`"
+);
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "annotation")] {
+        use crate::annotation_file;
         use crate::runtime::{
             execution::ExecutionState,
             task::{clock::VectorClock, Task, TaskId},
@@ -142,8 +151,11 @@ cfg_if::cfg_if! {
                 S: serde::ser::Serializer,
             {
                 use serde::ser::SerializeSeq;
-                let mut seq = serializer.serialize_seq(Some(self.time.len()))?;
-                for e in &self.time {
+                // `VectorClock` derefs to `[u32]` in both its real and its stubbed
+                // form, so go through the slice rather than the `time` field, which
+                // only exists when the `vector-clocks` feature is enabled.
+                let mut seq = serializer.serialize_seq(Some(self.len()))?;
+                for e in self.iter() {
                     seq.serialize_element(e)?;
                 }
                 seq.end()
@@ -252,7 +264,7 @@ cfg_if::cfg_if! {
                     task_id,
                     info,
                     event,
-                    ExecutionState::try_with(|state| state.get_clock(task_id).clone()),
+                    ExecutionState::try_with(|state| state.get_clock(task_id).clone()).ok(),
                     state.last_runnable_ids.take(),
                 ))
             });

--- a/shuttle/Cargo.toml
+++ b/shuttle/Cargo.toml
@@ -51,7 +51,7 @@ bench = false
 [features]
 default = []
 vector-clocks = ["shuttle-engine/vector-clocks"]
-annotation = ["shuttle-engine/annotation", "shuttle-schedulers/annotation", "dep:serde", "dep:serde_json", "dep:regex"]
+annotation = ["vector-clocks", "shuttle-engine/annotation", "shuttle-schedulers/annotation", "dep:serde", "dep:serde_json", "dep:regex"]
 # The following feature overrides the `vector-clocks` feature. It SHOULD NOT be used in production.
 # Its purpose is solely to allow `cargo bench` to be run without vector clocks enabled, as they
 # are otherwise always enabled via a dev-dependency to ensure all *test* assertions utilizing vector

--- a/shuttle/tests/basic/annotation.rs
+++ b/shuttle/tests/basic/annotation.rs
@@ -1,0 +1,167 @@
+use serde_json::Value;
+use shuttle::scheduler::{AnnotationScheduler, RoundRobinScheduler};
+use shuttle::sync::Mutex;
+use shuttle::{current, thread, Runner};
+use std::sync::Arc;
+
+/// Two tasks contending on a mutex, so the annotated schedule contains task creation
+/// and termination, a semaphore, and both a fast and a blocking acquire.
+fn contend() {
+    let lock = Arc::new(Mutex::new(0usize));
+    let handles = (0..2)
+        .map(|i| {
+            let lock = lock.clone();
+            thread::spawn(move || {
+                current::set_name_for_task(current::me(), format!("worker-{i}"));
+                *lock.lock().unwrap() += 1;
+            })
+        })
+        .collect::<Vec<_>>();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+/// Run `f` under an `AnnotationScheduler` and return the parsed annotated schedule.
+///
+/// `SHUTTLE_ANNOTATION_FILE` is process-global, so all annotation tests share this
+/// helper and run behind a single mutex to keep them from clobbering each other.
+fn annotated<F>(f: F) -> Value
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _guard = LOCK.lock().unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("annotated.json");
+    std::env::set_var(shuttle::ANNOTATION_FILE, &path);
+
+    {
+        // `AnnotationScheduler` writes the file when it is dropped
+        let runner = Runner::new(
+            AnnotationScheduler::new(RoundRobinScheduler::new(1)),
+            Default::default(),
+        );
+        runner.run(f);
+    }
+
+    let json = std::fs::read_to_string(&path).expect("annotation file should have been written");
+    serde_json::from_str(&json).expect("annotation file should be valid JSON")
+}
+
+/// The annotated schedule uses the schema Shuttle Explorer expects (see
+/// `shuttle-explorer/src/common/schedule.mts`).
+#[test]
+fn annotation_schema() {
+    let schedule = annotated(contend);
+
+    assert_eq!(schedule["version"], 0);
+    for key in ["files", "functions", "objects", "tasks", "events"] {
+        assert!(schedule[key].is_array(), "`{key}` should be an array");
+    }
+
+    // the main task plus the two workers
+    let tasks = schedule["tasks"].as_array().unwrap();
+    assert_eq!(tasks.len(), 3);
+    for task in tasks {
+        assert!(task["created_by"].is_u64());
+        assert!(task["first_step"].as_u64().unwrap() <= task["last_step"].as_u64().unwrap());
+    }
+    assert_eq!(tasks[0]["name"], Value::Null, "the main task is unnamed");
+    let worker_names = tasks[1..]
+        .iter()
+        .map(|task| task["name"].as_str().expect("workers are named"))
+        .collect::<Vec<_>>();
+    assert!(
+        worker_names.iter().all(|name| name.starts_with("worker-")),
+        "expected `set_name_for_task` to be recorded, got {worker_names:?}"
+    );
+
+    // the mutex's batch semaphore
+    let objects = schedule["objects"].as_array().unwrap();
+    assert_eq!(objects.len(), 1);
+    assert!(objects[0]["created_by"].is_u64());
+
+    let events = schedule["events"].as_array().unwrap();
+    assert!(!events.is_empty());
+    for event in events {
+        let event = event.as_array().expect("an event is a tuple");
+        assert!(event[0].is_u64(), "first element is the task ID");
+        assert!(
+            event[1].is_null() || event[1].is_array(),
+            "second element is a backtrace"
+        );
+        assert!(
+            event[4].is_null() || event[4].is_array(),
+            "fifth element is runnable tasks"
+        );
+    }
+}
+
+/// Every event carries a non-empty vector clock.
+///
+/// Note that this test cannot catch the `annotation` feature failing to turn on
+/// `vector-clocks`: the integration tests already get vector clocks via the
+/// `shuttle = { path = ".", features = ["vector-clocks"] }` dev-dependency. The
+/// `compile_error!` in `shuttle-engine/src/annotations/mod.rs` guards that instead.
+#[test]
+fn annotation_records_vector_clocks() {
+    let schedule = annotated(contend);
+
+    for event in schedule["events"].as_array().unwrap() {
+        let clock = event[3].as_array().expect("every event should have a vector clock");
+        assert!(!clock.is_empty(), "vector clocks should not be empty");
+        assert!(clock.iter().all(|entry| entry.is_u64()));
+    }
+}
+
+/// The event kinds a contended mutex is expected to produce all show up, and the
+/// object and task IDs they carry are in range.
+#[test]
+fn annotation_records_events() {
+    let schedule = annotated(contend);
+    let num_objects = schedule["objects"].as_array().unwrap().len() as u64;
+    let num_tasks = schedule["tasks"].as_array().unwrap().len() as u64;
+
+    let mut kinds = std::collections::HashSet::new();
+    for event in schedule["events"].as_array().unwrap() {
+        match &event[2] {
+            // unit variants serialize as a bare string
+            Value::String(name) => {
+                kinds.insert(name.clone());
+            }
+            // newtype/tuple variants serialize as a single-key object
+            Value::Object(map) => {
+                let (name, payload) = map.iter().next().expect("a variant has one key");
+                match name.as_str() {
+                    "SemaphoreCreated" | "SemaphoreClosed" => {
+                        assert!(payload.as_u64().unwrap() < num_objects);
+                    }
+                    "TaskCreated" => {
+                        assert!(payload[0].as_u64().unwrap() < num_tasks);
+                        assert!(payload[1].is_boolean());
+                    }
+                    _ => {
+                        assert!(payload[0].as_u64().unwrap() < num_objects, "{name} names an object");
+                    }
+                }
+                kinds.insert(name.clone());
+            }
+            other => panic!("unexpected event kind: {other}"),
+        }
+    }
+
+    for expected in [
+        "TaskCreated",
+        "TaskTerminated",
+        "Tick",
+        "SemaphoreCreated",
+        "SemaphoreAcquireFast",
+        "SemaphoreAcquireBlocked",
+        "SemaphoreAcquireUnblocked",
+        "SemaphoreRelease",
+    ] {
+        assert!(kinds.contains(expected), "expected a {expected} event, got {kinds:?}");
+    }
+}

--- a/shuttle/tests/basic/mod.rs
+++ b/shuttle/tests/basic/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "annotation")]
+mod annotation;
 mod atomic;
 mod barrier;
 pub(crate) mod clocks;


### PR DESCRIPTION
Pure Claude. PR looks good to me.

----
`cargo build --features annotation` has been failing for a while -- nothing in CI builds the feature, so it rotted behind a few refactors:

- `VectorClock` has no `time` field in its stubbed form, so the `Serialize` impl went through the `Deref<Target = [u32]>` that both forms provide instead.
- `ExecutionState::try_with` returns a `Result` now, not an `Option`.
- `annotation_file` was never imported into the `cfg_if` block.

Beyond compiling, the feature also emitted useless data: `annotation` did not turn on `vector-clocks`, so a consumer building with just `features = ["annotation"]` got the zero-sized `VectorClock` stub and every clock in the schedule serialized as `[]`. Shuttle Explorer reads those clocks to show causal dependence between tasks (`clockCmp` in `shuttle-explorer/src/common/clocks.mts`), so it would have shown none. `annotation` now implies `vector-clocks`, and a `compile_error!` rejects combining it with `bench-no-vector-clocks`, which would override that.

The empty-clock bug is invisible to the test suite, because the integration tests already get vector clocks from the `shuttle = { path = ".", features = ["vector-clocks"] }` dev-dependency. I verified it against a scratch crate outside the workspace depending on `shuttle` with only `annotation`: clocks were `[]` before, populated after.

Also adds:
- `shuttle/tests/basic/annotation.rs`, checking the emitted schedule against the schema in `shuttle-explorer/src/common/schedule.mts` -- task/object/event shape, task names from `set_name_for_task`, non-empty vector clocks, and that a contended mutex produces each expected event kind with in-range IDs.
- a `Tests (annotation)` CI job and a clippy run with the feature, so this cannot rot again.

Verified: `cargo nextest run --release --workspace --features annotation` is 652/652 green, the default run is 649/649, and doc tests, `cargo doc`, fmt and clippy all pass with `RUSTFLAGS=-Dwarnings`.

Two things I deliberately left out:

- No test for `annotate_replay`. It needs an encoded schedule recovered from a failing run, and that mechanism is already broken for a separate reason -- several tests in `shuttle/tests/basic/replay.rs` are `#[ignore]`d with "the schedule is not emitted in the panic output". I would rather not hardcode a brittle schedule string; worth revisiting when replay is fixed.
- Note that `cargo test --release --workspace` (as opposed to nextest) fails intermittently on this repo with or without my changes -- I saw `batch_semaphore_test_2` fail on unmodified main, and a tracing-subscriber "cloned a span that already closed" panic in `mpsc_many_senders_with_blocking`. It looks like cross-test global state that nextest's process-per-test isolation hides. Pre-existing and separate from this PR.