### PR TITLE
shuttle-tokio: Implement the mpsc reservation APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Publish `shuttle-tokio-impl` and `shuttle-tokio-impl-inner` 0.1.1.
 * Publish `shuttle-tokio-retry` 0.3.0 and `shuttle-tokio-retry-impl` 0.1.0 for the first time. (#275)
 * `shuttle-tokio` is now versioned 1.0.0, so that it mirrors the version of the crate it wraps like every other wrapper does and a downstream crate can depend on it with the same `version = "1"` requirement it would have used for `tokio`. The 0.1 line is unchanged and still resolves to 0.1.1; moving to the 1.x line is opt-in. (#327)
+* Implement the `mpsc` reservation APIs in `shuttle-tokio`: `Sender::{reserve, try_reserve, reserve_owned, try_reserve_owned}`, `Permit::send` and `OwnedPermit::{send, release, same_channel, same_channel_as_sender}`. `reserve` and `reserve_owned` previously panicked with `unimplemented!()` and the rest were missing. An unused permit returns its capacity to the channel when dropped. Note that `Permit` has gained a lifetime parameter (`Permit<'a, T>`) to match tokio; this is a breaking change in principle, but the only way to obtain a `Permit` used to panic. `reserve_many`/`try_reserve_many` and `PermitIterator` are still unimplemented. (#339)
 
 # 0.9.3 (August 19, 2026)
 

--- a/wrappers/tokio/impls/tokio/inner/src/sync/mpsc.rs
+++ b/wrappers/tokio/impls/tokio/inner/src/sync/mpsc.rs
@@ -18,6 +18,9 @@ use tokio::sync::mpsc::error::{SendError, TryRecvError, TrySendError};
 
 const MAX_INLINE_MESSAGES: usize = 32;
 
+const PERMIT_ALREADY_USED: &str =
+    "Internal Shuttle error. A permit was used after it had already been consumed. This should never happen.";
+
 // === Base Channel ===
 
 struct Channel<T> {
@@ -201,6 +204,47 @@ impl<T> Channel<T> {
     fn is_bounded(&self) -> bool {
         self.bound.is_some()
     }
+
+    // Acquires the capacity for one message, blocking until there is room. Callers of `send` must
+    // hold capacity acquired this way, and must return it with `release_capacity` if they end up
+    // not sending.
+    async fn acquire_capacity(&self) -> Result<(), SendError<()>> {
+        if self.is_bounded() {
+            self.send_semaphore.acquire(1).await.map_err(|_| SendError(()))
+        } else if self.is_closed() {
+            // An unbounded channel does not take capacity from the `send_semaphore` (nothing ever
+            // releases back into it), so the closed check that `acquire` would have done for free
+            // has to happen explicitly.
+            Err(SendError(()))
+        } else {
+            Ok(())
+        }
+    }
+
+    // Like `acquire_capacity`, but fails instead of blocking if the channel is full.
+    fn try_acquire_capacity(&self) -> Result<(), TrySendError<()>> {
+        if !self.is_bounded() {
+            return if self.is_closed() {
+                Err(TrySendError::Closed(()))
+            } else {
+                Ok(())
+            };
+        }
+
+        match self.send_semaphore.try_acquire(1) {
+            Err(TryAcquireError::Closed) => Err(TrySendError::Closed(())),
+            Err(TryAcquireError::NoPermits) => Err(TrySendError::Full(())),
+            Ok(()) => Ok(()),
+        }
+    }
+
+    // Returns the capacity for one message to the channel. Called by the receiver once a message
+    // has been taken out, and by `Permit`/`OwnedPermit` when a reservation goes unused.
+    fn release_capacity(&self) {
+        if self.is_bounded() {
+            self.send_semaphore.release(1);
+        }
+    }
 }
 
 /// Common building block to build [`Receiver`]/[`UnboundedReceiver`] atop.
@@ -303,9 +347,7 @@ impl<T> ReceiverInternal<T> {
                 let message = self.chan.recv().expect(
                     "Internal Shuttle error. We acquired a permit for an empty channel. This should never happen.",
                 );
-                if self.chan.is_bounded() {
-                    self.chan.send_semaphore.release(1);
-                }
+                self.chan.release_capacity();
                 Poll::Ready(Some(message))
             }
             Poll::Ready(Err(_)) => {
@@ -401,15 +443,68 @@ impl<T> SenderInternal<T> {
 
     /// Waits for channel capacity. Once capacity to send one message is
     /// available, it is reserved for the caller.
-    pub async fn reserve(&self) -> Result<Permit<T>, SendError<()>> {
-        unimplemented!()
+    pub async fn reserve(&self) -> Result<Permit<'_, T>, SendError<()>> {
+        self.chan.acquire_capacity().await?;
+
+        Ok(Permit {
+            chan: Some(&*self.chan),
+        })
+    }
+
+    /// Tries to acquire a slot in the channel without waiting for the slot to
+    /// become available.
+    pub fn try_reserve(&self) -> Result<Permit<'_, T>, TrySendError<()>> {
+        self.chan.try_acquire_capacity()?;
+
+        Ok(Permit {
+            chan: Some(&*self.chan),
+        })
     }
 
     /// Waits for channel capacity, moving the `Sender` and returning an owned
     /// permit. Once capacity to send one message is available, it is reserved
     /// for the caller.
     pub async fn reserve_owned(self) -> Result<OwnedPermit<T>, SendError<()>> {
-        unimplemented!()
+        // An `OwnedPermit` holds a sender slot for as long as it lives, so claim one up front.
+        // `self` is dropped when this function returns, giving its own slot back, so
+        // `known_senders` is unchanged overall. Claiming before the `await` rather than after
+        // matters: it keeps the count from dipping to zero (which would close the channel) while
+        // we are waiting for capacity.
+        self.claim_sender_slot();
+        let chan = Arc::clone(&self.chan);
+
+        if let Err(err) = chan.acquire_capacity().await {
+            // Hand the slot we just claimed back. `self` still holds one, so this cannot be the
+            // drop that closes the channel.
+            chan.drop_sender();
+            return Err(err);
+        }
+
+        Ok(OwnedPermit { chan: Some(chan) })
+    }
+
+    /// Tries to acquire a slot in the channel without waiting for the slot to
+    /// become available, moving the `Sender` and returning an owned permit.
+    pub fn try_reserve_owned(self) -> Result<OwnedPermit<T>, TrySendError<Self>> {
+        match self.chan.try_acquire_capacity() {
+            Err(TrySendError::Closed(())) => Err(TrySendError::Closed(self)),
+            Err(TrySendError::Full(())) => Err(TrySendError::Full(self)),
+            Ok(()) => {
+                // See `reserve_owned`. There is no `await` here, so `self`'s slot is live for the
+                // whole function and the ordering is not delicate, but the bookkeeping is the same.
+                self.claim_sender_slot();
+
+                Ok(OwnedPermit {
+                    chan: Some(Arc::clone(&self.chan)),
+                })
+            }
+        }
+    }
+
+    // Registers an additional sender on the channel, to be given back with `Channel::drop_sender`.
+    fn claim_sender_slot(&self) {
+        let mut state = self.chan.state.try_lock().unwrap();
+        state.known_senders += 1;
     }
 
     /// Returns `true` if senders belong to the same channel.
@@ -433,10 +528,7 @@ impl<T> SenderInternal<T> {
 
 impl<T> Clone for SenderInternal<T> {
     fn clone(&self) -> Self {
-        {
-            let mut state = self.chan.state.try_lock().unwrap();
-            state.known_senders += 1;
-        }
+        self.claim_sender_slot();
 
         SenderInternal {
             chan: self.chan.clone(),
@@ -698,13 +790,42 @@ impl<T> Clone for Sender<T> {
 }
 
 /// Permits to send one value into the channel.
-pub struct Permit<T> {
-    chan: Arc<Channel<T>>,
+///
+/// The permit holds one message worth of the channel's capacity. Sending consumes it; dropping it
+/// without sending returns the capacity to the channel.
+//
+// `chan` is `None` only after `send` has taken it, which consumes the `Permit`, so every method
+// other than `send` and `drop` can rely on it being `Some`.
+pub struct Permit<'a, T> {
+    chan: Option<&'a Channel<T>>,
 }
 
-impl<T> fmt::Debug for Permit<T> {
+impl<T> fmt::Debug for Permit<'_, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Permit").field("chan", &self.chan).finish()
+    }
+}
+
+impl<T> Permit<'_, T> {
+    /// Sends a value using the reserved capacity.
+    pub fn send(mut self, value: T) {
+        let chan = self.chan.take().expect(PERMIT_ALREADY_USED);
+
+        // Unlike `Sender::send` this returns `()`, so a channel that closed after the permit was
+        // handed out simply drops the value. The capacity is not returned: a closed channel has no
+        // capacity to hand out, and nothing is waiting for it.
+        if chan.send(value).is_ok() {
+            chan.recv_semaphore.release(1);
+        }
+    }
+}
+
+impl<T> Drop for Permit<'_, T> {
+    fn drop(&mut self) {
+        // `None` here means `send` consumed the permit and the capacity became a message.
+        if let Some(chan) = self.chan.take() {
+            chan.release_capacity();
+        }
     }
 }
 
@@ -712,6 +833,10 @@ impl<T> fmt::Debug for Permit<T> {
 ///
 /// This is identical to the [`Permit`] type, except that it moves the sender
 /// rather than borrowing it.
+//
+// As well as one message worth of capacity, this holds the moved-in sender's slot in
+// `ChannelState::known_senders`. `send` and `release` pass that slot on to the `Sender` they
+// return; `drop` gives it back to the channel.
 pub struct OwnedPermit<T> {
     chan: Option<Arc<Channel<T>>>,
 }
@@ -719,6 +844,64 @@ pub struct OwnedPermit<T> {
 impl<T> fmt::Debug for OwnedPermit<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("OwnedPermit").field("chan", &self.chan).finish()
+    }
+}
+
+impl<T> OwnedPermit<T> {
+    /// Sends a value using the reserved capacity, returning the [`Sender`] the
+    /// permit was created from.
+    pub fn send(mut self, value: T) -> Sender<T> {
+        let chan = self.chan.take().expect(PERMIT_ALREADY_USED);
+
+        // See `Permit::send` for why the error is swallowed.
+        if chan.send(value).is_ok() {
+            chan.recv_semaphore.release(1);
+        }
+
+        Sender {
+            inner: SenderInternal { chan },
+        }
+    }
+
+    /// Releases the reserved capacity without sending a message, returning the
+    /// [`Sender`] the permit was created from.
+    pub fn release(mut self) -> Sender<T> {
+        let chan = self.chan.take().expect(PERMIT_ALREADY_USED);
+        chan.release_capacity();
+
+        Sender {
+            inner: SenderInternal { chan },
+        }
+    }
+
+    /// Returns `true` if permits belong to the same channel.
+    pub fn same_channel(&self, other: &Self) -> bool {
+        // Like tokio, a consumed permit belongs to no channel rather than panicking.
+        match (self.chan.as_ref(), other.chan.as_ref()) {
+            (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if this permit belongs to the same channel as the given
+    /// [`Sender`].
+    pub fn same_channel_as_sender(&self, sender: &Sender<T>) -> bool {
+        match self.chan.as_ref() {
+            Some(chan) => Arc::ptr_eq(chan, &sender.inner.chan),
+            None => false,
+        }
+    }
+}
+
+impl<T> Drop for OwnedPermit<T> {
+    fn drop(&mut self) {
+        // `None` here means `send`/`release` handed the sender slot on to a `Sender`.
+        if let Some(chan) = self.chan.take() {
+            // Return the capacity before giving up the sender slot: `drop_sender` may close the
+            // channel, and a task blocked waiting for capacity should see it first.
+            chan.release_capacity();
+            chan.drop_sender();
+        }
     }
 }
 
@@ -752,8 +935,14 @@ impl<T> Sender<T> {
 
     /// Waits for channel capacity. Once capacity to send one message is
     /// available, it is reserved for the caller.
-    pub async fn reserve(&self) -> Result<Permit<T>, SendError<()>> {
+    pub async fn reserve(&self) -> Result<Permit<'_, T>, SendError<()>> {
         self.inner.reserve().await
+    }
+
+    /// Tries to acquire a slot in the channel without waiting for the slot to
+    /// become available.
+    pub fn try_reserve(&self) -> Result<Permit<'_, T>, TrySendError<()>> {
+        self.inner.try_reserve()
     }
 
     /// Waits for channel capacity, moving the `Sender` and returning an owned
@@ -761,6 +950,17 @@ impl<T> Sender<T> {
     /// for the caller.
     pub async fn reserve_owned(self) -> Result<OwnedPermit<T>, SendError<()>> {
         self.inner.reserve_owned().await
+    }
+
+    /// Tries to acquire a slot in the channel without waiting for the slot to
+    /// become available, moving the `Sender` and returning an owned permit.
+    ///
+    /// If no capacity is available, the `Sender` is returned in the error.
+    pub fn try_reserve_owned(self) -> Result<OwnedPermit<T>, TrySendError<Self>> {
+        self.inner.try_reserve_owned().map_err(|err| match err {
+            TrySendError::Closed(inner) => TrySendError::Closed(Self { inner }),
+            TrySendError::Full(inner) => TrySendError::Full(Self { inner }),
+        })
     }
 
     /// Returns `true` if senders belong to the same channel.

--- a/wrappers/tokio/impls/tokio/inner/tests/mpsc.rs
+++ b/wrappers/tokio/impls/tokio/inner/tests/mpsc.rs
@@ -1,4 +1,4 @@
-use crate::mpsc::error::TryRecvError;
+use crate::mpsc::error::{SendError, TryRecvError, TrySendError};
 use assert_matches::assert_matches;
 use shuttle::future;
 use shuttle::sync::Arc;
@@ -881,6 +881,372 @@ fn poll_recv_then_recv_no_leak() {
 
                 drop(tx);
                 assert_eq!(rx.recv().await, None);
+            });
+        },
+        None,
+    );
+}
+
+// === Reservations ===
+
+#[test]
+fn mpsc_reserve_send() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(2);
+
+                let permit = tx.reserve().await.unwrap();
+                permit.send(1);
+
+                assert_eq!(Some(1), rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+// A permit holds one message worth of capacity for as long as it lives, and gives it back if it is
+// dropped without sending.
+#[test]
+fn mpsc_reserve_holds_capacity() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(2);
+                assert_eq!(2, tx.capacity());
+
+                let permit = tx.reserve().await.unwrap();
+                assert_eq!(1, tx.capacity());
+
+                // Dropping without sending returns the capacity, and does not enqueue a message.
+                drop(permit);
+                assert_eq!(2, tx.capacity());
+                assert_eq!(0, rx.len());
+
+                // Sending consumes the capacity until the message is received.
+                let permit = tx.reserve().await.unwrap();
+                permit.send(1);
+                assert_eq!(1, tx.capacity());
+                assert_eq!(Some(1), rx.recv().await);
+                assert_eq!(2, tx.capacity());
+            });
+        },
+        None,
+    );
+}
+
+// Dropping an unused permit must return the capacity to a sender that is waiting for it, not just
+// to `capacity()`.
+#[test]
+fn mpsc_reserve_drop_unblocks_sender() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+                let permit = tx.reserve().await.unwrap();
+
+                let sender = {
+                    let tx = tx.clone();
+                    future::spawn(async move { tx.send(1).await })
+                };
+
+                // The channel is full as far as the spawned sender is concerned, so it can only
+                // make progress once the permit hands the capacity back.
+                drop(permit);
+
+                sender.await.unwrap().unwrap();
+                assert_eq!(Some(1), rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+// Reserving on a full channel waits, like `send` does.
+#[test]
+fn mpsc_reserve_blocks_when_full() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+                tx.send(1).await.unwrap();
+
+                let reserver = {
+                    let tx = tx.clone();
+                    future::spawn(async move {
+                        let permit = tx.reserve().await.unwrap();
+                        permit.send(2);
+                    })
+                };
+
+                assert_eq!(Some(1), rx.recv().await);
+                reserver.await.unwrap();
+                assert_eq!(Some(2), rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+#[test]
+fn mpsc_try_reserve() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+
+                let permit = tx.try_reserve().unwrap();
+                // The single slot is reserved, so a second reservation has nowhere to go.
+                assert_matches!(tx.try_reserve(), Err(TrySendError::Full(())));
+                permit.send(1);
+                assert_matches!(tx.try_reserve(), Err(TrySendError::Full(())));
+
+                assert_eq!(Some(1), rx.recv().await);
+                assert!(tx.try_reserve().is_ok());
+            });
+        },
+        None,
+    );
+}
+
+#[test]
+fn mpsc_reserve_after_receiver_dropped() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, rx) = mpsc::channel::<u32>(1);
+                drop(rx);
+
+                assert_matches!(tx.reserve().await, Err(SendError(())));
+                assert_matches!(tx.try_reserve(), Err(TrySendError::Closed(())));
+            });
+        },
+        None,
+    );
+}
+
+// A permit outlives the receiver being dropped. `Permit::send` returns `()`, so the message is
+// dropped rather than returned, but it must not panic.
+#[test]
+fn mpsc_permit_send_after_receiver_dropped() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, rx) = mpsc::channel::<u32>(1);
+                let permit = tx.reserve().await.unwrap();
+                drop(rx);
+                permit.send(1);
+                assert!(tx.is_closed());
+            });
+        },
+        None,
+    );
+}
+
+#[test]
+fn mpsc_reserve_owned_send() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+
+                let permit = tx.reserve_owned().await.unwrap();
+                // Sending gives the `Sender` back, and it is still connected to the same channel.
+                let tx = permit.send(1);
+                assert_eq!(Some(1), rx.recv().await);
+
+                tx.send(2).await.unwrap();
+                assert_eq!(Some(2), rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+// `release` returns both the capacity and the `Sender`, without sending anything.
+#[test]
+fn mpsc_reserve_owned_release() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+
+                let permit = tx.reserve_owned().await.unwrap();
+                let tx = permit.release();
+                assert_eq!(1, tx.capacity());
+                assert_eq!(0, rx.len());
+
+                tx.send(1).await.unwrap();
+                assert_eq!(Some(1), rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+// An `OwnedPermit` holds the moved-in sender's slot, so the channel must stay open while it lives
+// and close exactly once when it is dropped.
+#[test]
+fn mpsc_reserve_owned_holds_sender_slot() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+
+                let permit = tx.reserve_owned().await.unwrap();
+                assert!(!rx.is_closed());
+
+                drop(permit);
+                assert!(rx.is_closed());
+                assert_eq!(None, rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+// The same, but the permit is dropped from another task while the receiver is waiting: the receiver
+// must be woken rather than deadlocking.
+#[test]
+fn mpsc_reserve_owned_drop_wakes_receiver() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+
+                let dropper = future::spawn(async move {
+                    let permit = tx.reserve_owned().await.unwrap();
+                    drop(permit);
+                });
+
+                assert_eq!(None, rx.recv().await);
+                dropper.await.unwrap();
+            });
+        },
+        None,
+    );
+}
+
+// A failed `try_reserve_owned` hands the `Sender` back rather than dropping it, so the channel must
+// not close.
+#[test]
+fn mpsc_try_reserve_owned_full_returns_sender() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+                let blocker = tx.clone().reserve_owned().await.unwrap();
+
+                let tx = match tx.try_reserve_owned() {
+                    Err(TrySendError::Full(tx)) => tx,
+                    other => panic!("expected the channel to be full, got {:?}", other.is_ok()),
+                };
+                assert!(!rx.is_closed());
+
+                // Once the blocking permit sends, the recovered `Sender` can reserve again.
+                let blocker_tx = blocker.send(1);
+                assert_eq!(Some(1), rx.recv().await);
+                drop(blocker_tx);
+
+                let permit = tx.try_reserve_owned().unwrap();
+                let tx = permit.send(2);
+                assert_eq!(Some(2), rx.recv().await);
+                drop(tx);
+                assert_eq!(None, rx.recv().await);
+            });
+        },
+        None,
+    );
+}
+
+// Reservations and plain sends contend for the same capacity, so mixing them must not let more than
+// `bound` messages into the channel (which `Channel::send` asserts on) or lose capacity.
+#[test]
+fn mpsc_reserve_and_send_contend() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<u32>(1);
+
+                let reserver = {
+                    let tx = tx.clone();
+                    future::spawn(async move {
+                        let permit = tx.reserve().await.unwrap();
+                        permit.send(1);
+                    })
+                };
+                let sender = {
+                    let tx = tx.clone();
+                    future::spawn(async move { tx.send(2).await.unwrap() })
+                };
+
+                let first = rx.recv().await.unwrap();
+                let second = rx.recv().await.unwrap();
+                assert_eq!(3, first + second);
+
+                reserver.await.unwrap();
+                sender.await.unwrap();
+                assert_eq!(1, tx.capacity());
+            });
+        },
+        None,
+    );
+}
+
+#[test]
+fn mpsc_reserve_many_senders() {
+    check_random(
+        || {
+            future::block_on(async {
+                let (tx, mut rx) = mpsc::channel::<usize>(2);
+                let senders = (0..4)
+                    .map(|i| {
+                        let tx = tx.clone();
+                        future::spawn(async move {
+                            let permit = tx.reserve().await.unwrap();
+                            // Half the reservations go unused, so their capacity has to come back.
+                            if i % 2 == 0 {
+                                permit.send(i);
+                            }
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                drop(tx);
+
+                let mut received = vec![];
+                while let Some(i) = rx.recv().await {
+                    received.push(i);
+                }
+                received.sort_unstable();
+                assert_eq!(vec![0, 2], received);
+
+                for sender in senders {
+                    sender.await.unwrap();
+                }
+            });
+        },
+        1000,
+    );
+}
+
+#[test]
+fn mpsc_owned_permit_same_channel() {
+    check_dfs(
+        || {
+            future::block_on(async {
+                let (tx, _rx) = mpsc::channel::<()>(2);
+                let (tx2, _rx2) = mpsc::channel::<()>(2);
+
+                let permit = tx.clone().reserve_owned().await.unwrap();
+                let permit2 = tx.clone().reserve_owned().await.unwrap();
+                let permit3 = tx2.clone().reserve_owned().await.unwrap();
+
+                assert!(permit.same_channel(&permit2));
+                assert!(!permit.same_channel(&permit3));
+
+                assert!(permit.same_channel_as_sender(&tx));
+                assert!(!permit.same_channel_as_sender(&tx2));
             });
         },
         None,


### PR DESCRIPTION
Fixes #339.

`Sender::reserve` and `Sender::reserve_owned` panicked with `unimplemented!()`, `try_reserve`/`try_reserve_owned` were missing, and `Permit`/`OwnedPermit` had no methods at all, so there was no way to use a reservation under Shuttle.

## Approach

The permit accounting this needs already existed. `send` acquires one permit from `send_semaphore` before pushing a message, and the receiver releases one back once it has popped a message. A `Permit` is exactly that acquire without the push, so:

- `reserve` is the first half of `send`, with the acquired capacity parked in the `Permit`
- `Permit::send` is the second half
- `Permit::drop` returns the capacity — the "returning capacity when an unused permit is dropped" the issue asks for

There is no double-release risk, because the receiver only releases capacity for messages it actually popped, so capacity that never became a message is solely the permit's to return.

`OwnedPermit` additionally holds the moved-in sender's slot in `ChannelState::known_senders`. `reserve_owned` can't just move the `Arc` out of the `SenderInternal`, since `SenderInternal::drop` would then decrement that count and could close the channel out from under the permit. Instead it claims a second slot up front and lets the consumed sender give its own slot back, which keeps the count from dipping to zero across the `await`. `OwnedPermit::{send, release}` pass the slot on to the `Sender` they return, and `OwnedPermit::drop` returns the capacity and then gives the slot back.

Also factors the send-capacity accounting into `Channel::{acquire_capacity, try_acquire_capacity, release_capacity}`, so the rule that capacity is released exactly once by whoever consumed it lives in one place rather than being spelled out at each `is_bounded()` call site.

## API

Signatures match tokio 1.x exactly:

| | |
|---|---|
| `Sender::reserve` | `async fn(&self) -> Result<Permit<'_, T>, SendError<()>>` |
| `Sender::try_reserve` | `fn(&self) -> Result<Permit<'_, T>, TrySendError<()>>` |
| `Sender::reserve_owned` | `async fn(self) -> Result<OwnedPermit<T>, SendError<()>>` |
| `Sender::try_reserve_owned` | `fn(self) -> Result<OwnedPermit<T>, TrySendError<Self>>` |
| `Permit::send` | `fn(self, value: T)` |
| `OwnedPermit::send` | `fn(self, value: T) -> Sender<T>` |
| `OwnedPermit::release` | `fn(self) -> Sender<T>` |
| `OwnedPermit::same_channel` | `fn(&self, other: &Self) -> bool` |
| `OwnedPermit::same_channel_as_sender` | `fn(&self, sender: &Sender<T>) -> bool` |

**`Permit` gains a lifetime parameter** (`Permit<T>` → `Permit<'a, T>`) to match tokio's `Permit<'a, T>`. That's a breaking change in principle, but the only way to obtain a `Permit` was `reserve`, which panicked, so nothing can be relying on the old shape. Doing it now is what makes the type drop-in compatible; `SemaphorePermit<'a>` in the same crate already borrows this way.

`reserve_many`/`try_reserve_many` and `PermitIterator` are still unimplemented — out of scope for #339.

## Tests

15 new tests in `tests/mpsc.rs`, all `check_dfs` except the two that fan out over many senders. They cover: reserve→send delivery; capacity held while a permit lives and restored on drop; a dropped permit unblocking a `send` that was waiting on a full channel (this deadlocks without the `Drop` impl); `reserve` blocking when full; `try_reserve` full/closed; reserve after the receiver dropped; `Permit::send` after the receiver dropped not panicking; `reserve_owned` send/release round-tripping the `Sender`; an `OwnedPermit` keeping the channel open and closing it exactly once on drop, including waking a waiting receiver; `try_reserve_owned` handing the `Sender` back on failure; reservations and plain `send`s contending for the same capacity; and `same_channel`/`same_channel_as_sender`.

Verified locally: full `tests/mpsc.rs` suite (40 tests) passes, `cargo clippy --all-targets -- -D clippy::all` clean, `cargo fmt --check` clean, `cargo doc --no-deps` adds no new warnings, and `shuttle-tokio` builds with `--features shuttle,full`.