### PR TITLE
Make shuttle-tokio's `full` feature match tokio's

### DIFF
--- a/wrappers/tokio/impls/tokio/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/Cargo.toml
@@ -10,8 +10,35 @@ repository = "https://github.com/awslabs/shuttle"
 # Include nothing by default
 default = []
 
-# enable everything
-full = ["tokio-orig/full", "shuttle-tokio-impl-inner/full"]
+# Enable everything.
+#
+# This must list this crate's own features (not just forward `full` to the
+# dependencies), because the `cfg(feature = ...)` gates in this crate's source
+# check its own features. Forwarding `tokio-orig/full` also covers tokio
+# features that have no equivalent here. As in tokio, `test-util` and unstable
+# features are not part of `full`.
+#
+# There is intentionally no `parking_lot` feature in this crate: it is an
+# internal tokio performance feature and irrelevant to the Shuttle
+# implementation. `shuttle-tokio` forwards it to tokio directly.
+#
+# Note: not all features are modeled by Shuttle; several (e.g. `io`, `net`, `fs`)
+# are plain re-exports of tokio. See the crate docs for details.
+full = [
+    "fs",
+    "io-util",
+    "io-std",
+    "macros",
+    "net",
+    "process",
+    "rt",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time",
+    "tokio-orig/full",
+    "shuttle-tokio-impl-inner/full",
+]
 
 fs = ["tokio-orig/fs", "shuttle-tokio-impl-inner/fs"]
 io-util = ["tokio-orig/io-util", "shuttle-tokio-impl-inner/io-util"]

--- a/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
@@ -21,6 +21,10 @@ io-util = ["tokio/io-util", "shuttle-tokio-impl?/io-util"]
 io-std = ["tokio/io-std", "shuttle-tokio-impl?/io-std"]
 macros = ["tokio/macros", "shuttle-tokio-impl?/macros"]
 net = ["tokio/net", "shuttle-tokio-impl?/net"]
+# Pass-through for tokio's internal performance feature, so `shuttle-tokio`
+# stays a drop-in replacement. Irrelevant to the Shuttle implementation, so
+# there is no matching feature in the impl crate.
+parking_lot = ["tokio/parking_lot"]
 process = ["tokio/process", "shuttle-tokio-impl?/process"]
 # Includes basic task execution capabilities
 rt = ["tokio/rt", "shuttle-tokio-impl?/rt"]


### PR DESCRIPTION
`full` in shuttle-tokio-impl only forwarded `full` to its dependencies and never enabled the crate's own feature flags, so the `cfg(feature = ...)`-gated re-exports (`fs`, `signal`, `task_local`, `join`, `main`, `try_join`) were silently missing when building with `full`. Define `full` as the same list of features as real tokio.

Also add a `parking_lot` pass-through feature to shuttle-tokio so it remains a drop-in replacement for users who enable that tokio feature explicitly.

<!-- Enter your PR description here -->

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.