### PR TITLE
Mirror tokio's full feature set in shuttle-tokio, with impl pass-throughs

### DIFF
--- a/wrappers/tokio/impls/tokio/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/Cargo.toml
@@ -14,13 +14,9 @@ default = []
 #
 # This must list this crate's own features (not just forward `full` to the
 # dependencies), because the `cfg(feature = ...)` gates in this crate's source
-# check its own features. Forwarding `tokio-orig/full` also covers tokio
-# features that have no equivalent here. As in tokio, `test-util` and unstable
+# check its own features. Forwarding `tokio-orig/full` also covers any tokio
+# feature that has no equivalent here. As in tokio, `test-util` and unstable
 # features are not part of `full`.
-#
-# There is intentionally no `parking_lot` feature in this crate: it is an
-# internal tokio performance feature and irrelevant to the Shuttle
-# implementation. `shuttle-tokio` forwards it to tokio directly.
 #
 # Note: not all features are modeled by Shuttle; several (e.g. `io`, `net`, `fs`)
 # are plain re-exports of tokio. See the crate docs for details.
@@ -30,6 +26,7 @@ full = [
     "io-std",
     "macros",
     "net",
+    "parking_lot",
     "process",
     "rt",
     "rt-multi-thread",
@@ -46,6 +43,7 @@ io-util = ["tokio-orig/io-util", "shuttle-tokio-impl-inner/io-util"]
 io-std = ["tokio-orig/io-std", "shuttle-tokio-impl-inner/io-std"]
 macros = ["tokio-orig/macros", "shuttle-tokio-impl-inner/macros"]
 net = ["tokio-orig/net", "shuttle-tokio-impl-inner/net"]
+parking_lot = ["tokio-orig/parking_lot", "shuttle-tokio-impl-inner/parking_lot"]
 process = ["tokio-orig/process", "shuttle-tokio-impl-inner/process"]
 # Includes basic task execution capabilities
 rt = ["tokio-orig/rt", "shuttle-tokio-impl-inner/rt"]
@@ -58,6 +56,20 @@ time = ["tokio-orig/time", "shuttle-tokio-impl-inner/time"]
 io-uring = ["tokio-orig/io-uring", "shuttle-tokio-impl-inner/io-uring"]
 # Unstable feature. Requires `--cfg tokio_unstable` to enable.
 taskdump = ["tokio-orig/taskdump", "shuttle-tokio-impl-inner/taskdump"]
+
+# tokio's optional dependencies are also implicit features, so mirror them here
+# too, keeping this crate's feature set identical to tokio's. They only pull in a
+# dependency in tokio and mean nothing here, but having them means `shuttle-tokio`
+# can forward every one of its features uniformly, and means nothing gets missed
+# if one of them ever does start to mean something here.
+bytes = ["tokio-orig/bytes", "shuttle-tokio-impl-inner/bytes"]
+libc = ["tokio-orig/libc", "shuttle-tokio-impl-inner/libc"]
+mio = ["tokio-orig/mio", "shuttle-tokio-impl-inner/mio"]
+signal-hook-registry = ["tokio-orig/signal-hook-registry", "shuttle-tokio-impl-inner/signal-hook-registry"]
+socket2 = ["tokio-orig/socket2", "shuttle-tokio-impl-inner/socket2"]
+tokio-macros = ["tokio-orig/tokio-macros", "shuttle-tokio-impl-inner/tokio-macros"]
+tracing = ["tokio-orig/tracing", "shuttle-tokio-impl-inner/tracing"]
+windows-sys = ["tokio-orig/windows-sys", "shuttle-tokio-impl-inner/windows-sys"]
 
 [dependencies]
 cfg-if = "1.0"

--- a/wrappers/tokio/impls/tokio/inner/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/inner/Cargo.toml
@@ -19,6 +19,7 @@ io-util = []
 io-std = []
 macros = []
 net = []
+parking_lot = []
 process = []
 # Includes basic task execution capabilities
 rt = []
@@ -31,6 +32,19 @@ time = []
 io-uring = []
 # Unstable feature. Requires `--cfg tokio_unstable` to enable.
 taskdump = []
+
+# tokio's optional dependencies are also implicit features. They mean nothing
+# here, but are mirrored so that every feature of `shuttle-tokio` has a
+# counterpart all the way down and nothing gets missed if one of them ever does
+# start to mean something here.
+bytes = []
+libc = []
+mio = []
+signal-hook-registry = []
+socket2 = []
+tokio-macros = []
+tracing = []
+windows-sys = []
 
 [dependencies]
 criterion = { version = "0.8", features = [

--- a/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
@@ -21,10 +21,7 @@ io-util = ["tokio/io-util", "shuttle-tokio-impl?/io-util"]
 io-std = ["tokio/io-std", "shuttle-tokio-impl?/io-std"]
 macros = ["tokio/macros", "shuttle-tokio-impl?/macros"]
 net = ["tokio/net", "shuttle-tokio-impl?/net"]
-# Pass-through for tokio's internal performance feature, so `shuttle-tokio`
-# stays a drop-in replacement. Irrelevant to the Shuttle implementation, so
-# there is no matching feature in the impl crate.
-parking_lot = ["tokio/parking_lot"]
+parking_lot = ["tokio/parking_lot", "shuttle-tokio-impl?/parking_lot"]
 process = ["tokio/process", "shuttle-tokio-impl?/process"]
 # Includes basic task execution capabilities
 rt = ["tokio/rt", "shuttle-tokio-impl?/rt"]
@@ -37,6 +34,21 @@ time = ["tokio/time", "shuttle-tokio-impl?/time"]
 io-uring = ["tokio/io-uring", "shuttle-tokio-impl?/io-uring"]
 # Unstable feature. Requires `--cfg tokio_unstable` to enable.
 taskdump = ["tokio/taskdump", "shuttle-tokio-impl?/taskdump"]
+
+# tokio's optional dependencies are also implicit features, so mirror them here
+# too: a crate that depends on `tokio` with, say, `features = ["socket2"]` must
+# keep building after switching to `shuttle-tokio`. These features only pull in
+# a dependency in tokio and mean nothing to the Shuttle implementation, but they
+# are still forwarded to the impl crate so that every feature of this crate is
+# forwarded uniformly.
+bytes = ["tokio/bytes", "shuttle-tokio-impl?/bytes"]
+libc = ["tokio/libc", "shuttle-tokio-impl?/libc"]
+mio = ["tokio/mio", "shuttle-tokio-impl?/mio"]
+signal-hook-registry = ["tokio/signal-hook-registry", "shuttle-tokio-impl?/signal-hook-registry"]
+socket2 = ["tokio/socket2", "shuttle-tokio-impl?/socket2"]
+tokio-macros = ["tokio/tokio-macros", "shuttle-tokio-impl?/tokio-macros"]
+tracing = ["tokio/tracing", "shuttle-tokio-impl?/tracing"]
+windows-sys = ["tokio/windows-sys", "shuttle-tokio-impl?/windows-sys"]
 
 
 [dependencies]


### PR DESCRIPTION
Follow-up to #335, implementing https://github.com/awslabs/shuttle/pull/335#discussion_r3926479996 and its parent comment.

## Expose tokio's optional-dependency features

tokio's optional dependencies are also implicit Cargo features, so a crate can legitimately depend on tokio with e.g. `features = ["socket2"]`. `shuttle-tokio` didn't expose those, so such a crate would fail to build after switching over. Added:

`bytes`, `libc`, `mio`, `signal-hook-registry`, `socket2`, `tokio-macros`, `tracing`, `windows-sys`

Two notes on the list in the review comment:

* `slab` and `backtrace` are *not* tokio features — tokio references them as `dep:slab` / `dep:backtrace` (from `io-uring` / `taskdump`), which suppresses the implicit feature, so there is nothing to pass through.
* `tracing` and `windows-sys` weren't listed but are in exactly the same category, so they're included.

`schedule-latency` is deliberately left out: it's a real tokio feature, but it doesn't exist in tokio 1.43, which is the minimum `shuttle-tokio-impl` declares for `tokio-orig`. Happy to add it plus a version bump if wanted.

## Pass everything through to the impl crate

Every feature now forwards to `shuttle-tokio-impl` (and on to `shuttle-tokio-impl-inner`), including `parking_lot`, which previously forwarded to tokio only. Uniform forwarding is less to reason about when reading the feature list, and means nothing gets accidentally missed if one of these features ever does start to mean something in the impl crate.

Since tokio's `full` includes `parking_lot`, it's been added to the impl crate's `full` too, keeping `full` there equivalent to tokio's.

## Testing

`cargo check -p shuttle-tokio` and `-p shuttle-tokio-impl` with `full,test-util` plus all eight new features, both with and without the `shuttle` feature, and `cargo check --workspace --all-targets`. `Cargo.lock` is unchanged.

(`--all-features` still fails, as it did before this change, because `io-uring`/`taskdump` need `--cfg tokio_unstable` and Linux.)