### PR TITLE
BOOK: 01: Add mdBook scaffold for the Shuttle book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,54 @@
+name: Book
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  MDBOOK_VERSION: 0.5.4
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook@${{ env.MDBOOK_VERSION }}
+      - name: mdbook build
+        run: mdbook build book
+      - name: Test code samples
+        run: |
+          cargo build --tests --workspace
+          mdbook test book -L target/debug/deps
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: book/book
+
+  deploy:
+    name: Deploy to GitHub Pages
+    # Only publish from main; pull requests just build the book above.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ debug/
 target/
 Cargo.lock
 .DS_Store
+book/book/

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ trade-off: Shuttle is not sound (a passing Shuttle test does not prove the code
 is correct), but it scales to much larger test cases than Loom. Empirically,
 randomized testing is successful at finding most concurrency bugs, which tend
 not to be adversarial.
+
+## Documentation
+
+The [Shuttle Book](https://awslabs.github.io/shuttle/) is a guide to testing concurrent code with
+Shuttle. Its sources live in [book/](/book) and can be built locally with
+[mdBook](https://rust-lang.github.io/mdBook/):
+
+```sh
+cargo install mdbook
+mdbook serve book --open
+```
+
+API documentation is available on [docs.rs](https://docs.rs/shuttle).
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,23 @@
+[book]
+title = "The Shuttle Book"
+authors = ["The Shuttle contributors"]
+description = "A guide to testing concurrent Rust code with Shuttle"
+language = "en"
+src = "src"
+
+[output.html]
+default-theme = "rust"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/awslabs/shuttle"
+edit-url-template = "https://github.com/awslabs/shuttle/edit/main/book/{path}"
+site-url = "/shuttle/"
+
+[output.html.playground]
+runnable = false
+
+[output.html.fold]
+enable = true
+level = 1
+
+[rust]
+edition = "2021"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,23 @@
+# Summary
+
+[Introduction](./introduction.md)
+
+# Getting started
+
+- [Installation and your first test](./getting-started.md)
+- [Writing Shuttle tests](./writing-tests.md)
+
+# Using Shuttle
+
+- [Schedulers and check functions](./schedulers.md)
+- [Configuring test runs](./configuration.md)
+- [Debugging failures: schedules and replay](./debugging.md)
+- [Async code and futures](./async.md)
+- [Third-party crates and wrappers](./wrappers.md)
+- [Annotations and Shuttle Explorer](./explorer.md)
+
+# Understanding Shuttle
+
+- [How Shuttle works](./internals.md)
+- [Determinism rules and common pitfalls](./pitfalls.md)
+- [Performance and continuous integration](./ci-and-performance.md)

--- a/book/src/async.md
+++ b/book/src/async.md
@@ -1,0 +1,3 @@
+# Async code and futures
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/ci-and-performance.md
+++ b/book/src/ci-and-performance.md
@@ -1,0 +1,3 @@
+# Performance and continuous integration
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,0 +1,3 @@
+# Configuring test runs
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/debugging.md
+++ b/book/src/debugging.md
@@ -1,0 +1,3 @@
+# Debugging failures: schedules and replay
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/explorer.md
+++ b/book/src/explorer.md
@@ -1,0 +1,3 @@
+# Annotations and Shuttle Explorer
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -1,0 +1,3 @@
+# Installation and your first test
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/internals.md
+++ b/book/src/internals.md
@@ -1,0 +1,3 @@
+# How Shuttle works
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,0 +1,3 @@
+# Introduction
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/pitfalls.md
+++ b/book/src/pitfalls.md
@@ -1,0 +1,3 @@
+# Determinism rules and common pitfalls
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/schedulers.md
+++ b/book/src/schedulers.md
@@ -1,0 +1,3 @@
+# Schedulers and check functions
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/wrappers.md
+++ b/book/src/wrappers.md
@@ -1,0 +1,3 @@
+# Third-party crates and wrappers
+
+<!-- TODO: written in a follow-up commit. -->

--- a/book/src/writing-tests.md
+++ b/book/src/writing-tests.md
@@ -1,0 +1,3 @@
+# Writing Shuttle tests
+
+<!-- TODO: written in a follow-up commit. -->


### PR DESCRIPTION
Sarek here, AI under the `---`-split

I'm adding a book. The writing of the book is heavily AI-assisted, but I don't want it to be AI-y so I have forked Shuttle and I'm reviewing each chapter there and having Claude/Codex respond to my comments. Once a PR is merged there it'll  be put up here for review by others. I'll probably also fully write certain sections myself. I expect certain sections like the ones that for now are under "advanced", like how to do reftesting to require more input from me.

I don't expect the book to be superb, but to be better than the nothing we have currently. I also expect it to require a bit of editing in terms of moving stuff around and changing how things are presented, but I think some of that'll come in a pass after the initial version of the book has been made.

I won't bother with PR description and commit message for any BOOK pr in this initial batch and I'll just take whatever the LLM generates. Once I start doing edits there might be something in the PR description.


----
First commit of a documentation series: an mdBook at `book/` that grows into a guide to testing concurrent code with Shuttle. This PR is scaffolding only — `book.toml`, the table of contents, placeholder chapter pages, and CI. The chapters themselves follow as separate PRs so each can be reviewed on its own.

## What is here

- `book/book.toml` — mdBook config. `runnable = false` for the playground, since the samples need `shuttle` linked and the playground cannot provide it.
- `book/src/SUMMARY.md` — the table of contents, in three parts: getting started, using Shuttle, understanding Shuttle.
- `book/src/*.md` — one placeholder per planned chapter, each a heading plus a `<!-- TODO -->` marker, so `SUMMARY.md` resolves and the book builds from this commit onward.
- `.github/workflows/book.yml` — builds the book on every PR, runs `mdbook test` against the samples, and deploys to GitHub Pages from `main` only.
- `README.md` — a Documentation section pointing at the book and at docs.rs.
- `.gitignore` — ignores the `book/book/` build output.

## Why a book

The rustdoc is good on individual APIs but there is no single place that explains the workflow — randomize to find a failure, replay to debug it — or the determinism rules a test body has to follow for replay to work at all. Those are the questions that come up repeatedly, and they do not belong on any one API page.

## Two things worth flagging

**`mdbook test` needs `-L`, not the playground.** The workflow runs `cargo build --tests --workspace` and then `mdbook test book -L target/debug/deps`. Because mdBook passes only `-L` and never `--extern`, every Rust sample that names `shuttle` needs a hidden `# extern crate shuttle;` line or it fails to resolve the crate. The chapter PRs follow that convention throughout.

**Pages needs enabling before the deploy job can work.** The `deploy` job uses `actions/deploy-pages@v4`, which requires the repository to have Pages configured with GitHub Actions as the source. Until a maintainer does that, the `build` job passes and `deploy` fails on `main`. The README link to `https://awslabs.github.io/shuttle/` is likewise dead until then. Happy to drop the deploy job from this PR and add it separately once Pages is set up — say the word.

## Verification

`mdbook build book` and `mdbook test book` both pass on this commit (mdBook 0.5.4, the version the workflow pins).

## Note on process

`CONTRIBUTING.md` asks for an issue before significant work. I did not open one first — the book was drafted before I read that, and the content is already written and reviewed on a fork. I am happy to open a tracking issue for the series if that is useful for coordination; tell me and I will file it. If you would rather review the book as fewer, larger PRs than one-per-chapter, that is easy to reshape too.