### PR TITLE
Publish shuttle-tokio-impl-inner 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Publish `shuttle-tokio-retry` 0.3.0 and `shuttle-tokio-retry-impl` 0.1.0 for the first time. (#275)
 * `shuttle-tokio` is now versioned 1.0.0, so that it mirrors the version of the crate it wraps like every other wrapper does and a downstream crate can depend on it with the same `version = "1"` requirement it would have used for `tokio`. The 0.1 line is unchanged and still resolves to 0.1.1; moving to the 1.x line is opt-in. (#327)
 * Implement the `mpsc` reservation APIs in `shuttle-tokio`: `Sender::{reserve, try_reserve, reserve_owned, try_reserve_owned}`, `Permit::send` and `OwnedPermit::{send, release, same_channel, same_channel_as_sender}`. `reserve` and `reserve_owned` previously panicked with `unimplemented!()` and the rest were missing. An unused permit returns its capacity to the channel when dropped. Note that `Permit` has gained a lifetime parameter (`Permit<'a, T>`) to match tokio; this is a breaking change in principle, but the only way to obtain a `Permit` used to panic. `reserve_many`/`try_reserve_many` and `PermitIterator` are still unimplemented. (#339)
+* Implement `mpsc::Receiver::poll_recv` in `shuttle-tokio`. (#319)
+* Publish `shuttle-tokio-impl-inner` 0.1.2. The already-published `shuttle-tokio-impl` 0.1.1 and `shuttle-tokio` 1.0.0 both require it as `^0.1.1` and re-export it with a glob, so they pick the new version up without needing to be republished.
 
 # 0.9.3 (August 19, 2026)
 

--- a/wrappers/tokio/impls/tokio/inner/Cargo.toml
+++ b/wrappers/tokio/impls/tokio/inner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-tokio-impl-inner"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "Internal implementation of the `tokio` crate for use with the Shuttle concurrency testing tool. Do not depend on this crate directly; use `shuttle-tokio`."


### PR DESCRIPTION
The mpsc reservation APIs (#340) and `Receiver::poll_recv` (#319) both landed in `shuttle-tokio-impl-inner`, which still declared 0.1.1 — already on crates.io, so it can't be published.

## Only this crate needs a version

`shuttle-tokio-impl` 0.1.1 requires inner as `^0.1.1` and re-exports it with `pub use shuttle_tokio_impl_inner::*`, and `shuttle-tokio` 1.0.0 requires impl as `^0.1.1`. `^0.1.1` admits 0.1.2, and the glob picks up the new items, so both published crates get the new APIs on resolution without a republish. Neither crate's own sources have changed since they were published, so bumping them would upload identical content.

0.1.2 rather than 0.2.0 for the `Permit<T>` → `Permit<'a, T>` change: the only way to obtain a `Permit` was `reserve`, which panicked with `unimplemented!()`, so nothing can have been relying on the old shape.

## Also in 0.1.2

`Receiver::poll_recv` (#319) was missing a changelog entry; added. The only other inner change since 0.1.1 is two iteration counts in `watch.rs`'s `mod tests` (#320), which isn't user-visible.

## Testing

* `cargo package -p shuttle-tokio-impl-inner` — packages and verifies clean, building against the **published** `shuttle 0.9.3`, so this needs no new `shuttle` release.
* `cargo nextest run --release -p shuttle-tokio-impl-inner` — 112 passed, 1 skipped.