### PR TITLE
Publish shuttle-tokio 0.1.1 and the tokio-retry crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
 
 * Performance: `backtrace_enabled` no longer reads the environment on every call. It is called from `Task::block` and `Task::sleep`, so on every block and every `Poll::Pending`, and `std::env::var` takes a lock on the environment and allocates. Lock-heavy workloads are 9-12% faster.
+* Better instrument backtraces for blocked futures. (#215)
+* Fix the `annotation` feature. (#334)
+* `shuttle-tokio`'s `full` feature now matches tokio's, and tokio's remaining features (including its implicit optional-dependency features) are mirrored as pass-throughs, so switching a crate from `tokio` to `shuttle-tokio` no longer breaks on an unknown feature. (#335, #337)
+* Publish `shuttle-tokio`, `shuttle-tokio-impl` and `shuttle-tokio-impl-inner` 0.1.1.
+* Publish `shuttle-tokio-retry` 0.3.0 and `shuttle-tokio-retry-impl` 0.1.0 for the first time. (#275)
 
 # 0.9.3 (August 19, 2026)
 

--- a/wrappers/tokio/impls/tokio/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-tokio-impl"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Internal implementation of the `tokio` crate for use with the Shuttle concurrency testing tool. Do not depend on this crate directly; use `shuttle-tokio`."
@@ -74,7 +74,7 @@ windows-sys = ["tokio-orig/windows-sys", "shuttle-tokio-impl-inner/windows-sys"]
 [dependencies]
 cfg-if = "1.0"
 tokio-orig = { package = "tokio", version = "1.43" }
-shuttle-tokio-impl-inner = { version = "0.1.0", path = "./inner" }
+shuttle-tokio-impl-inner = { version = "0.1.1", path = "./inner" }
 
 [dev-dependencies]
 shuttle = { version = "0.9", path = "../../../../shuttle" }

--- a/wrappers/tokio/impls/tokio/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/Cargo.toml
@@ -79,3 +79,9 @@ shuttle-tokio-impl-inner = { version = "0.1.1", path = "./inner" }
 [dev-dependencies]
 shuttle = { version = "0.9", path = "../../../../shuttle" }
 futures = "0.3.15"
+
+# docs.rs builds with no features by default, which hides most of the crate.
+# `all-features` is not usable here: `io-uring` and `taskdump` require
+# `--cfg tokio_unstable` and are platform-gated, so they fail the build.
+[package.metadata.docs.rs]
+features = ["full"]

--- a/wrappers/tokio/impls/tokio/inner/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/inner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-tokio-impl-inner"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Internal implementation of the `tokio` crate for use with the Shuttle concurrency testing tool. Do not depend on this crate directly; use `shuttle-tokio`."

--- a/wrappers/tokio/impls/tokio/inner/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/inner/Cargo.toml
@@ -67,3 +67,7 @@ tokio-macros = { package = "shuttle-tokio-macros-impl", path = "../../tokio-macr
 
 [dev-dependencies]
 assert_matches = "1.5"
+
+# docs.rs builds with no features by default, which hides most of the crate.
+[package.metadata.docs.rs]
+features = ["full"]

--- a/wrappers/tokio/wrappers/shuttle-tokio-retry/README.md
+++ b/wrappers/tokio/wrappers/shuttle-tokio-retry/README.md
@@ -20,4 +20,4 @@ The code will then behave as before when the `shuttle` feature flag is not provi
 
 ## Limitations
 
-For the list of current limitations, see the [tokio-retry](https://crates.io/crates/shuttle-tokio-retry-impl) inner crate.
+For the list of current limitations, see the [shuttle-tokio-retry-impl](https://crates.io/crates/shuttle-tokio-retry-impl) inner crate.

--- a/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
@@ -55,3 +55,9 @@ windows-sys = ["tokio/windows-sys", "shuttle-tokio-impl?/windows-sys"]
 cfg-if = "1.0"
 tokio = "1"
 shuttle-tokio-impl = { path = "../../impls/tokio", version = "0.1.1", optional = true }
+
+# docs.rs builds with no features by default, which hides most of the crate.
+# `all-features` is not usable here: `io-uring` and `taskdump` require
+# `--cfg tokio_unstable` and are platform-gated, so they fail the build.
+[package.metadata.docs.rs]
+features = ["full"]

--- a/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
+++ b/wrappers/tokio/wrappers/shuttle-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-tokio"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "tokio wrapper for the Shuttle concurrency testing tool."
@@ -54,4 +54,4 @@ windows-sys = ["tokio/windows-sys", "shuttle-tokio-impl?/windows-sys"]
 [dependencies]
 cfg-if = "1.0"
 tokio = "1"
-shuttle-tokio-impl = { path = "../../impls/tokio", version = "0.1.0", optional = true }
+shuttle-tokio-impl = { path = "../../impls/tokio", version = "0.1.1", optional = true }


### PR DESCRIPTION
The tokio feature-parity work in #335 and #337, plus the `BatchSemaphore` fix in #317, landed on `main` without a version bump. All three affected crates still declared `0.1.0`, which is already on crates.io, so they could not be published.

## Version bumps

| Crate | Old | New |
|---|---|---|
| `shuttle-tokio` | 0.1.0 | 0.1.1 |
| `shuttle-tokio-impl` | 0.1.0 | 0.1.1 |
| `shuttle-tokio-impl-inner` | 0.1.0 | 0.1.1 |

Patch bumps: everything #337 added is additive.

The intra-crate requirements are tightened from `"0.1"`/`"0.1.0"` to `"0.1.1"`. This is required, not cosmetic — with a loose requirement, `cargo publish` resolves the path dependency against the *published* 0.1.0 during packaging and fails:

```
package `shuttle-tokio-impl` depends on `shuttle-tokio-impl-inner` with feature `bytes`
but `shuttle-tokio-impl-inner` does not have that feature.
```

`shuttle-tokio-retry` 0.3.0 and `shuttle-tokio-retry-impl` 0.1.0 are published for the first time; their versions are unchanged.

Crates with no changes since their last publish, or with only metadata/README changes, are deliberately untouched: `shuttle-tokio-stream`, `shuttle-tokio-stream-impl`, `shuttle-tokio-macros-impl`, `shuttle-tokio-util`, `shuttle-tokio-util-impl`.

## docs.rs

These crates have `default = []`, so docs.rs was rendering only `io`, `net`, `stream`, `task` and `pin!` — hiding `sync`, `time`, `rt`, `fs` and the macros, which is exactly what #337 was about. Added `[package.metadata.docs.rs] features = ["full"]`.

`all-features = true` is deliberately avoided: `io-uring` and `taskdump` forward to tokio features that require `--cfg tokio_unstable` and are platform-gated, so enabling everything fails the docs build with `The taskdump feature is only currently supported on linux, ...`.

## Also

`shuttle-tokio-retry`'s README linked to `shuttle-tokio-retry-impl` under the link text `tokio-retry`. Fixed before the crate name goes out for the first time.

`shuttle` core stays at 0.9.3; its unreleased changes are recorded in the changelog but not released here.

## Verification

- `cargo fmt --all -- --check` clean.
- `cargo nextest run --release` over the four tokio packages: 111 passed, 1 skipped.
- `cargo publish --dry-run` packages and verifies cleanly for both chain leaves (`shuttle-tokio-impl-inner`, `shuttle-tokio-retry-impl`). The dependent crates can only resolve once their dependency is on the index, so they are published in order.
- `cargo doc --no-deps --features full` succeeds for all three docs.rs-configured crates.